### PR TITLE
Fix use of keccak256 function

### DIFF
--- a/packages/core/src/eip-1967.ts
+++ b/packages/core/src/eip-1967.ts
@@ -39,13 +39,13 @@ async function getEip1967Storage(
 }
 
 export function toFallbackEip1967Hash(label: string): string {
-  return `0x${keccak256(Buffer.from(label)).toString('hex')}`;
+  return '0x' + keccak256(Buffer.from(label)).toString('hex');
 }
 
 export function toEip1967Hash(label: string): string {
   const hash = keccak256(Buffer.from(label));
   const bigNumber = new BN(hash).sub(new BN(1));
-  return `0x${bigNumber.toString(16)}`;
+  return '0x' + bigNumber.toString(16);
 }
 
 function isEmptySlot(storage: string): boolean {


### PR DESCRIPTION
`keccak256` from `ethereumjs-util` returns a `Buffer`, so where a string is expected we need to explicitly convert it to a string using hex encoding (otherwise it automatically uses UTF8 encoding).

Other changes in this PR:

- We call the `BN` constructor with a `Buffer` argument, so it's not necessary to specify an encoding.
- For simply adding a prefix I prefer using string concatenation rather than string templates, since there is less visual overhead.