### PR TITLE
Fix identification of storage renames and typechanges

### DIFF
--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -84,9 +84,9 @@ export function getStorageUpgradeErrors(
     if (typeMatches && nameMatches) {
       return 'equal';
     } else if (typeMatches) {
-      return 'typechange';
-    } else if (nameMatches) {
       return 'rename';
+    } else if (nameMatches) {
+      return 'typechange';
     } else {
       return 'replace';
     }


### PR DESCRIPTION
The logic was swapped: renames were reported as typechanges and vice versa.