### PR TITLE
Leave Truffle artifact address unchanged in upgradeProxy

### DIFF
--- a/packages/plugin-truffle/src/upgrade-proxy.ts
+++ b/packages/plugin-truffle/src/upgrade-proxy.ts
@@ -47,6 +47,5 @@ export async function upgradeProxy(
 
   await admin.upgrade(proxyAddress, nextImpl);
 
-  Contract.address = proxyAddress;
   return new Contract(proxyAddress);
 }


### PR DESCRIPTION
`deployProxy` in Truffle sets the "deployed" address of the contract to the new proxy instance. This allows retrieving the instance after a migration using `MyContract.deployed()`.

The same thing was done in `upgradeProxy` but this doesn't make a lot of sense since the proxy instance already existed, and it could be very confusing for users.