### PR TITLE
Create custom error class for tx mined timeout

### DIFF
--- a/packages/core/src/deployment.ts
+++ b/packages/core/src/deployment.ts
@@ -62,7 +62,13 @@ export async function waitAndValidateDeployment(provider: EthereumProvider, depl
   }
 
   // A timeout is NOT an InvalidDeployment
-  throw new Error(`Timed out waiting for transaction ${deployment.txHash}`);
+  throw new TransactionMinedTimeout(deployment);
+}
+
+export class TransactionMinedTimeout extends Error {
+  constructor(readonly deployment: Deployment) {
+    super(`Timed out waiting for transaction ${deployment.txHash}`);
+  }
 }
 
 export class InvalidDeployment extends Error {


### PR DESCRIPTION
Only adds a custom error class where a special case for managing retries is needed. Other errors in the code do not need different handling.

Fixes #60