### PR TITLE
Fix error for missing Truffle config

### DIFF
--- a/packages/plugin-truffle/src/truffle.ts
+++ b/packages/plugin-truffle/src/truffle.ts
@@ -70,8 +70,8 @@ export interface TruffleConfig {
 declare const config: undefined | TruffleConfig;
 
 export function getTruffleConfig(): TruffleConfig {
-  if (config === undefined) {
-    throw new Error('Global Truffle config not found: Truffle >=5.1.35 is required');
+  if (typeof config === 'undefined') {
+    throw new Error('Global Truffle config not found: Truffle >=5.1.35 is required. Truffle exec not yet supported');
   } else {
     return config;
   }


### PR DESCRIPTION
Related to https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/104.

The existing check was not working because in strict mode it's an error to access the variable `config` if it's missing. The fix is to use `typeof config` instead.

Additionally expanded the error message to mention that `truffle exec` is not yet supported.