### PR TITLE
Store deployTransaction in Ethers contract instances

### DIFF
--- a/packages/plugin-buidler/README.md
+++ b/packages/plugin-buidler/README.md
@@ -26,6 +26,7 @@ const { ethers, upgrades } = require("@nomiclabs/buidler");
 async function main() {
   const Box = await ethers.getContractFactory("Box");
   const box = await upgrades.deployProxy(Box, [42]);
+  await box.deployed();
   console.log("Box deployed to:", box.address);
 }
 
@@ -43,6 +44,7 @@ const { ethers, upgrades } = require("@nomiclabs/buidler");
 async function main() {
   const BoxV2 = await ethers.getContractFactory("BoxV2");
   const box = await upgrades.upgradeProxy(BOX_ADDRESS, BoxV2);
+  await box.deployed();
   console.log("Box upgraded");
 }
 

--- a/packages/plugin-buidler/src/deploy-proxy.ts
+++ b/packages/plugin-buidler/src/deploy-proxy.ts
@@ -46,6 +46,9 @@ export function makeDeployProxy(bre: BuidlerRuntimeEnvironment): DeployFunction 
     const proxy = await ProxyFactory.deploy(impl, adminAddress, data);
 
     const inst = ImplFactory.attach(proxy.address);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Won't be readonly because inst was created through attach.
+    inst.deployTransaction = proxy.deployTransaction;
     return inst;
   };
 


### PR DESCRIPTION
Fixes #122.

Stores the deployment transaction in the contract instance. This is used by `await contract.deployed()` to wait until the deployment transaction is mined.

It was necessary to ignore a TypeScript error. This property is sometimes readonly ([example](https://github.com/ethers-io/ethers.js/blob/9640e864a68b4a9e84e820f0ceaf1eb56c66715f/packages/contracts/src.ts/index.ts#L1156)) but not in our case since we create the instance with [`attach`](https://github.com/ethers-io/ethers.js/blob/9640e864a68b4a9e84e820f0ceaf1eb56c66715f/packages/contracts/src.ts/index.ts#L1160-L1162).