### PR TITLE
Fix Buidler deployProxy for overloaded initializers

### DIFF
--- a/packages/plugin-buidler/src/deploy-proxy.ts
+++ b/packages/plugin-buidler/src/deploy-proxy.ts
@@ -56,14 +56,17 @@ export function makeDeployProxy(bre: BuidlerRuntimeEnvironment): DeployFunction 
     const allowNoInitialization = initializer === undefined && args.length === 0;
     initializer = initializer ?? 'initialize';
 
-    const initializers = ImplFactory.interface.fragments.filter(f => f.name === initializer);
-
-    if (initializers.length > 0) {
-      return ImplFactory.interface.encodeFunctionData(initializer, args);
-    } else if (allowNoInitialization) {
-      return '0x';
-    } else {
-      throw new Error(`Contract does not have a function \`${initializer}\``);
+    try {
+      const fragment = ImplFactory.interface.getFunction(initializer);
+      return ImplFactory.interface.encodeFunctionData(fragment, args);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        console.log(e.message);
+        if (allowNoInitialization && e.message.includes('no matching function')) {
+          return '0x';
+        }
+      }
+      throw e;
     }
   }
 }

--- a/packages/plugin-buidler/src/deploy-proxy.ts
+++ b/packages/plugin-buidler/src/deploy-proxy.ts
@@ -61,7 +61,6 @@ export function makeDeployProxy(bre: BuidlerRuntimeEnvironment): DeployFunction 
       return ImplFactory.interface.encodeFunctionData(fragment, args);
     } catch (e: unknown) {
       if (e instanceof Error) {
-        console.log(e.message);
         if (allowNoInitialization && e.message.includes('no matching function')) {
           return '0x';
         }

--- a/packages/plugin-buidler/test.js
+++ b/packages/plugin-buidler/test.js
@@ -36,3 +36,4 @@ testFile('happy-path-with-structs');
 testFile('happy-path-with-enums');
 testFile('change-admin-happy-path');
 testFile('transfer-admin-ownership-happy-path');
+testFile('initializers');

--- a/packages/plugin-buidler/test/contracts/Initializers.sol
+++ b/packages/plugin-buidler/test/contracts/Initializers.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.1;
+
+contract InitializerOverloaded {
+  uint public x;
+
+  function initialize(uint _x) public {
+    x = _x;
+  }
+
+  function initialize(string memory) public {}
+}
+
+contract InitializerMissing {
+}

--- a/packages/plugin-buidler/test/initializers.js
+++ b/packages/plugin-buidler/test/initializers.js
@@ -10,8 +10,6 @@ async function main() {
   await upgrades.deployProxy(InitializerMissing);
 }
 
-// We recommend this pattern to be able to use async/await everywhere
-// and properly handle errors.
 main()
   .then(() => process.exit(0))
   .catch(error => {

--- a/packages/plugin-buidler/test/initializers.js
+++ b/packages/plugin-buidler/test/initializers.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { ethers, upgrades } = require('@nomiclabs/buidler');
+
+async function main() {
+  const InitializerOverloaded = await ethers.getContractFactory('InitializerOverloaded');
+  const instance = await upgrades.deployProxy(InitializerOverloaded, [42], { initializer: 'initialize(uint256)' });
+  assert.strictEqual('42', (await instance.x()).toString());
+
+  const InitializerMissing = await ethers.getContractFactory('InitializerMissing');
+  await upgrades.deployProxy(InitializerMissing);
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Fixes #146.

We were only allowing initializer names, which doesn't work with overloading. This PR changes the implementation to use the native [`Interface.getFunction`](https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--fragments) function provided by Ethers, which supports all of: names, signatures, and selectors.

cc @abcoathup: This should be reflected in the API docs which I didn't edit in this PR because we moved them to another file in the `docs` branch (#142). See [Specifying Fragments](https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments) in the Ethers documentation for the different ways initializers can be specified.