### PR TITLE
Add repository URI to package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@openzeppelin/upgrades-core",
   "version": "1.1.0",
   "description": "",
+  "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/core",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/packages/plugin-buidler/package.json
+++ b/packages/plugin-buidler/package.json
@@ -2,6 +2,7 @@
   "name": "@openzeppelin/buidler-upgrades",
   "version": "1.1.0",
   "description": "",
+  "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/plugin-buidler",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/packages/plugin-truffle/package.json
+++ b/packages/plugin-truffle/package.json
@@ -2,6 +2,7 @@
   "name": "@openzeppelin/truffle-upgrades",
   "version": "1.1.0",
   "description": "",
+  "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/plugin-truffle",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
The repository currently doesn't show any dependents: https://github.com/OpenZeppelin/openzeppelin-upgrades/network/dependents

A project that has Upgrades Plugins as a dependency doesn't show links to the repository:
https://github.com/abcoathup/box/network/dependencies

Adding repository URI to each package.json in case this resolves the issue when the packages are next released.