### PR TITLE
add: get unknown network name from env

### DIFF
--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -40,8 +40,7 @@ export class Manifest {
   }
 
   constructor(chainId: number) {
-    const networkName = process.env.NETWORK || networkNames[chainId] || 'unknown';
-    const name = `${networkName}-${chainId}`;
+    const name = process.env.NETWORK ? `${process.env.NETWORK}-${chainId}` : networkNames[chainId] ?? `unknown-${chainId}`;
     this.file = path.join(manifestDir, `${name}.json`);
   }
 

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -40,7 +40,8 @@ export class Manifest {
   }
 
   constructor(chainId: number) {
-    const name = networkNames[chainId] ?? `unknown-${chainId}`;
+    const networkName = process.env.NETWORK || networkNames[chainId] || 'unknown';
+    const name =  `${networkName}-${chainId}`;
     this.file = path.join(manifestDir, `${name}.json`);
   }
 

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -41,7 +41,7 @@ export class Manifest {
 
   constructor(chainId: number) {
     const networkName = process.env.NETWORK || networkNames[chainId] || 'unknown';
-    const name =  `${networkName}-${chainId}`;
+    const name = `${networkName}-${chainId}`;
     this.file = path.join(manifestDir, `${name}.json`);
   }
 


### PR DESCRIPTION
Sometimes you may want to have dev/staging/prod contracts on same network
if you set NETWORK in env this allows for multiple deployment to same network ie:
export NETWORK='ropsten-staging'