### PR TITLE
feature: Add deployer options as an argument

### DIFF
--- a/packages/plugin-truffle/src/utils/deploy.ts
+++ b/packages/plugin-truffle/src/utils/deploy.ts
@@ -2,8 +2,12 @@ import type { Deployment } from '@openzeppelin/upgrades-core';
 
 import type { ContractClass, Deployer } from '../truffle';
 
-export async function deploy(contract: ContractClass, deployer: Deployer): Promise<Deployment> {
-  const { address, transactionHash: txHash } = await deployer.deploy(contract);
+export interface DeployerOptions {
+  from?: string;
+}
+
+export async function deploy(contract: ContractClass, deployer: Deployer, deployerOpts: DeployerOptions): Promise<Deployment> {
+  const { address, transactionHash: txHash } = await deployer.deploy(contract, deployerOpts);
   if (txHash === undefined) {
     throw new Error('Transaction hash is undefined');
   }


### PR DESCRIPTION
Draft PR for an initial proposal for fixing #85. 

I've only implemented `from` argument since other options doesn't seem so relevant as a custom deploy address.