### PR TITLE
Replace all Buidler mentions in documentation

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,6 @@
 * xref:index.adoc[Overview]
 * xref:truffle-upgrades.adoc[Using with Truffle]
-* xref:buidler-upgrades.adoc[Using with Buidler]
+* xref:hardhat-upgrades.adoc[Using with Hardhat]
 * xref:writing-upgradeable.adoc[Writing Upgradeable Contracts]
 * xref:proxies.adoc[Proxy Upgrade Pattern]
 * xref:network-files.adoc[Network Files]
@@ -9,4 +9,4 @@
 
 .API Reference
 * xref:api-truffle-upgrades.adoc[Truffle Upgrades]
-* xref:api-buidler-upgrades.adoc[Buidler Upgrades]
+* xref:api-hardhat-upgrades.adoc[Hardhat Upgrades]

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -1,4 +1,4 @@
-= OpenZeppelin Buidler Upgrades API
+= OpenZeppelin Hardhat Upgrades API
 
 Both `deployProxy` and `upgradeProxy` functions will return instances of https://docs.ethers.io/v5/api/contract/contract[ethers.js contracts], and require https://docs.ethers.io/v5/api/contract/contract-factory[ethers.js contract factories] as arguments. All functions validate that the implementation contract is upgrade-safe, and will fail otherwise.
 
@@ -44,7 +44,7 @@ async function upgradeProxy(
 [[prepare-upgrade]]
 == prepareUpgrade
 
-Validates and deploys a new implementation contract, and returns its address. Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from Buidler. 
+Validates and deploys a new implementation contract, and returns its address. Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from Hardhat. 
 
 Options are:
 

--- a/docs/modules/ROOT/pages/hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/hardhat-upgrades.adoc
@@ -14,7 +14,7 @@ $ npm install --save-dev @openzeppelin/hardhat-upgrades
 $ npm install --save-dev @nomiclabs/hardhat-ethers ethers # peer dependencies
 ----
 
-And register the plugins in your https://hardhat.org/config[`hardhat.config.js`]:
+And register the plugin in your https://hardhat.org/config[`hardhat.config.js`]:
 
 [source,js]
 ----

--- a/docs/modules/ROOT/pages/hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/hardhat-upgrades.adoc
@@ -1,6 +1,6 @@
-= Using with Buidler
+= Using with Hardhat
 
-This package adds functions to your Buidler scripts so you can deploy and upgrade proxies for your contracts. Depends on `ethers.js`.
+This package adds functions to your Hardhat scripts so you can deploy and upgrade proxies for your contracts. Depends on `ethers.js`.
 
 
 TIP: Check out the https://forum.openzeppelin.com/t/openzeppelin-buidler-upgrades-step-by-step-tutorial/3580[step by step tutorial], showing from creating, testing and deploying, all the way through to upgrading with Gnosis Safe.
@@ -10,36 +10,26 @@ TIP: Check out the https://forum.openzeppelin.com/t/openzeppelin-buidler-upgrade
 
 [source,console]
 ----
-$ npm install --save-dev @openzeppelin/buidler-upgrades
-$ npm install --save-dev @nomiclabs/buidler-ethers ethers # peer dependencies
+$ npm install --save-dev @openzeppelin/hardhat-upgrades
+$ npm install --save-dev @nomiclabs/hardhat-ethers ethers # peer dependencies
 ----
 
-And register the plugins in your https://buidler.dev/config[`buidler.config.js`]:
+And register the plugins in your https://hardhat.org/config[`hardhat.config.js`]:
 
 [source,js]
 ----
-usePlugin('@nomiclabs/buidler-ethers');
-usePlugin('@openzeppelin/buidler-upgrades');
-----
-
-If you're using TypeScript, remember to add our https://buidler.dev/guides/typescript.html#plugin-type-extensions[type extensions] in your `tsconfig.json`:
-
-[source,json]
-----
-"files": [
-  "./node_modules/@openzeppelin/buidler-upgrades/src/type-extensions.d.ts"
-]
+require('@openzeppelin/hardhat-upgrades');
 ----
 
 [[script-usage]]
 == Usage in scripts
 
-You can use this plugin in a https://buidler.dev/guides/scripts.html[Buidler script] to deploy an upgradeable instance of one of your contracts via the `deployProxy` function:
+You can use this plugin in a https://hardhat.org/guides/scripts.html[Hardhat script] to deploy an upgradeable instance of one of your contracts via the `deployProxy` function:
 
 [source,js]
 ----
 // scripts/create-box.js
-const { ethers, upgrades } = require("@nomiclabs/buidler");
+const { ethers, upgrades } = require("hardhat");
 
 async function main() {
   const Box = await ethers.getContractFactory("Box");
@@ -58,7 +48,7 @@ Then, in another script, you can use the `upgradeProxy` function to upgrade the 
 [source,js]
 ----
 // scripts/upgrade-box.js
-const { ethers, upgrades } = require("@nomiclabs/buidler");
+const { ethers, upgrades } = require("hardhat");
 
 async function main() {
   const BoxV2 = await ethers.getContractFactory("BoxV2");
@@ -76,7 +66,7 @@ The plugin will take care of comparing `BoxV2` to the previous one to ensure the
 [[test-usage]]
 == Usage in tests
 
-You can also use the `deployProxy` and `upgradeProxy` functions from your Buidler tests, in case you want to add tests for upgrading your contracts (which you should!). The API is the same as in scripts.
+You can also use the `deployProxy` and `upgradeProxy` functions from your Hardhat tests, in case you want to add tests for upgrading your contracts (which you should!). The API is the same as in scripts.
 
 [source,js]
 ----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 = Upgrades Plugins
 
-**Integrate upgrades into your existing workflow.** Plugins for https://buidler.dev[Buidler] and https://www.trufflesuite.com/truffle[Truffle] to deploy and manage upgradeable contracts on Ethereum.
+**Integrate upgrades into your existing workflow.** Plugins for https://hardhat.org[Hardhat] and https://www.trufflesuite.com/truffle[Truffle] to deploy and manage upgradeable contracts on Ethereum.
 
 * Deploy upgradeable contracts.
 * Upgrade deployed contracts.
@@ -14,15 +14,15 @@ TIP: New to upgrades? Start by reading our xref:learn::upgrading-smart-contracts
 [[install]]
 === Installation
 
-[[install-buidler]]
-==== Buidler install
+[[install-hardhat]]
+==== Hardhat install
 
 [source,console]
 ----
-$ npm install --save-dev @openzeppelin/buidler-upgrades @nomiclabs/buidler-ethers ethers
+$ npm install --save-dev @openzeppelin/hardhat-upgrades @nomiclabs/hardhat-ethers ethers
 ----
 
-This installs our Buidler plugin along with the necessary peer dependencies.
+This installs our Hardhat plugin along with the necessary peer dependencies.
 
 [[install-truffle]]
 ==== Truffle install
@@ -35,16 +35,16 @@ $ npm install --save-dev @openzeppelin/truffle-upgrades
 [[usage]]
 === Usage
 
-See the documentation for using xref:truffle-upgrades.adoc[Truffle Upgrades] and xref:buidler-upgrades.adoc[Buidler Upgrades], or take a look at the sample code snippets below.
+See the documentation for using xref:truffle-upgrades.adoc[Truffle Upgrades] and xref:hardhat-upgrades.adoc[Hardhat Upgrades], or take a look at the sample code snippets below.
 
-[[buidler-usage]]
-==== Buidler usage
+[[hardhat-usage]]
+==== Hardhat usage
 
-Buidler users will be able to write https://buidler.dev/guides/scripts.html[scripts] that use the plugin to deploy or upgrade a contract, and manage proxy admin rights.
+Hardhat users will be able to write https://hardhat.org/guides/scripts.html[scripts] that use the plugin to deploy or upgrade a contract, and manage proxy admin rights.
 
 [source,js]
 ----
-const { ethers, upgrades } = require("@nomiclabs/buidler");
+const { ethers, upgrades } = require("hardhat");
 
 async function main() {
   // Deploying
@@ -82,7 +82,7 @@ module.exports = async function (deployer) {
 [[test-usage]]
 ==== Test usage
 
-Whether you're using Buidler or Truffle, you can use the plugin in your tests to ensure everything works as expected.
+Whether you're using Hardhat or Truffle, you can use the plugin in your tests to ensure everything works as expected.
 
 [source,js]
 ----

--- a/docs/modules/ROOT/pages/migrate-from-cli.adoc
+++ b/docs/modules/ROOT/pages/migrate-from-cli.adoc
@@ -1,6 +1,6 @@
 = Migrate from OpenZeppelin CLI
 
-This guide will walk through migrating a project from the OpenZeppelin CLI to OpenZeppelin Upgrades Plugins for either Truffle or Buidler.
+This guide will walk through migrating a project from the OpenZeppelin CLI to OpenZeppelin Upgrades Plugins for either Truffle or Hardhat.
 
 include::learn::partial$hardhat-truffle-toggle.adoc[]
 
@@ -18,26 +18,25 @@ Keeping that aside, everything else remains the same since both the CLI and plug
 
 [.hardhat]
 --
-https://buidler.dev/tutorial/creating-a-new-buidler-project.html[Install Buidler] and when initializing it, select the `Create an empty buidler.config.js` option.
+https://hardhat.org/tutorial/creating-a-new-hardhat-project.html[Install Hardhat] and when initializing it, select the `Create an empty hardhat.config.js` option.
 
 ```bash
-$ npm install --save-dev @nomiclabs/buidler
-$ npx buidler
+$ npm install --save-dev hardhat
+$ npx hardhat
 ```
 
 Then install the Upgrades plugin:
 
 ```bash
-$ npm install --save-dev @openzeppelin/buidler-upgrades
-$ npm install --save-dev @nomiclabs/buidler-ethers ethers # peer dependencies
+$ npm install --save-dev @openzeppelin/hardhat-upgrades
+$ npm install --save-dev @nomiclabs/hardhat-ethers ethers # peer dependencies
 ```
 
-Once it is done, register the plugin in the Buidler config file by adding these lines:
+Once it is done, register the plugin in the Hardhat config file by adding these lines:
 
 ```jsx
-// buidler.config.js
-usePlugin('@nomiclabs/buidler-ethers');
-usePlugin('@openzeppelin/buidler-upgrades');
+// hardhat.config.js
+require('@openzeppelin/hardhat-upgrades');
 
 module.exports = {
   // ...
@@ -102,10 +101,10 @@ The migration script will also export a `openzeppelin-cli-export.json` file into
 
 [.hardhat]
 --
-Copy compiler settings into the https://buidler.dev/config/#available-config-options[`solc` field] in the Buidler config file
+Copy compiler settings into the https://hardhat.org/config/#available-config-options[`solc` field] in the Hardhat config file
 
 ```json
-// buidler.config.js
+// hardhat.config.js
 
 // ...
 
@@ -146,7 +145,7 @@ module.exports = {
 ```
 --
 
-NOTE: The solc configuration format is different in `truffle-config.js` and `buidler.config.js` files
+NOTE: The solc configuration format is different in `truffle-config.js` and `hardhat.config.js` files
 
 And that's it, you have successfully migrated your CLI project. Let's now try your new setup upgrading one of your migrated contracts.
 
@@ -190,12 +189,12 @@ These scripts are just examples of how to use the exported data. We make no sugg
 
 [.hardhat]
 --
-With Buidler, we would write a script (*you can read more about Buidler scripts https://buidler.dev/guides/scripts.html[here] and about using the `buidler-upgrades` plugin https://docs.openzeppelin.com/upgrades-plugins/1.x/buidler-upgrades[here]*):
+With Hardhat, we would write a script (*you can read more about Hardhat scripts https://hardhat.org/guides/scripts.html[here] and about using the `hardhat-upgrades` plugin https://docs.openzeppelin.com/upgrades-plugins/1.x/hardhat-upgrades[here]*):
 
 ```jsx
 // scripts/upgradeBoxToV2.js
 
-const { ethers, upgrades } = require("@nomiclabs/buidler");
+const { ethers, upgrades } = require("hardhat");
 const OZ_SDK_EXPORT = require("../openzeppelin-cli-export.json");
 
 async function main() {
@@ -208,7 +207,7 @@ main();
 ```
 
 ```bash
-$ npx buidler run scripts/upgradeBoxToV2.js --network rinkeby
+$ npx hardhat run scripts/upgradeBoxToV2.js --network rinkeby
 ```
 --
 
@@ -237,4 +236,4 @@ $ npx truffle migrate --network rinkeby
 ```
 --
 
-And that's it! You have migrated your OpenZeppelin CLI project to Truffle or Buidler and performed an upgrade using the plugins.
+And that's it! You have migrated your OpenZeppelin CLI project to Truffle or Hardhat and performed an upgrade using the plugins.

--- a/docs/modules/ROOT/pages/network-files.adoc
+++ b/docs/modules/ROOT/pages/network-files.adoc
@@ -45,7 +45,7 @@ For every logic contract, besides the deployment address, the following info is 
 * `types` keeps track of all the types used in the contract or its ancestors, from basic types like `uint256` to custom `struct` types
 * `storage` tracks the storage layout of the linearized contract, referencing the types defined in the `types` section, and is used for verifying that any xref:faq.adoc#what-does-it-mean-for-an-implementation-to-be-compatible[storage layout changes between subsequent versions are compatible] 
 
-The naming of the file will be `<network_name>.json`, but note that `<network_name>` is not taken from the name of the network's entry in the Truffle or Buidler configuration file, but is instead inferred from the chain id associated to the entry. 
+The naming of the file will be `<network_name>.json`, but note that `<network_name>` is not taken from the name of the network's entry in the Truffle or Hardhat configuration file, but is instead inferred from the chain id associated to the entry. 
 
 There is a limited set of public chains; Chains not on the list such as Ethereum Classic will have network files named `unknown-<chain_id>.json`.
 

--- a/packages/plugin-hardhat/README.md
+++ b/packages/plugin-hardhat/README.md
@@ -12,7 +12,7 @@ npm install --save-dev @openzeppelin/hardhat-upgrades
 npm install --save-dev @nomiclabs/hardhat-ethers ethers # peer dependencies
 ```
 
-And register the plugins in your [`hardhat.config.js`](https://hardhat.org/config/):
+And register the plugin in your [`hardhat.config.js`](https://hardhat.org/config/):
 
 ```js
 // Javascript


### PR DESCRIPTION
We have to update https://forum.openzeppelin.com/t/openzeppelin-upgrades-step-by-step-tutorial-for-buidler/3580 once this is released.

See also https://github.com/OpenZeppelin/docs.openzeppelin.com/pull/261.