### PR TITLE
Allow ommitting `args` in `deployProxy` when it's an empty array

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Allow ommitting `args` in `deployProxy` when it's an empty array.
+
 ## 1.3.0 (2020-11-13)
 
 - Migrate plugin to Hardhat. ([#214](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/214))

--- a/packages/plugin-hardhat/contracts/DeployOverload.sol
+++ b/packages/plugin-hardhat/contracts/DeployOverload.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.1;
+
+contract DeployOverload {
+    uint public value;
+
+    function customInitialize() public {
+        value = 42;
+    }
+
+}

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -16,7 +16,7 @@
     "prepublish": "rimraf dist *.tsbuildinfo",
     "prepare": "tsc -b",
     "test": "tsc -b && bash scripts/test.sh",
-    "test:watch": "fgbg 'bash scripts/test.sh --watch' 'tsc -b --watch'",
+    "test:watch": "fgbg 'bash scripts/test.sh --watch' 'tsc -b --watch' --",
     "version": "node ../../scripts/bump-changelog.js"
   },
   "devDependencies": {

--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -15,18 +15,26 @@ import { getProxyFactory, getProxyAdminFactory } from './proxy-factory';
 import { readValidations } from './validations';
 import { deploy } from './utils/deploy';
 
-export type DeployFunction = (
-  ImplFactory: ContractFactory,
-  args?: unknown[],
-  opts?: DeployOptions,
-) => Promise<Contract>;
+export interface DeployFunction {
+  (ImplFactory: ContractFactory, args?: unknown[], opts?: DeployOptions): Promise<Contract>;
+  (ImplFactory: ContractFactory, opts?: DeployOptions): Promise<Contract>;
+}
 
 export interface DeployOptions extends ValidationOptions {
   initializer?: string | false;
 }
 
 export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction {
-  return async function deployProxy(ImplFactory, args = [], opts = {}) {
+  return async function deployProxy(
+    ImplFactory: ContractFactory,
+    args: unknown[] | DeployOptions = [],
+    opts: DeployOptions = {},
+  ) {
+    if (!Array.isArray(args)) {
+      opts = args;
+      args = [];
+    }
+
     const { provider } = hre.network;
     const validations = await readValidations(hre);
 

--- a/packages/plugin-hardhat/test/deploy-overload.js
+++ b/packages/plugin-hardhat/test/deploy-overload.js
@@ -1,0 +1,12 @@
+const test = require('ava');
+
+const { ethers, upgrades } = require('hardhat');
+
+test.before(async t => {
+  t.context.DeployOverload = await ethers.getContractFactory('DeployOverload');
+});
+
+test('no args', async t => {
+  const c = await upgrades.deployProxy(t.context.DeployOverload, { initializer: 'customInitialize' });
+  t.is((await c.value()).toString(), '42');
+});

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Allow ommitting `args` in `deployProxy` when it's an empty array.
+
 ## 1.2.4 (2020-11-17)
 
 - Fix spurious "Artifacts are from different compiler runs" error when using dependencies through `artifacts.require`. ([#225](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/225))

--- a/packages/plugin-truffle/src/deploy-proxy.ts
+++ b/packages/plugin-truffle/src/deploy-proxy.ts
@@ -19,9 +19,25 @@ interface InitializerOptions {
 
 export async function deployProxy(
   Contract: ContractClass,
-  args: unknown[] = [],
+  opts?: Options & InitializerOptions,
+): Promise<ContractInstance>;
+
+export async function deployProxy(
+  Contract: ContractClass,
+  args?: unknown[],
+  opts?: Options & InitializerOptions,
+): Promise<ContractInstance>;
+
+export async function deployProxy(
+  Contract: ContractClass,
+  args: unknown[] | (Options & InitializerOptions) = [],
   opts: Options & InitializerOptions = {},
 ): Promise<ContractInstance> {
+  if (!Array.isArray(args)) {
+    opts = args;
+    args = [];
+  }
+
   const { deployer } = withDeployDefaults(opts);
   const provider = wrapProvider(deployer.provider);
 

--- a/packages/plugin-truffle/test/contracts/DeployOverload.sol
+++ b/packages/plugin-truffle/test/contracts/DeployOverload.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.1;
+
+contract DeployOverload {
+    uint public value;
+
+    function customInitialize() public {
+        value = 42;
+    }
+
+}

--- a/packages/plugin-truffle/test/test/deploy-overload.js
+++ b/packages/plugin-truffle/test/test/deploy-overload.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+
+const { deployProxy } = require('@openzeppelin/truffle-upgrades');
+
+const DeployOverload = artifacts.require('DeployOverload');
+
+contract('DeployOverload', function () {
+  it('deployProxy', async function () {
+    const c = await deployProxy(DeployOverload, { initializer: 'customInitialize' });
+    assert.strictEqual((await c.value()).toString(), '42');
+  });
+});


### PR DESCRIPTION
Adds an overload to `deployProxy` so that the options object can be specified as a second argument, omitting the empty args array.

A few people had issues because they assumed this was possible [[1]](https://forum.openzeppelin.com/t/types-values-length-mismatch/4613) [[2]](https://forum.openzeppelin.com/t/contract-is-not-upgrade-safe-defining-structs-is-not-yet-supported/4597).