### PR TITLE
Add a function to silence warnings

### DIFF
--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -89,6 +89,8 @@ async function transferProxyAdminOwnership(
 
 Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
 
+NOTE: This function is useful for tests, but its use in production deployment scripts is discouraged.
+
 [source,ts]
 ----
 function silenceWarnings()

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -84,3 +84,12 @@ async function transferProxyAdminOwnership(
   newAdmin: string,
 ): Promise<void>
 ----
+
+== silenceWarnings
+
+Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
+
+[source,ts]
+----
+function silenceWarnings()
+----

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -94,6 +94,8 @@ async function transferProxyAdminOwnership(
 
 Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
 
+NOTE: This function is useful for tests, but its use in production deployment scripts is discouraged.
+
 [source,ts]
 ----
 function silenceWarnings()

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -89,3 +89,12 @@ async function transferProxyAdminOwnership(
   newAdmin: string,
 ): Promise<void>
 ----
+
+== silenceWarnings
+
+Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
+
+[source,ts]
+----
+function silenceWarnings()
+----

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `silenceWarnings` to emit a single warning and silence all subsequent ones. ([#228](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/228))
+
 ## 1.3.1 (2020-11-13)
 
 - Add missing artifact files in the package.

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -454,7 +454,7 @@ export function silenceWarnings(): void {
   console.error(
     '\n' +
       chalk.keyword('orange').bold('Warning: ') +
-      `All subsequent warnings will be silenced.\n\n` +
+      `All subsequent Upgrades warnings will be silenced.\n\n` +
       `    Make sure you have manually checked all uses of unsafe flags.\n`,
   );
   silenced = true;

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -451,11 +451,13 @@ function* getEnumErrors(contractDef: ContractDefinition, decodeSrc: SrcDecoder):
 let silenced = false;
 
 export function silenceWarnings(): void {
-  console.error(
-    '\n' +
-      chalk.keyword('orange').bold('Warning: ') +
-      `All subsequent Upgrades warnings will be silenced.\n\n` +
-      `    Make sure you have manually checked all uses of unsafe flags.\n`,
-  );
-  silenced = true;
+  if (!silenced) {
+    console.error(
+      '\n' +
+        chalk.keyword('orange').bold('Warning: ') +
+        `All subsequent Upgrades warnings will be silenced.\n\n` +
+        `    Make sure you have manually checked all uses of unsafe flags.\n`,
+    );
+    silenced = true;
+  }
 }

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -250,7 +250,7 @@ function processOverride(
     return !isException;
   });
 
-  if (exceptionsFound) {
+  if (exceptionsFound && !silenced) {
     console.error(
       '\n' +
         chalk.keyword('orange').bold('Warning: ') +
@@ -446,4 +446,16 @@ function* getEnumErrors(contractDef: ContractDefinition, decodeSrc: SrcDecoder):
       src: decodeSrc(enumDefinition),
     };
   }
+}
+
+let silenced = false;
+
+export function silenceWarnings(): void {
+  console.error(
+    '\n' +
+      chalk.keyword('orange').bold('Warning: ') +
+      `All subsequent warnings will be silenced.\n\n` +
+      `    Make sure you have manually checked all uses of unsafe flags.\n`,
+  );
+  silenced = true;
 }

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `silenceWarnings` to emit a single warning and silence all subsequent ones. ([#228](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/228))
+
 ## 1.3.0 (2020-11-13)
 
 - Migrate plugin to Hardhat. ([#214](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/214))

--- a/packages/plugin-hardhat/src/index.ts
+++ b/packages/plugin-hardhat/src/index.ts
@@ -26,8 +26,10 @@ extendEnvironment(hre => {
     const { makeChangeProxyAdmin, makeTransferProxyAdminOwnership } = require('./admin');
     const { makeDeployProxy } = require('./deploy-proxy');
     const { makeUpgradeProxy, makePrepareUpgrade } = require('./upgrade-proxy');
+    const { silenceWarnings } = require('@openzeppelin/upgrades-core');
 
     return {
+      silenceWarnings,
       deployProxy: makeDeployProxy(hre),
       upgradeProxy: makeUpgradeProxy(hre),
       prepareUpgrade: makePrepareUpgrade(hre),

--- a/packages/plugin-hardhat/src/type-extensions.ts
+++ b/packages/plugin-hardhat/src/type-extensions.ts
@@ -1,5 +1,6 @@
 import 'hardhat/types/runtime';
 
+import type { silenceWarnings } from '@openzeppelin/upgrades-core';
 import type { DeployFunction } from './deploy-proxy';
 import type { UpgradeFunction, PrepareUpgradeFunction } from './upgrade-proxy';
 
@@ -9,6 +10,7 @@ declare module 'hardhat/types/runtime' {
       deployProxy: DeployFunction;
       upgradeProxy: UpgradeFunction;
       prepareUpgrade: PrepareUpgradeFunction;
+      silenceWarnings: typeof silenceWarnings;
     };
   }
 }

--- a/packages/plugin-hardhat/test/happy-path-with-enums.js
+++ b/packages/plugin-hardhat/test/happy-path-with-enums.js
@@ -2,6 +2,8 @@ const test = require('ava');
 
 const { ethers, upgrades } = require('hardhat');
 
+upgrades.silenceWarnings();
+
 test.before(async t => {
   t.context.Action = await ethers.getContractFactory('Action');
   t.context.ActionV2 = await ethers.getContractFactory('ActionV2');

--- a/packages/plugin-hardhat/test/happy-path-with-structs.js
+++ b/packages/plugin-hardhat/test/happy-path-with-structs.js
@@ -2,6 +2,8 @@ const test = require('ava');
 
 const { ethers, upgrades } = require('hardhat');
 
+upgrades.silenceWarnings();
+
 test.before(async t => {
   t.context.Portfolio = await ethers.getContractFactory('Portfolio');
   t.context.PortfolioV2 = await ethers.getContractFactory('PortfolioV2');

--- a/packages/plugin-hardhat/test/linked-libraries.js
+++ b/packages/plugin-hardhat/test/linked-libraries.js
@@ -4,6 +4,8 @@ const { ethers, upgrades, artifacts } = require('hardhat');
 
 const testAddress = '0x1E6876a6C2757de611c9F12B23211dBaBd1C9028';
 
+upgrades.silenceWarnings();
+
 test('without flag', async t => {
   // Deploying library
   const safeMathLib = await deployLibrary('SafeMath');

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `silenceWarnings` to emit a single warning and silence all subsequent ones. ([#228](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/228))
+
 ## 1.2.4 (2020-11-17)
 
 - Fix spurious "Artifacts are from different compiler runs" error when using dependencies through `artifacts.require`. ([#225](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/225))

--- a/packages/plugin-truffle/src/index.ts
+++ b/packages/plugin-truffle/src/index.ts
@@ -1,3 +1,5 @@
 export * from './deploy-proxy';
 export * from './upgrade-proxy';
 export { admin } from './admin';
+
+export { silenceWarnings } from '@openzeppelin/upgrades-core';

--- a/packages/plugin-truffle/test.sh
+++ b/packages/plugin-truffle/test.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 rimraf test/.openzeppelin
 
-yarn --cwd test truffle test
+yarn --cwd test truffle test "$@"

--- a/packages/plugin-truffle/test/migrations/1_initial_migration.js
+++ b/packages/plugin-truffle/test/migrations/1_initial_migration.js
@@ -1,3 +1,7 @@
+const upgrades = require('@openzeppelin/truffle-upgrades');
+
+upgrades.silenceWarnings();
+
 const Migrations = artifacts.require('Migrations');
 
 module.exports = function (deployer) {


### PR DESCRIPTION
Fixes #226 

Requested by a user in the forum [[1]](https://forum.openzeppelin.com/t/logging-verbose-during-local-tests-with-upgradeable-contracts/4633). I think it makes sense.