### PR TITLE
Custom Deployments

### DIFF
--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -13,7 +13,7 @@ import {
 
 import { getProxyFactory, getProxyAdminFactory } from './proxy-factory';
 import { readValidations } from './validations';
-import { deploy } from './utils/deploy';
+import { defaultDeploy, DeploymentExecutor, intoCoreDeployment } from './utils/deploy';
 
 export interface DeployFunction {
   (ImplFactory: ContractFactory, args?: unknown[], opts?: DeployOptions): Promise<Contract>;
@@ -22,6 +22,7 @@ export interface DeployFunction {
 
 export interface DeployOptions extends ValidationOptions {
   initializer?: string | false;
+  executor?: DeploymentExecutor;
 }
 
 export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction {
@@ -35,6 +36,7 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
       args = [];
     }
 
+    const deploy = opts.executor || defaultDeploy;
     const { provider } = hre.network;
     const validations = await readValidations(hre);
 
@@ -43,17 +45,19 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
     assertUpgradeSafe(validations, version, opts);
 
     const impl = await fetchOrDeploy(version, provider, async () => {
-      const deployment = await deploy(ImplFactory);
+      const deployment = intoCoreDeployment(await deploy(ImplFactory, []));
       const layout = getStorageLayout(validations, version);
       return { ...deployment, layout };
     });
 
     const AdminFactory = await getProxyAdminFactory(hre, ImplFactory.signer);
-    const adminAddress = await fetchOrDeployAdmin(provider, () => deploy(AdminFactory));
+    const adminAddress = await fetchOrDeployAdmin(provider, async () =>
+      intoCoreDeployment(await deploy(AdminFactory, [])),
+    );
 
     const data = getInitializerData(ImplFactory, args, opts.initializer);
     const ProxyFactory = await getProxyFactory(hre, ImplFactory.signer);
-    const proxy = await ProxyFactory.deploy(impl, adminAddress, data);
+    const proxy = await deploy(ProxyFactory, [impl, adminAddress, data]);
 
     const inst = ImplFactory.attach(proxy.address);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/plugin-hardhat/src/upgrade-proxy.ts
+++ b/packages/plugin-hardhat/src/upgrade-proxy.ts
@@ -16,18 +16,22 @@ import {
 
 import { getProxyAdminFactory } from './proxy-factory';
 import { readValidations } from './validations';
-import { deploy } from './utils/deploy';
+import { defaultDeploy, DeploymentExecutor, intoCoreDeployment } from './utils/deploy';
+
+export interface UpgradeOptions extends ValidationOptions {
+  executor?: DeploymentExecutor;
+}
 
 export type PrepareUpgradeFunction = (
   proxyAddress: string,
   ImplFactory: ContractFactory,
-  opts?: ValidationOptions,
+  opts?: UpgradeOptions,
 ) => Promise<string>;
 
 export type UpgradeFunction = (
   proxyAddress: string,
   ImplFactory: ContractFactory,
-  opts?: ValidationOptions,
+  opts?: UpgradeOptions,
 ) => Promise<Contract>;
 
 async function prepareUpgradeImpl(
@@ -35,8 +39,9 @@ async function prepareUpgradeImpl(
   manifest: Manifest,
   proxyAddress: string,
   ImplFactory: ContractFactory,
-  opts: ValidationOptions,
+  opts: UpgradeOptions,
 ): Promise<string> {
+  const deploy = opts.executor || defaultDeploy;
   const { provider } = hre.network;
   const validations = await readValidations(hre);
 
@@ -51,7 +56,7 @@ async function prepareUpgradeImpl(
   assertStorageUpgradeSafe(deployment.layout, layout, opts.unsafeAllowCustomTypes);
 
   return await fetchOrDeploy(version, provider, async () => {
-    const deployment = await deploy(ImplFactory);
+    const deployment = intoCoreDeployment(await deploy(ImplFactory, []));
     return { ...deployment, layout };
   });
 }

--- a/packages/plugin-hardhat/src/utils/deploy.ts
+++ b/packages/plugin-hardhat/src/utils/deploy.ts
@@ -1,8 +1,18 @@
+import type { ContractFactory, ContractTransaction } from 'ethers';
 import type { Deployment } from '@openzeppelin/upgrades-core';
-import type { ContractFactory } from 'ethers';
+export interface DeploymentExecutor {
+  (factory: ContractFactory): Promise<HardhatDeployment>;
+}
 
-export async function deploy(factory: ContractFactory): Promise<Deployment> {
-  const { address, deployTransaction } = await factory.deploy();
-  const txHash = deployTransaction.hash;
-  return { address, txHash };
+export interface HardhatDeployment {
+  address: string;
+  deployTransaction: ContractTransaction;
+}
+
+export function defaultDeploy(factory: ContractFactory, args: unknown[]): Promise<HardhatDeployment> {
+  return factory.deploy(...args);
+}
+
+export function intoCoreDeployment({ address, deployTransaction }: HardhatDeployment): Deployment {
+  return { address, txHash: deployTransaction.hash };
 }


### PR DESCRIPTION
Addresses Issue #272 by allowing projects depending on this plugin to specify their own `deploy` function. If a deployment executor is not specified, then the initial (default) implementation is used as a fallback.

Currently this remains untested apart from the fact that all existing tests still pass. Open to suggestions for testing!