### PR TITLE
Add admin.getInstance

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `upgrades.admin.getInstance()` to retrieve the instance of `ProxyAdmin` that is in use. ([#274](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/274))
+
 ## 1.4.3 (2020-12-16)
 
 - Fix an error in the `unsafeAllowCustomTypes` flag that would cause other storage layout incompatibilities to be ignored. ([#259](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/259))

--- a/packages/plugin-hardhat/src/admin.ts
+++ b/packages/plugin-hardhat/src/admin.ts
@@ -5,7 +5,7 @@ import { getProxyAdminFactory } from './proxy-factory';
 
 export type ChangeAdminFunction = (proxyAddress: string, newAdmin: string) => Promise<void>;
 export type TransferProxyAdminOwnershipFunction = (newOwner: string) => Promise<void>;
-export type DeployedProxyAdminFunction = () => Promise<Contract>;
+export type GetInstanceFunction = () => Promise<Contract>;
 
 export function makeChangeProxyAdmin(hre: HardhatRuntimeEnvironment): ChangeAdminFunction {
   return async function changeProxyAdmin(proxyAddress, newAdmin) {
@@ -27,8 +27,8 @@ export function makeTransferProxyAdminOwnership(hre: HardhatRuntimeEnvironment):
   };
 }
 
-export function makeDeployedProxyAdmin(hre: HardhatRuntimeEnvironment): DeployedProxyAdminFunction {
-  return async function deployedProxyAdmin() {
+export function makeGetInstanceFunction(hre: HardhatRuntimeEnvironment): GetInstanceFunction {
+  return async function getInstance() {
     return await getManifestAdmin(hre);
   };
 }

--- a/packages/plugin-hardhat/src/admin.ts
+++ b/packages/plugin-hardhat/src/admin.ts
@@ -5,6 +5,7 @@ import { getProxyAdminFactory } from './proxy-factory';
 
 export type ChangeAdminFunction = (proxyAddress: string, newAdmin: string) => Promise<void>;
 export type TransferProxyAdminOwnershipFunction = (newOwner: string) => Promise<void>;
+export type DeployedProxyAdminFunction = () => Promise<Contract>;
 
 export function makeChangeProxyAdmin(hre: HardhatRuntimeEnvironment): ChangeAdminFunction {
   return async function changeProxyAdmin(proxyAddress, newAdmin) {
@@ -23,6 +24,12 @@ export function makeTransferProxyAdminOwnership(hre: HardhatRuntimeEnvironment):
   return async function transferProxyAdminOwnership(newOwner) {
     const admin = await getManifestAdmin(hre);
     await admin.transferOwnership(newOwner);
+  };
+}
+
+export function makeDeployedProxyAdmin(hre: HardhatRuntimeEnvironment): DeployedProxyAdminFunction {
+  return async function deployedProxyAdmin() {
+    return await getManifestAdmin(hre);
   };
 }
 

--- a/packages/plugin-hardhat/src/index.ts
+++ b/packages/plugin-hardhat/src/index.ts
@@ -11,7 +11,7 @@ import { writeValidations } from './validations';
 import type { silenceWarnings } from '@openzeppelin/upgrades-core';
 import type { DeployFunction } from './deploy-proxy';
 import type { UpgradeFunction, PrepareUpgradeFunction } from './upgrade-proxy';
-import type { ChangeAdminFunction, TransferProxyAdminOwnershipFunction, DeployedProxyAdminFunction } from './admin';
+import type { ChangeAdminFunction, TransferProxyAdminOwnershipFunction, GetInstanceFunction } from './admin';
 
 export interface HardhatUpgrades {
   deployProxy: DeployFunction;
@@ -19,7 +19,7 @@ export interface HardhatUpgrades {
   prepareUpgrade: PrepareUpgradeFunction;
   silenceWarnings: typeof silenceWarnings;
   admin: {
-    deployedProxyAdmin: DeployedProxyAdminFunction;
+    getInstance: GetInstanceFunction;
     changeProxyAdmin: ChangeAdminFunction;
     transferProxyAdminOwnership: TransferProxyAdminOwnershipFunction;
   };
@@ -46,7 +46,7 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE, async (args: RunCompilerArgs, hre, runSup
 extendEnvironment(hre => {
   hre.upgrades = lazyObject(
     (): HardhatUpgrades => {
-      const { makeChangeProxyAdmin, makeTransferProxyAdminOwnership, makeDeployedProxyAdmin } = require('./admin');
+      const { makeChangeProxyAdmin, makeTransferProxyAdminOwnership, makeGetInstanceFunction } = require('./admin');
       const { makeDeployProxy } = require('./deploy-proxy');
       const { makeUpgradeProxy, makePrepareUpgrade } = require('./upgrade-proxy');
       const { silenceWarnings } = require('@openzeppelin/upgrades-core');
@@ -57,7 +57,7 @@ extendEnvironment(hre => {
         upgradeProxy: makeUpgradeProxy(hre),
         prepareUpgrade: makePrepareUpgrade(hre),
         admin: {
-          deployedProxyAdmin: makeDeployedProxyAdmin(hre),
+          getInstance: makeGetInstanceFunction(hre),
           changeProxyAdmin: makeChangeProxyAdmin(hre),
           transferProxyAdminOwnership: makeTransferProxyAdminOwnership(hre),
         },

--- a/packages/plugin-hardhat/src/index.ts
+++ b/packages/plugin-hardhat/src/index.ts
@@ -11,7 +11,7 @@ import { writeValidations } from './validations';
 import type { silenceWarnings } from '@openzeppelin/upgrades-core';
 import type { DeployFunction } from './deploy-proxy';
 import type { UpgradeFunction, PrepareUpgradeFunction } from './upgrade-proxy';
-import type { ChangeAdminFunction, TransferProxyAdminOwnershipFunction } from './admin';
+import type { ChangeAdminFunction, TransferProxyAdminOwnershipFunction, DeployedProxyAdminFunction } from './admin';
 
 export interface HardhatUpgrades {
   deployProxy: DeployFunction;
@@ -19,6 +19,7 @@ export interface HardhatUpgrades {
   prepareUpgrade: PrepareUpgradeFunction;
   silenceWarnings: typeof silenceWarnings;
   admin: {
+    deployedProxyAdmin: DeployedProxyAdminFunction;
     changeProxyAdmin: ChangeAdminFunction;
     transferProxyAdminOwnership: TransferProxyAdminOwnershipFunction;
   };
@@ -45,7 +46,7 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE, async (args: RunCompilerArgs, hre, runSup
 extendEnvironment(hre => {
   hre.upgrades = lazyObject(
     (): HardhatUpgrades => {
-      const { makeChangeProxyAdmin, makeTransferProxyAdminOwnership } = require('./admin');
+      const { makeChangeProxyAdmin, makeTransferProxyAdminOwnership, makeDeployedProxyAdmin } = require('./admin');
       const { makeDeployProxy } = require('./deploy-proxy');
       const { makeUpgradeProxy, makePrepareUpgrade } = require('./upgrade-proxy');
       const { silenceWarnings } = require('@openzeppelin/upgrades-core');
@@ -56,6 +57,7 @@ extendEnvironment(hre => {
         upgradeProxy: makeUpgradeProxy(hre),
         prepareUpgrade: makePrepareUpgrade(hre),
         admin: {
+          deployedProxyAdmin: makeDeployedProxyAdmin(hre),
           changeProxyAdmin: makeChangeProxyAdmin(hre),
           transferProxyAdminOwnership: makeTransferProxyAdminOwnership(hre),
         },

--- a/packages/plugin-hardhat/test/admin-instance.js
+++ b/packages/plugin-hardhat/test/admin-instance.js
@@ -6,9 +6,11 @@ test.before(async t => {
   t.context.Greeter = await ethers.getContractFactory('Greeter');
 });
 
-test('admin.deployedProxyAdmin', async t => {
+test('admin.getInstance', async t => {
+  await t.throwsAsync(() => upgrades.admin.getInstance(), undefined, 'No ProxyAdmin was found in the network manifest');
+
   const { Greeter } = t.context;
   await upgrades.deployProxy(Greeter, ['Hola admin!']);
-  const proxyAdmin = await upgrades.admin.deployedProxyAdmin();
+  const proxyAdmin = await upgrades.admin.getInstance();
   t.assert(proxyAdmin);
 });

--- a/packages/plugin-hardhat/test/admin-instance.js
+++ b/packages/plugin-hardhat/test/admin-instance.js
@@ -7,10 +7,11 @@ test.before(async t => {
 });
 
 test('admin.getInstance', async t => {
-  await t.throwsAsync(() => upgrades.admin.getInstance(), undefined, 'No ProxyAdmin was found in the network manifest');
+  await t.throwsAsync(upgrades.admin.getInstance(), undefined, 'No ProxyAdmin was found in the network manifest');
 
   const { Greeter } = t.context;
-  await upgrades.deployProxy(Greeter, ['Hola admin!']);
-  const proxyAdmin = await upgrades.admin.getInstance();
-  t.assert(proxyAdmin);
+  const greeter = await upgrades.deployProxy(Greeter, ['Hola admin!']);
+  const adminInstance = await upgrades.admin.getInstance();
+  const adminAddress = await adminInstance.getProxyAdmin(greeter.address);
+  t.is(adminInstance.address, adminAddress);
 });

--- a/packages/plugin-hardhat/test/admin-instance.js
+++ b/packages/plugin-hardhat/test/admin-instance.js
@@ -1,0 +1,14 @@
+const test = require('ava');
+
+const { ethers, upgrades } = require('hardhat');
+
+test.before(async t => {
+  t.context.Greeter = await ethers.getContractFactory('Greeter');
+});
+
+test('admin.deployedProxyAdmin', async t => {
+  const { Greeter } = t.context;
+  await upgrades.deployProxy(Greeter, ['Hola admin!']);
+  const proxyAdmin = await upgrades.admin.deployedProxyAdmin();
+  t.assert(proxyAdmin);
+});

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+- Add `upgrades.admin.getInstance()` to retrieve the instance of `ProxyAdmin` that is in use. ([#274](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/274))
+
 ## 1.3.1 (2020-12-16)
 
 - Fix an error in the `unsafeAllowCustomTypes` flag that would cause other storage layout incompatibilities to be ignored. ([#259](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/259))

--- a/packages/plugin-truffle/src/admin.ts
+++ b/packages/plugin-truffle/src/admin.ts
@@ -25,6 +25,12 @@ async function transferProxyAdminOwnership(newOwner: string, opts: Options = {})
   await admin.transferOwnership(newOwner);
 }
 
+async function getInstance(opts: Options = {}): Promise<ContractInstance> {
+  const { deployer } = withDefaults(opts);
+  const provider = wrapProvider(deployer.provider);
+  return await getManifestAdmin(provider);
+}
+
 export async function getManifestAdmin(provider: EthereumProvider): Promise<ContractInstance> {
   const manifest = await Manifest.forNetwork(provider);
   const manifestAdmin = await manifest.getAdmin();
@@ -39,6 +45,7 @@ export async function getManifestAdmin(provider: EthereumProvider): Promise<Cont
 }
 
 export const admin = {
+  getInstance,
   transferProxyAdminOwnership,
   changeProxyAdmin,
 };

--- a/packages/plugin-truffle/test/test/admin-happy-path.js
+++ b/packages/plugin-truffle/test/test/admin-happy-path.js
@@ -13,10 +13,10 @@ contract('Admin', function () {
   const testAddress = '0x1E6876a6C2757de611c9F12B23211dBaBd1C9028';
 
   it('getInstance', async function () {
-    await upgrades.deployProxy(Greeter, ['Hello Truffle']);
-    const got = await upgrades.admin.getInstance();
-    const expected = await getManifestAdmin(provider);
-    assert.strictEqual(got.address, expected.address);
+    const greeter = await upgrades.deployProxy(Greeter, ['Hello Truffle']);
+    const adminInstance = await upgrades.admin.getInstance();
+    const adminAddress = await adminInstance.getProxyAdmin(greeter.address);
+    assert.strictEqual(adminInstance.address, adminAddress);
   });
 
   it('changeProxyAdmin', async function () {

--- a/packages/plugin-truffle/test/test/admin-happy-path.js
+++ b/packages/plugin-truffle/test/test/admin-happy-path.js
@@ -12,6 +12,13 @@ contract('Admin', function () {
   const provider = wrapProvider(deployer.provider);
   const testAddress = '0x1E6876a6C2757de611c9F12B23211dBaBd1C9028';
 
+  it('getInstance', async function () {
+    await upgrades.deployProxy(Greeter, ['Hello Truffle']);
+    const got = await upgrades.admin.getInstance();
+    const expected = await getManifestAdmin(provider);
+    assert.strictEqual(got.address, expected.address);
+  });
+
   it('changeProxyAdmin', async function () {
     const greeter = await upgrades.deployProxy(Greeter, ['Hello Truffle']);
     await upgrades.admin.changeProxyAdmin(greeter.address, testAddress);


### PR DESCRIPTION
This PR is for kicking off #173.

An `deployedProxyAdmin` method is added to `admin` module to get `ProxyAdmin` instance (feel free to suggest names). My use case is simply to get the address programmatically without `fs.readFileSync` the manifest.