### PR TITLE
Remove console.log from test contracts

### DIFF
--- a/packages/plugin-hardhat/contracts/Adder.sol
+++ b/packages/plugin-hardhat/contracts/Adder.sol
@@ -1,12 +1,9 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract Adder {
     uint n;
 
     function initialize() public view {
-        console.log("Deploying Adder");
     }
 
     function add(uint x) public returns (uint) {

--- a/packages/plugin-hardhat/contracts/AdderV2.sol
+++ b/packages/plugin-hardhat/contracts/AdderV2.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 library SafeAdd {
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;
@@ -17,7 +15,6 @@ contract AdderV2 {
     uint n;
 
     function initialize() public view {
-        console.log("Deploying AdderV2");
     }
 
     function add(uint x) public returns (uint) {

--- a/packages/plugin-hardhat/contracts/ExternalLibraries.sol
+++ b/packages/plugin-hardhat/contracts/ExternalLibraries.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 library SafeMath {
     function add(uint256 a, uint256 b) external pure returns (uint256) {
         uint256 c = a + b;

--- a/packages/plugin-hardhat/contracts/Invalid.sol
+++ b/packages/plugin-hardhat/contracts/Invalid.sol
@@ -1,11 +1,8 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract Invalid {
 
     function initialize() public view {
-        console.log("This is an invalid contract, it should not be deployed");
     }
 
     function oops() public {

--- a/packages/plugin-hardhat/contracts/InvalidGreeter.sol
+++ b/packages/plugin-hardhat/contracts/InvalidGreeter.sol
@@ -1,14 +1,11 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract GreeterStorageConflict {
 
     uint greets;
     string greeting;
 
     function initialize(string memory _greeting) public {
-        console.log("Deploying a Greeter with greeting:", _greeting);
         greeting = _greeting;
     }
 
@@ -18,7 +15,6 @@ contract GreeterStorageConflict {
     }
 
     function setGreeting(string memory _greeting) public {
-        console.log("Changing greeting from '%s' to '%s'", greeting, _greeting);
         greeting = _greeting;
     }
 

--- a/packages/plugin-hardhat/contracts/Portfolio.sol
+++ b/packages/plugin-hardhat/contracts/Portfolio.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract Portfolio {
     struct Asset {
         bool enabled;
@@ -11,7 +9,6 @@ contract Portfolio {
     mapping (string => Asset) assets;
 
     function initialize() public view {
-        console.log("Deploying Portfolio");
     }
 
     function enable(string memory name) public returns (bool) {

--- a/packages/plugin-hardhat/contracts/PortfolioV2.sol
+++ b/packages/plugin-hardhat/contracts/PortfolioV2.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract PortfolioV2 {
     struct Asset {
         bool enabled;
@@ -11,7 +9,6 @@ contract PortfolioV2 {
     mapping (string => Asset) assets;
 
     function initialize() public view {
-        console.log("Deploying PortfolioV2");
     }
 
     function enable(string memory name) public returns (bool) {
@@ -35,7 +32,6 @@ contract PortfolioV2Bad {
     mapping (string => Asset) assets;
 
     function initialize() public view {
-        console.log("Deploying PortfolioV2");
     }
 
     function enable(string memory name) public returns (bool) {

--- a/packages/plugin-hardhat/contracts/Token.sol
+++ b/packages/plugin-hardhat/contracts/Token.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
 import "./ExternalLibraries.sol";
 
 contract Token {
@@ -15,7 +14,6 @@ contract Token {
   mapping(address => uint256) balances;
 
   function initialize(string memory tokenSymbol, uint256 amount) public { 
-    console.log("Deploying Token");
     symbol = tokenSymbol;
     totalSupply = amount;
     balances[msg.sender] = amount;

--- a/packages/plugin-hardhat/contracts/TokenV2.sol
+++ b/packages/plugin-hardhat/contracts/TokenV2.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
 import "./Token.sol";
 
 contract TokenV2 is Token {

--- a/packages/plugin-truffle/test/contracts/Action.sol
+++ b/packages/plugin-truffle/test/contracts/Action.sol
@@ -1,13 +1,10 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract Action {
     enum ActionType { UP, DOWN }
     event ActionEvent(ActionType actionType);
 
     function initialize() public view {
-        console.log("Deploying Action");
     }
 
     function log(ActionType action) public {

--- a/packages/plugin-truffle/test/contracts/ActionV2.sol
+++ b/packages/plugin-truffle/test/contracts/ActionV2.sol
@@ -1,14 +1,11 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract ActionV2 {
     enum ActionType { UP, DOWN, LEFT, RIGHT }
     event ActionEvent(ActionType actionType);
 
 
     function initialize() public view {
-        console.log("Deploying ActionV2");
     }
 
     function log(ActionType action) public {

--- a/packages/plugin-truffle/test/contracts/Adder.sol
+++ b/packages/plugin-truffle/test/contracts/Adder.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract Adder {
     uint public n;
 

--- a/packages/plugin-truffle/test/contracts/AdderV2.sol
+++ b/packages/plugin-truffle/test/contracts/AdderV2.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 library SafeAdd {
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;

--- a/packages/plugin-truffle/test/contracts/ExternalLibraries.sol
+++ b/packages/plugin-truffle/test/contracts/ExternalLibraries.sol
@@ -1,8 +1,6 @@
 
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 library SafeMath {
     function add(uint256 a, uint256 b) external pure returns (uint256) {
         uint256 c = a + b;

--- a/packages/plugin-truffle/test/contracts/Portfolio.sol
+++ b/packages/plugin-truffle/test/contracts/Portfolio.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract Portfolio {
     struct Asset {
         bool enabled;
@@ -11,7 +9,6 @@ contract Portfolio {
     mapping (string => Asset) assets;
 
     function initialize() public view {
-        console.log("Deploying Portfolio");
     }
 
     function enable(string memory name) public returns (bool) {

--- a/packages/plugin-truffle/test/contracts/PortfolioV2.sol
+++ b/packages/plugin-truffle/test/contracts/PortfolioV2.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
-
 contract PortfolioV2 {
     struct Asset {
         bool enabled;
@@ -11,7 +9,6 @@ contract PortfolioV2 {
     mapping (string => Asset) assets;
 
     function initialize() public view {
-        console.log("Deploying PortfolioV2");
     }
 
     function enable(string memory name) public returns (bool) {
@@ -35,7 +32,6 @@ contract PortfolioV2Bad {
     mapping (string => Asset) assets;
 
     function initialize() public view {
-        console.log("Deploying PortfolioV2");
     }
 
     function enable(string memory name) public returns (bool) {

--- a/packages/plugin-truffle/test/contracts/Token.sol
+++ b/packages/plugin-truffle/test/contracts/Token.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
 import "./ExternalLibraries.sol";
 
 contract Token {
@@ -15,7 +14,6 @@ contract Token {
   mapping(address => uint256) balances;
 
   function initialize(string memory tokenSymbol, uint256 amount) public { 
-    console.log("Deploying Token");
     symbol = tokenSymbol;
     totalSupply = amount;
     balances[msg.sender] = amount;

--- a/packages/plugin-truffle/test/contracts/TokenV2.sol
+++ b/packages/plugin-truffle/test/contracts/TokenV2.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.1;
 
-import "hardhat/console.sol";
 import "./Token.sol";
 
 contract TokenV2 is Token {


### PR DESCRIPTION
This was left over from the initial days of the prototype doing manual testing. It is only adding noise in the console and not providing any value for the tests.