### PR TITLE
Include DeployOption skipAll for validation

### DIFF
--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -58,12 +58,14 @@ interface ValidationErrorOpcode extends ValidationErrorBase {
 export interface ValidationOptions {
   unsafeAllowCustomTypes?: boolean;
   unsafeAllowLinkedLibraries?: boolean;
+  skipAll?: boolean;
 }
 
 export function withValidationDefaults(opts: ValidationOptions): Required<ValidationOptions> {
   return {
     unsafeAllowCustomTypes: opts.unsafeAllowCustomTypes ?? false,
     unsafeAllowLinkedLibraries: opts.unsafeAllowLinkedLibraries ?? false,
+    skipAll: opts.skipAll ?? false,
   };
 }
 
@@ -199,7 +201,7 @@ export function assertUpgradeSafe(validations: Validations, version: Version, op
   let errors = getErrors(validations, version);
   errors = processExceptions(contractName, errors, opts);
 
-  if (errors.length > 0) {
+  if (errors.length > 0 && !opts.skipAll) {
     throw new ValidationErrors(contractName, errors);
   }
 }

--- a/packages/plugin-hardhat/test/deploy-validation.js
+++ b/packages/plugin-hardhat/test/deploy-validation.js
@@ -10,3 +10,8 @@ test('invalid deployment', async t => {
   const { Invalid } = t.context;
   await t.throwsAsync(() => upgrades.deployProxy(Invalid), undefined, 'Contract `Invalid` is not upgrade safe');
 });
+
+test('deploys invalid deployment with skipAll = true', async t => {
+  const { Invalid } = t.context;
+  await t.notThrowsAsync(upgrades.deployProxy(Invalid, [], { skipAll: true }));
+});

--- a/packages/plugin-truffle/src/options.ts
+++ b/packages/plugin-truffle/src/options.ts
@@ -5,11 +5,12 @@ export type Options = DeployOptions & ValidationOptions;
 
 export function withDefaults(opts: Options): Required<Options> {
   const { deployer } = withDeployDefaults(opts);
-  const { unsafeAllowCustomTypes, unsafeAllowLinkedLibraries } = withValidationDefaults(opts);
+  const { unsafeAllowCustomTypes, unsafeAllowLinkedLibraries, skipAll } = withValidationDefaults(opts);
   return {
     deployer,
     unsafeAllowCustomTypes,
     unsafeAllowLinkedLibraries,
+    skipAll,
   };
 }
 

--- a/packages/plugin-truffle/test/contracts/Invalid.sol
+++ b/packages/plugin-truffle/test/contracts/Invalid.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.1;
+
+contract Invalid {
+
+    function initialize() public view {
+    }
+
+    function oops() public {
+        selfdestruct(msg.sender);
+    }
+
+}

--- a/packages/plugin-truffle/test/test/deploy-validation.js
+++ b/packages/plugin-truffle/test/test/deploy-validation.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const upgrades = require('@openzeppelin/truffle-upgrades');
+
+const InvalidFactory = artifacts.require('Invalid');
+
+contract('Invalid', function () {
+  it('Invalid contract fails validation', async function () {
+    await assert.rejects(upgrades.deployProxy(InvalidFactory));
+  });
+
+  it('is deployable with skipall', async function () {
+    const invalid = await upgrades.deployProxy(InvalidFactory, { skipAll: true });
+    assert.ok(invalid.transactionHash, 'transaction hash is missing');
+  });
+});


### PR DESCRIPTION
Addresses/closes #280

This PR introduces a new deployment option that allows the user to override validation entirely with a boolean flag `skipAll`. Both truffle and hardhat plugin have been changed accordingly and unit tests are introduced in both. 

Note that the tests in truffle plugin include new contracts that are explicitly tested (probably not as on point and irrelvant to the change) while the hard hat test is much more concise and directly to the point. Willing to do either, both are probably not necessary.