### PR TITLE
Update wrap-provider.ts

### DIFF
--- a/packages/plugin-truffle/src/wrap-provider.ts
+++ b/packages/plugin-truffle/src/wrap-provider.ts
@@ -6,7 +6,10 @@ import { EthereumProvider } from '@openzeppelin/upgrades-core';
 import { TruffleProvider } from './truffle';
 
 export function wrapProvider(provider: TruffleProvider): EthereumProvider {
-  const web3Send = promisify(provider.send.bind(provider));
+  let web3Send = promisify(provider.send.bind(provider));
+  if (provider['sendAsync']!=undefined){
+      web3Send = promisify(provider['sendAsync'].bind(provider));
+  }
   return {
     async send(method: string, params: unknown[]) {
       const id = crypto.randomBytes(4).toString('hex');


### PR DESCRIPTION
fixed wrapProvider when providers like ledger-provider who used Web3ProviderEngine, which throws an error with 'Web3ProviderEngine.prototype.send'