### PR TITLE
Ignore assign of immutable variable

### DIFF
--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -143,8 +143,10 @@ In some cases you may want to allow multiple errors in a single line.
 [source,solidity]
 ----
 contract SomeOtherContract {
-  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
-  uint256 immutable x = 1;
+  /// @custom:oz-upgrades-unsafe-allow delegatecall selfdestruct
+  function unsafe() public onlyInProxy {
+    ...
+  }
 }
 ----
 

--- a/packages/core/contracts/test/ValidationsNatspec.sol
+++ b/packages/core/contracts/test/ValidationsNatspec.sol
@@ -32,18 +32,18 @@ contract HasStateVariableAssignmentNatspec3 {
   uint y = 2;
 }
 
-/// @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
+/// @custom:oz-upgrades-unsafe-allow state-variable-immutable
 contract HasImmutableStateVariableNatspec1 {
   uint immutable x = 1;
 }
 
 contract HasImmutableStateVariableNatspec2 {
-  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
   uint immutable x = 1;
 }
 
 contract HasImmutableStateVariableNatspec3 {
-  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
   uint immutable x = 1;
   uint immutable y = 2;
 }

--- a/packages/core/src/validate/run.ts
+++ b/packages/core/src/validate/run.ts
@@ -201,7 +201,7 @@ function* getStateVariableErrors(
 ): Generator<ValidationErrorWithName> {
   for (const varDecl of contractDef.nodes) {
     if (isNodeType('VariableDeclaration', varDecl)) {
-      if (!varDecl.constant && !isNullish(varDecl.value)) {
+      if (!varDecl.constant && varDecl.mutability !== 'immutable' && !isNullish(varDecl.value)) {
         if (!skipCheck('state-variable-assignment', contractDef) && !skipCheck('state-variable-assignment', varDecl)) {
           yield {
             kind: 'state-variable-assignment',


### PR DESCRIPTION
Assignments to immutable variables will not be considered errors. Note that immutable variables are still errors and currently require a manual override to allow them (`unsafeAllow: ['state-variable-immutable']` or `@custom:oz-upgrades-unsafe-allow state-variable-immutable`).

Not adding a changelog entry for this since it doesn't have a visible user effect (`unsafeAllow` hasn't been released yet).