### PR TITLE
feat: Utilize generic to better support Typechain types

### DIFF
--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -16,8 +16,8 @@ import { readValidations } from './validations';
 import { deploy } from './utils/deploy';
 
 export interface DeployFunction {
-  (ImplFactory: ContractFactory, args?: unknown[], opts?: DeployOptions): Promise<Contract>;
-  (ImplFactory: ContractFactory, opts?: DeployOptions): Promise<Contract>;
+  <C extends Contract>(ImplFactory: ContractFactory, args?: unknown[], opts?: DeployOptions): Promise<C>;
+  <C extends Contract>(ImplFactory: ContractFactory, opts?: DeployOptions): Promise<C>;
 }
 
 export interface DeployOptions extends ValidationOptions {

--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -1,5 +1,5 @@
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
-import type { ContractFactory, Contract } from 'ethers';
+import type { ContractFactory } from 'ethers';
 
 import {
   assertUpgradeSafe,
@@ -15,9 +15,11 @@ import { getProxyFactory, getProxyAdminFactory } from './proxy-factory';
 import { readValidations } from './validations';
 import { deploy } from './utils/deploy';
 
+type InstanceOf<F extends ContractFactory> = ReturnType<F['attach']>;
+
 export interface DeployFunction {
-  <C extends Contract>(ImplFactory: ContractFactory, args?: unknown[], opts?: DeployOptions): Promise<C>;
-  <C extends Contract>(ImplFactory: ContractFactory, opts?: DeployOptions): Promise<C>;
+  <F extends ContractFactory>(ImplFactory: F, args?: unknown[], opts?: DeployOptions): Promise<InstanceOf<F>>;
+  <F extends ContractFactory>(ImplFactory: F, opts?: DeployOptions): Promise<InstanceOf<F>>;
 }
 
 export interface DeployOptions extends ValidationOptions {


### PR DESCRIPTION
This adds a generic to the return result of the DeployFunction. This allows better integration with Typechain types, like so:

```ts
const WhitelistFactory = await hre.ethers.getContractFactory('Whitelist');

// Notice the `: Whitelist` here, which casts the Contract return to the Typechain
const whitelist: Whitelist = await hre.upgrades.deployProxy(WhitelistFactory, [args.address]);

await whitelist.deployed();

// We could then use custom RPC methods on Whitelist and have it fully typechecked here.
```