### PR TITLE
Accept contract instance as well as address for upgradeProxy

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support passing contract instance to `upgradeProxy` and `prepareUpgrade`.
+
 ## 1.7.0 (2021-04-29)
 
 - Add support for UUPS proxies. ([#315](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/315))

--- a/packages/plugin-hardhat/src/prepare-upgrade.ts
+++ b/packages/plugin-hardhat/src/prepare-upgrade.ts
@@ -3,17 +3,19 @@ import type { ContractFactory } from 'ethers';
 
 import { ValidationOptions, withValidationDefaults, setProxyKind } from '@openzeppelin/upgrades-core';
 
-import { deployImpl } from './utils';
+import { ContractAddressOrInstance, deployImpl, getContractAddress } from './utils';
 
 export type PrepareUpgradeFunction = (
-  proxyAddress: string,
+  proxyAddress: ContractAddressOrInstance,
   ImplFactory: ContractFactory,
   opts?: ValidationOptions,
 ) => Promise<string>;
 
 export function makePrepareUpgrade(hre: HardhatRuntimeEnvironment): PrepareUpgradeFunction {
-  return async function prepareUpgrade(proxyAddress, ImplFactory, opts: ValidationOptions = {}) {
+  return async function prepareUpgrade(proxy, ImplFactory, opts: ValidationOptions = {}) {
     const { provider } = hre.network;
+
+    const proxyAddress = getContractAddress(proxy);
 
     await setProxyKind(provider, proxyAddress, opts);
 

--- a/packages/plugin-hardhat/src/upgrade-proxy.ts
+++ b/packages/plugin-hardhat/src/upgrade-proxy.ts
@@ -10,17 +10,19 @@ import {
   getCode,
 } from '@openzeppelin/upgrades-core';
 
-import { deployImpl, getTransparentUpgradeableProxyFactory, getProxyAdminFactory } from './utils';
+import { deployImpl, getTransparentUpgradeableProxyFactory, getProxyAdminFactory, getContractAddress, ContractAddressOrInstance } from './utils';
 
 export type UpgradeFunction = (
-  proxyAddress: string,
+  proxy: ContractAddressOrInstance,
   ImplFactory: ContractFactory,
   opts?: ValidationOptions,
 ) => Promise<Contract>;
 
 export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment): UpgradeFunction {
-  return async function upgradeProxy(proxyAddress, ImplFactory, opts: ValidationOptions = {}) {
+  return async function upgradeProxy(proxy, ImplFactory, opts: ValidationOptions = {}) {
     const { provider } = hre.network;
+
+    const proxyAddress = getContractAddress(proxy);
 
     await setProxyKind(provider, proxyAddress, opts);
 

--- a/packages/plugin-hardhat/src/upgrade-proxy.ts
+++ b/packages/plugin-hardhat/src/upgrade-proxy.ts
@@ -10,7 +10,13 @@ import {
   getCode,
 } from '@openzeppelin/upgrades-core';
 
-import { deployImpl, getTransparentUpgradeableProxyFactory, getProxyAdminFactory, getContractAddress, ContractAddressOrInstance } from './utils';
+import {
+  deployImpl,
+  getTransparentUpgradeableProxyFactory,
+  getProxyAdminFactory,
+  getContractAddress,
+  ContractAddressOrInstance,
+} from './utils';
 
 export type UpgradeFunction = (
   proxy: ContractAddressOrInstance,

--- a/packages/plugin-hardhat/src/utils/contract-address.ts
+++ b/packages/plugin-hardhat/src/utils/contract-address.ts
@@ -1,0 +1,9 @@
+export type ContractAddressOrInstance = string | { address: string };
+
+export function getContractAddress(addressOrInstance: ContractAddressOrInstance): string {
+  if (typeof addressOrInstance === 'string') {
+    return addressOrInstance;
+  } else {
+    return addressOrInstance.address;
+  }
+}

--- a/packages/plugin-hardhat/src/utils/index.ts
+++ b/packages/plugin-hardhat/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './deploy-impl';
 export * from './factories';
 export * from './is-full-solc-output';
 export * from './validations';
+export * from './contract-address';

--- a/packages/plugin-hardhat/test/transparent-admin-validation.js
+++ b/packages/plugin-hardhat/test/transparent-admin-validation.js
@@ -14,7 +14,7 @@ test('admin validation', async t => {
   const greeter = await upgrades.deployProxy(Greeter, ['Hola admin!'], { kind: 'transparent' });
   await upgrades.admin.changeProxyAdmin(greeter.address, NEW_ADMIN);
   await t.throwsAsync(
-    () => upgrades.upgradeProxy(greeter.address, GreeterV2),
+    () => upgrades.upgradeProxy(greeter, GreeterV2),
     undefined,
     'Proxy admin is not the one registered in the network manifest',
   );

--- a/packages/plugin-hardhat/test/transparent-happy-path-with-enums.js
+++ b/packages/plugin-hardhat/test/transparent-happy-path-with-enums.js
@@ -18,12 +18,12 @@ test('deployProxy', async t => {
 test('upgradeProxy', async t => {
   const { Action, ActionV2 } = t.context;
   const action = await upgrades.deployProxy(Action, [], { kind: 'transparent' });
-  await upgrades.upgradeProxy(action.address, ActionV2);
+  await upgrades.upgradeProxy(action, ActionV2);
 });
 
 test('upgradeProxy with incompatible layout', async t => {
   const { Action, ActionV2Bad } = t.context;
   const action = await upgrades.deployProxy(Action, [], { kind: 'transparent' });
-  const error = await t.throwsAsync(() => upgrades.upgradeProxy(action.address, ActionV2Bad));
+  const error = await t.throwsAsync(() => upgrades.upgradeProxy(action, ActionV2Bad));
   t.true(error.message.includes('Upgraded `action` to an incompatible type'));
 });

--- a/packages/plugin-hardhat/test/transparent-happy-path-with-library.js
+++ b/packages/plugin-hardhat/test/transparent-happy-path-with-library.js
@@ -10,6 +10,6 @@ test.before(async t => {
 test('happy path with library', async t => {
   const { Adder, AdderV2 } = t.context;
   const adder = await upgrades.deployProxy(Adder, { kind: 'transparent' });
-  const adder2 = await upgrades.upgradeProxy(adder.address, AdderV2);
+  const adder2 = await upgrades.upgradeProxy(adder, AdderV2);
   await adder2.add(1);
 });

--- a/packages/plugin-hardhat/test/transparent-happy-path-with-structs.js
+++ b/packages/plugin-hardhat/test/transparent-happy-path-with-structs.js
@@ -19,13 +19,13 @@ test('deployProxy', async t => {
 test('upgradeProxy', async t => {
   const { Portfolio, PortfolioV2 } = t.context;
   const portfolio = await upgrades.deployProxy(Portfolio, [], { kind: 'transparent' });
-  const portfolio2 = await upgrades.upgradeProxy(portfolio.address, PortfolioV2);
+  const portfolio2 = await upgrades.upgradeProxy(portfolio, PortfolioV2);
   await portfolio2.enable('ETH');
 });
 
 test('upgradeProxy with incompatible layout', async t => {
   const { Portfolio, PortfolioV2Bad } = t.context;
   const portfolio = await upgrades.deployProxy(Portfolio, [], { kind: 'transparent' });
-  const error = await t.throwsAsync(() => upgrades.upgradeProxy(portfolio.address, PortfolioV2Bad));
+  const error = await t.throwsAsync(() => upgrades.upgradeProxy(portfolio, PortfolioV2Bad));
   t.true(error.message.includes('Upgraded `assets` to an incompatible type'));
 });

--- a/packages/plugin-hardhat/test/transparent-happy-path.js
+++ b/packages/plugin-hardhat/test/transparent-happy-path.js
@@ -13,7 +13,7 @@ test('happy path', async t => {
 
   const greeter = await upgrades.deployProxy(Greeter, ['Hello, Hardhat!'], { kind: 'transparent' });
 
-  const greeter2 = await upgrades.upgradeProxy(greeter.address, GreeterV2);
+  const greeter2 = await upgrades.upgradeProxy(greeter, GreeterV2);
   await greeter2.resetGreeting();
 
   const greeter3ImplAddr = await upgrades.prepareUpgrade(greeter.address, GreeterV3);

--- a/packages/plugin-hardhat/test/transparent-linked-libraries.js
+++ b/packages/plugin-hardhat/test/transparent-linked-libraries.js
@@ -50,7 +50,7 @@ test('with flag', async t => {
 
   // Attempting to upgrade to TokenV2 using same library
   const TokenV2 = await getLinkedContractFactory('TokenV2', { SafeMath: safeMathLib.address });
-  const token2 = await upgrades.upgradeProxy(token.address, TokenV2, {
+  const token2 = await upgrades.upgradeProxy(token, TokenV2, {
     unsafeAllow: ['external-library-linking'],
   });
 
@@ -60,7 +60,7 @@ test('with flag', async t => {
 
   // Attempting to upgrade to same TokenV2 using different library
   const TokenV2New = await getLinkedContractFactory('TokenV2', { SafeMath: safeMathLib2.address });
-  const token2New = await upgrades.upgradeProxy(token.address, TokenV2New, {
+  const token2New = await upgrades.upgradeProxy(token, TokenV2New, {
     unsafeAllow: ['external-library-linking'],
   });
 
@@ -73,7 +73,7 @@ test('with flag', async t => {
     SafeMath: safeMathLib.address,
     SafePercent: safePctLib.address,
   });
-  const token3 = await upgrades.upgradeProxy(token.address, TokenV3, {
+  const token3 = await upgrades.upgradeProxy(token, TokenV3, {
     unsafeAllow: ['external-library-linking'],
   });
 

--- a/packages/plugin-hardhat/test/transparent-upgrade-storage.js
+++ b/packages/plugin-hardhat/test/transparent-upgrade-storage.js
@@ -11,7 +11,7 @@ test('incompatible storage', async t => {
   const { Greeter, GreeterStorageConflict } = t.context;
   const greeter = await upgrades.deployProxy(Greeter, ['Hola mundo!'], { kind: 'transparent' });
   await t.throwsAsync(
-    () => upgrades.upgradeProxy(greeter.address, GreeterStorageConflict),
+    () => upgrades.upgradeProxy(greeter, GreeterStorageConflict),
     undefined,
     'New storage layout is incompatible due to the following changes',
   );

--- a/packages/plugin-hardhat/test/transparent-upgrade-validation.js
+++ b/packages/plugin-hardhat/test/transparent-upgrade-validation.js
@@ -12,7 +12,7 @@ test('invalid upgrade', async t => {
 
   const greeter = await upgrades.deployProxy(Greeter, ['Hola mundo!'], { kind: 'transparent' });
   await t.throwsAsync(
-    () => upgrades.upgradeProxy(greeter.address, Invalid),
+    () => upgrades.upgradeProxy(greeter, Invalid),
     undefined,
     'Contract `Invalid` is not upgrade safe',
   );

--- a/packages/plugin-hardhat/test/uups-happy-path-with-enums.js
+++ b/packages/plugin-hardhat/test/uups-happy-path-with-enums.js
@@ -18,12 +18,12 @@ test('deployProxy', async t => {
 test('upgradeProxy', async t => {
   const { Action, ActionV2 } = t.context;
   const action = await upgrades.deployProxy(Action, [], { kind: 'uups' });
-  await upgrades.upgradeProxy(action.address, ActionV2);
+  await upgrades.upgradeProxy(action, ActionV2);
 });
 
 test('upgradeProxy with incompatible layout', async t => {
   const { Action, ActionV2Bad } = t.context;
   const action = await upgrades.deployProxy(Action, [], { kind: 'uups' });
-  const error = await t.throwsAsync(() => upgrades.upgradeProxy(action.address, ActionV2Bad));
+  const error = await t.throwsAsync(() => upgrades.upgradeProxy(action, ActionV2Bad));
   t.true(error.message.includes('Upgraded `action` to an incompatible type'));
 });

--- a/packages/plugin-hardhat/test/uups-happy-path-with-library.js
+++ b/packages/plugin-hardhat/test/uups-happy-path-with-library.js
@@ -10,6 +10,6 @@ test.before(async t => {
 test('happy path with library', async t => {
   const { Adder, AdderV2 } = t.context;
   const adder = await upgrades.deployProxy(Adder, { kind: 'uups' });
-  const adder2 = await upgrades.upgradeProxy(adder.address, AdderV2);
+  const adder2 = await upgrades.upgradeProxy(adder, AdderV2);
   await adder2.add(1);
 });

--- a/packages/plugin-hardhat/test/uups-happy-path-with-structs.js
+++ b/packages/plugin-hardhat/test/uups-happy-path-with-structs.js
@@ -19,13 +19,13 @@ test('deployProxy', async t => {
 test('upgradeProxy', async t => {
   const { Portfolio, PortfolioV2 } = t.context;
   const portfolio = await upgrades.deployProxy(Portfolio, [], { kind: 'uups' });
-  const portfolio2 = await upgrades.upgradeProxy(portfolio.address, PortfolioV2);
+  const portfolio2 = await upgrades.upgradeProxy(portfolio, PortfolioV2);
   await portfolio2.enable('ETH');
 });
 
 test('upgradeProxy with incompatible layout', async t => {
   const { Portfolio, PortfolioV2Bad } = t.context;
   const portfolio = await upgrades.deployProxy(Portfolio, [], { kind: 'uups' });
-  const error = await t.throwsAsync(() => upgrades.upgradeProxy(portfolio.address, PortfolioV2Bad));
+  const error = await t.throwsAsync(() => upgrades.upgradeProxy(portfolio, PortfolioV2Bad));
   t.true(error.message.includes('Upgraded `assets` to an incompatible type'));
 });

--- a/packages/plugin-hardhat/test/uups-happy-path.js
+++ b/packages/plugin-hardhat/test/uups-happy-path.js
@@ -13,7 +13,7 @@ test('happy path', async t => {
 
   const greeter = await upgrades.deployProxy(Greeter, ['Hello, Hardhat!'], { kind: 'uups' });
 
-  const greeter2 = await upgrades.upgradeProxy(greeter.address, GreeterV2);
+  const greeter2 = await upgrades.upgradeProxy(greeter, GreeterV2);
   await greeter2.resetGreeting();
 
   const greeter3ImplAddr = await upgrades.prepareUpgrade(greeter.address, GreeterV3);

--- a/packages/plugin-hardhat/test/uups-linked-libraries.js
+++ b/packages/plugin-hardhat/test/uups-linked-libraries.js
@@ -50,7 +50,7 @@ test('with flag', async t => {
 
   // Attempting to upgrade to TokenV2 using same library
   const TokenV2 = await getLinkedContractFactory('TokenV2Proxiable', { SafeMath: safeMathLib.address });
-  const token2 = await upgrades.upgradeProxy(token.address, TokenV2, {
+  const token2 = await upgrades.upgradeProxy(token, TokenV2, {
     unsafeAllow: ['external-library-linking'],
   });
 
@@ -60,7 +60,7 @@ test('with flag', async t => {
 
   // Attempting to upgrade to same TokenV2 using different library
   const TokenV2New = await getLinkedContractFactory('TokenV2Proxiable', { SafeMath: safeMathLib2.address });
-  const token2New = await upgrades.upgradeProxy(token.address, TokenV2New, {
+  const token2New = await upgrades.upgradeProxy(token, TokenV2New, {
     unsafeAllow: ['external-library-linking'],
   });
 
@@ -73,7 +73,7 @@ test('with flag', async t => {
     SafeMath: safeMathLib.address,
     SafePercent: safePctLib.address,
   });
-  const token3 = await upgrades.upgradeProxy(token.address, TokenV3, {
+  const token3 = await upgrades.upgradeProxy(token, TokenV3, {
     unsafeAllow: ['external-library-linking'],
   });
 

--- a/packages/plugin-hardhat/test/uups-upgrade-storage.js
+++ b/packages/plugin-hardhat/test/uups-upgrade-storage.js
@@ -11,7 +11,7 @@ test('incompatible storage', async t => {
   const { Greeter, GreeterStorageConflict } = t.context;
   const greeter = await upgrades.deployProxy(Greeter, ['Hola mundo!'], { kind: 'uups' });
   await t.throwsAsync(
-    () => upgrades.upgradeProxy(greeter.address, GreeterStorageConflict),
+    () => upgrades.upgradeProxy(greeter, GreeterStorageConflict),
     undefined,
     'New storage layout is incompatible due to the following changes',
   );

--- a/packages/plugin-hardhat/test/uups-upgrade-validation.js
+++ b/packages/plugin-hardhat/test/uups-upgrade-validation.js
@@ -12,7 +12,7 @@ test('invalid upgrade', async t => {
 
   const greeter = await upgrades.deployProxy(Greeter, ['Hola mundo!'], { kind: 'uups' });
   await t.throwsAsync(
-    () => upgrades.upgradeProxy(greeter.address, Invalid),
+    () => upgrades.upgradeProxy(greeter, Invalid),
     undefined,
     'Contract `Invalid` is not upgrade safe',
   );

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support passing contract instance to `upgradeProxy` and `prepareUpgrade`.
+
 ## 1.6.1 (2021-05-03)
 
 - Ignore non-JSON files in artifacts directory.

--- a/packages/plugin-truffle/src/prepare-upgrade.ts
+++ b/packages/plugin-truffle/src/prepare-upgrade.ts
@@ -1,15 +1,17 @@
 import { setProxyKind } from '@openzeppelin/upgrades-core';
 
-import { ContractClass, wrapProvider, deployImpl, Options, withDefaults } from './utils';
+import { ContractClass, wrapProvider, deployImpl, Options, withDefaults, ContractAddressOrInstance, getContractAddress } from './utils';
 
 export async function prepareUpgrade(
-  proxyAddress: string,
+  proxy: ContractAddressOrInstance,
   Contract: ContractClass,
   opts: Options = {},
 ): Promise<string> {
   const requiredOpts: Required<Options> = withDefaults(opts);
 
   const provider = wrapProvider(requiredOpts.deployer.provider);
+
+  const proxyAddress = getContractAddress(proxy);
 
   requiredOpts.kind = await setProxyKind(provider, proxyAddress, opts);
 

--- a/packages/plugin-truffle/src/prepare-upgrade.ts
+++ b/packages/plugin-truffle/src/prepare-upgrade.ts
@@ -1,6 +1,14 @@
 import { setProxyKind } from '@openzeppelin/upgrades-core';
 
-import { ContractClass, wrapProvider, deployImpl, Options, withDefaults, ContractAddressOrInstance, getContractAddress } from './utils';
+import {
+  ContractClass,
+  wrapProvider,
+  deployImpl,
+  Options,
+  withDefaults,
+  ContractAddressOrInstance,
+  getContractAddress,
+} from './utils';
 
 export async function prepareUpgrade(
   proxy: ContractAddressOrInstance,

--- a/packages/plugin-truffle/src/upgrade-proxy.ts
+++ b/packages/plugin-truffle/src/upgrade-proxy.ts
@@ -9,16 +9,20 @@ import {
   getProxyAdminFactory,
   Options,
   withDefaults,
+  getContractAddress,
+  ContractAddressOrInstance,
 } from './utils';
 
 export async function upgradeProxy(
-  proxyAddress: string,
+  proxy: ContractAddressOrInstance,
   Contract: ContractClass,
   opts: Options = {},
 ): Promise<ContractInstance> {
   const requiredOpts: Required<Options> = withDefaults(opts);
 
   const provider = wrapProvider(requiredOpts.deployer.provider);
+
+  const proxyAddress = getContractAddress(proxy);
 
   requiredOpts.kind = await setProxyKind(provider, proxyAddress, opts);
 

--- a/packages/plugin-truffle/src/utils/contract-address.ts
+++ b/packages/plugin-truffle/src/utils/contract-address.ts
@@ -1,0 +1,9 @@
+export type ContractAddressOrInstance = string | { address: string };
+
+export function getContractAddress(addressOrInstance: ContractAddressOrInstance): string {
+  if (typeof addressOrInstance === 'string') {
+    return addressOrInstance;
+  } else {
+    return addressOrInstance.address;
+  }
+}

--- a/packages/plugin-truffle/src/utils/index.ts
+++ b/packages/plugin-truffle/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './options';
 export * from './truffle';
 export * from './validations';
 export * from './wrap-provider';
+export * from './contract-address';

--- a/packages/plugin-truffle/test/migrations/2_1_deploy_greeter_transparent.js
+++ b/packages/plugin-truffle/test/migrations/2_1_deploy_greeter_transparent.js
@@ -5,5 +5,5 @@ const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 module.exports = async function (deployer) {
   const g = await deployProxy(Greeter, ['Hello Truffle'], { deployer, kind: 'transparent' });
-  await upgradeProxy(g.address, GreeterV2, { deployer });
+  await upgradeProxy(g, GreeterV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/2_2_deploy_greeter_uups.js
+++ b/packages/plugin-truffle/test/migrations/2_2_deploy_greeter_uups.js
@@ -5,5 +5,5 @@ const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 module.exports = async function (deployer) {
   const g = await deployProxy(Greeter, ['Hello Truffle'], { deployer, kind: 'uups' });
-  await upgradeProxy(g.address, GreeterV2, { deployer });
+  await upgradeProxy(g, GreeterV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/3_1_deploy_adder_transparent.js
+++ b/packages/plugin-truffle/test/migrations/3_1_deploy_adder_transparent.js
@@ -5,5 +5,5 @@ const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 module.exports = async function (deployer) {
   const a = await deployProxy(Adder, [0], { deployer, kind: 'transparent' });
-  await upgradeProxy(a.address, AdderV2, { deployer });
+  await upgradeProxy(a, AdderV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/3_2_deploy_adder_uups.js
+++ b/packages/plugin-truffle/test/migrations/3_2_deploy_adder_uups.js
@@ -5,5 +5,5 @@ const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 module.exports = async function (deployer) {
   const a = await deployProxy(Adder, [0], { deployer, kind: 'uups' });
-  await upgradeProxy(a.address, AdderV2, { deployer });
+  await upgradeProxy(a, AdderV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/4_1_deploy_action_transparent.js
+++ b/packages/plugin-truffle/test/migrations/4_1_deploy_action_transparent.js
@@ -5,5 +5,5 @@ const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 module.exports = async function (deployer) {
   const a = await deployProxy(Action, [], { deployer, kind: 'transparent' });
-  await upgradeProxy(a.address, ActionV2, { deployer });
+  await upgradeProxy(a, ActionV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/4_2_deploy_action_uups.js
+++ b/packages/plugin-truffle/test/migrations/4_2_deploy_action_uups.js
@@ -5,5 +5,5 @@ const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 module.exports = async function (deployer) {
   const a = await deployProxy(Action, [], { deployer, kind: 'uups' });
-  await upgradeProxy(a.address, ActionV2, { deployer });
+  await upgradeProxy(a, ActionV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/5_1_deploy_portfolio_transparent.js
+++ b/packages/plugin-truffle/test/migrations/5_1_deploy_portfolio_transparent.js
@@ -5,5 +5,5 @@ const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 module.exports = async function (deployer) {
   const a = await deployProxy(Portfolio, [], { deployer, kind: 'transparent' });
-  await upgradeProxy(a.address, PortfolioV2, { deployer });
+  await upgradeProxy(a, PortfolioV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/5_2_deploy_portfolio_uups.js
+++ b/packages/plugin-truffle/test/migrations/5_2_deploy_portfolio_uups.js
@@ -5,5 +5,5 @@ const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 module.exports = async function (deployer) {
   const a = await deployProxy(Portfolio, [], { deployer, kind: 'uups' });
-  await upgradeProxy(a.address, PortfolioV2, { deployer });
+  await upgradeProxy(a, PortfolioV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/6_1_deploy_token_transparent.js
+++ b/packages/plugin-truffle/test/migrations/6_1_deploy_token_transparent.js
@@ -20,9 +20,9 @@ module.exports = async function (deployer) {
   });
 
   await deployer.link(SafeMath, TokenV2);
-  await upgradeProxy(t.address, TokenV2, { deployer, unsafeAllow: ['external-library-linking'] });
+  await upgradeProxy(t, TokenV2, { deployer, unsafeAllow: ['external-library-linking'] });
 
   await deployer.link(SafeMath, TokenV3);
   await deployer.link(SafePercent, TokenV3);
-  await upgradeProxy(t.address, TokenV3, { deployer, unsafeAllow: ['external-library-linking'] });
+  await upgradeProxy(t, TokenV3, { deployer, unsafeAllow: ['external-library-linking'] });
 };

--- a/packages/plugin-truffle/test/migrations/6_2_deploy_token_uups.js
+++ b/packages/plugin-truffle/test/migrations/6_2_deploy_token_uups.js
@@ -20,9 +20,9 @@ module.exports = async function (deployer) {
   });
 
   await deployer.link(SafeMath, TokenV2);
-  await upgradeProxy(t.address, TokenV2, { deployer, unsafeAllow: ['external-library-linking'] });
+  await upgradeProxy(t, TokenV2, { deployer, unsafeAllow: ['external-library-linking'] });
 
   await deployer.link(SafeMath, TokenV3);
   await deployer.link(SafePercent, TokenV3);
-  await upgradeProxy(t.address, TokenV3, { deployer, unsafeAllow: ['external-library-linking'] });
+  await upgradeProxy(t, TokenV3, { deployer, unsafeAllow: ['external-library-linking'] });
 };

--- a/packages/plugin-truffle/test/test/transparent-happy-path-with-enums.js
+++ b/packages/plugin-truffle/test/test/transparent-happy-path-with-enums.js
@@ -8,12 +8,12 @@ const ActionV2Bad = artifacts.require('ActionV2Bad');
 contract('Action', function () {
   it('compatible enums', async function () {
     const action = await deployProxy(Action, [], { kind: 'transparent' });
-    await upgradeProxy(action.address, ActionV2);
+    await upgradeProxy(action, ActionV2);
   });
 
   it('incompatible enums', async function () {
     const action = await deployProxy(Action, [], { kind: 'transparent' });
-    await assert.rejects(upgradeProxy(action.address, ActionV2Bad), error =>
+    await assert.rejects(upgradeProxy(action, ActionV2Bad), error =>
       error.message.includes('Upgraded `action` to an incompatible type'),
     );
   });

--- a/packages/plugin-truffle/test/test/transparent-happy-path-with-library.js
+++ b/packages/plugin-truffle/test/test/transparent-happy-path-with-library.js
@@ -17,6 +17,6 @@ contract('Adder', function () {
   it('deployProxy', async function () {
     const adder = await deployProxy(Adder, [2], { kind: 'transparent' });
     assert.strictEqual(new BN(await adder.n()).toNumber(), 2);
-    await upgradeProxy(adder.address, AdderV2);
+    await upgradeProxy(adder, AdderV2);
   });
 });

--- a/packages/plugin-truffle/test/test/transparent-happy-path-with-structs.js
+++ b/packages/plugin-truffle/test/test/transparent-happy-path-with-structs.js
@@ -9,12 +9,12 @@ const PortfolioV2Bad = artifacts.require('PortfolioV2Bad');
 contract('Portfolio', function () {
   it('compatible struct', async function () {
     const portfolio = await deployProxy(Portfolio, [], { kind: 'transparent' });
-    await upgradeProxy(portfolio.address, PortfolioV2);
+    await upgradeProxy(portfolio, PortfolioV2);
   });
 
   it('incompatible struct', async function () {
     const portfolio = await deployProxy(Portfolio, [], { kind: 'transparent' });
-    await assert.rejects(upgradeProxy(portfolio.address, PortfolioV2Bad), error =>
+    await assert.rejects(upgradeProxy(portfolio, PortfolioV2Bad), error =>
       error.message.includes('Upgraded `assets` to an incompatible type'),
     );
   });

--- a/packages/plugin-truffle/test/test/transparent-happy-path.js
+++ b/packages/plugin-truffle/test/test/transparent-happy-path.js
@@ -17,7 +17,7 @@ contract('Greeter', function () {
 
     assert.ok(greeter.transactionHash, 'transaction hash is missing');
 
-    await upgradeProxy(greeter.address, GreeterV2, ['Hello Truffle']);
+    await upgradeProxy(greeter, GreeterV2, ['Hello Truffle']);
 
     const greeter3ImplAddr = await prepareUpgrade(greeter.address, GreeterV3);
     const greeter3 = await GreeterV3.at(greeter3ImplAddr);

--- a/packages/plugin-truffle/test/test/transparent-linked-libraries.js
+++ b/packages/plugin-truffle/test/test/transparent-linked-libraries.js
@@ -15,7 +15,7 @@ contract('Token without flag', function () {
       unsafeAllow: ['external-library-linking'],
       kind: 'transparent',
     });
-    await assert.rejects(upgradeProxy(token.address, Token));
+    await assert.rejects(upgradeProxy(token, Token));
   });
 });
 
@@ -28,7 +28,7 @@ contract('Token with flag', function (accounts) {
       unsafeAllow: ['external-library-linking'],
       kind: 'transparent',
     });
-    const token2 = await upgradeProxy(token.address, TokenV2, { unsafeAllow: ['external-library-linking'] });
+    const token2 = await upgradeProxy(token, TokenV2, { unsafeAllow: ['external-library-linking'] });
     assert.strictEqual('10000', (await token2.totalSupply()).toString());
     assert.strictEqual('V1', await token2.getLibraryVersion());
   });
@@ -55,7 +55,7 @@ contract('Token with flag', function (accounts) {
 
     const safeMathLib2 = await SafeMathV2.deployed();
     TokenV2.link('SafeMath', safeMathLib2.address);
-    const token2 = await upgradeProxy(token.address, TokenV2, { unsafeAllow: ['external-library-linking'] });
+    const token2 = await upgradeProxy(token, TokenV2, { unsafeAllow: ['external-library-linking'] });
 
     assert.strictEqual(token.address, token2.address);
     assert.strictEqual('10000', (await token2.totalSupply()).toString());
@@ -73,8 +73,8 @@ contract('Token with flag', function (accounts) {
       unsafeAllow: ['external-library-linking'],
       kind: 'transparent',
     });
-    const token2 = await upgradeProxy(token.address, TokenV2, { unsafeAllow: ['external-library-linking'] });
-    const token3 = await upgradeProxy(token2.address, TokenV3, { unsafeAllow: ['external-library-linking'] });
+    const token2 = await upgradeProxy(token, TokenV2, { unsafeAllow: ['external-library-linking'] });
+    const token3 = await upgradeProxy(token2, TokenV3, { unsafeAllow: ['external-library-linking'] });
 
     assert.strictEqual(token.address, token3.address);
     assert.strictEqual('10000', (await token3.totalSupply()).toString());

--- a/packages/plugin-truffle/test/test/uups-happy-path-with-enums.js
+++ b/packages/plugin-truffle/test/test/uups-happy-path-with-enums.js
@@ -8,12 +8,12 @@ const ActionV2Bad = artifacts.require('ActionV2BadProxiable');
 contract('Action', function () {
   it('compatible enums', async function () {
     const action = await deployProxy(Action, [], { kind: 'uups' });
-    await upgradeProxy(action.address, ActionV2);
+    await upgradeProxy(action, ActionV2);
   });
 
   it('incompatible enums', async function () {
     const action = await deployProxy(Action, [], { kind: 'uups' });
-    await assert.rejects(upgradeProxy(action.address, ActionV2Bad), error =>
+    await assert.rejects(upgradeProxy(action, ActionV2Bad), error =>
       error.message.includes('Upgraded `action` to an incompatible type'),
     );
   });

--- a/packages/plugin-truffle/test/test/uups-happy-path-with-library.js
+++ b/packages/plugin-truffle/test/test/uups-happy-path-with-library.js
@@ -17,6 +17,6 @@ contract('Adder', function () {
   it('deployProxy', async function () {
     const adder = await deployProxy(Adder, [2], { kind: 'uups' });
     assert.strictEqual(new BN(await adder.n()).toNumber(), 2);
-    await upgradeProxy(adder.address, AdderV2);
+    await upgradeProxy(adder, AdderV2);
   });
 });

--- a/packages/plugin-truffle/test/test/uups-happy-path-with-structs.js
+++ b/packages/plugin-truffle/test/test/uups-happy-path-with-structs.js
@@ -9,12 +9,12 @@ const PortfolioV2Bad = artifacts.require('PortfolioV2BadProxiable');
 contract('Portfolio', function () {
   it('compatible struct', async function () {
     const portfolio = await deployProxy(Portfolio, [], { kind: 'uups' });
-    await upgradeProxy(portfolio.address, PortfolioV2);
+    await upgradeProxy(portfolio, PortfolioV2);
   });
 
   it('incompatible struct', async function () {
     const portfolio = await deployProxy(Portfolio, [], { kind: 'uups' });
-    await assert.rejects(upgradeProxy(portfolio.address, PortfolioV2Bad), error =>
+    await assert.rejects(upgradeProxy(portfolio, PortfolioV2Bad), error =>
       error.message.includes('Upgraded `assets` to an incompatible type'),
     );
   });

--- a/packages/plugin-truffle/test/test/uups-happy-path.js
+++ b/packages/plugin-truffle/test/test/uups-happy-path.js
@@ -17,7 +17,7 @@ contract('Greeter', function () {
 
     assert.ok(greeter.transactionHash, 'transaction hash is missing');
 
-    await upgradeProxy(greeter.address, GreeterV2, ['Hello Truffle']);
+    await upgradeProxy(greeter, GreeterV2, ['Hello Truffle']);
 
     const greeter3ImplAddr = await prepareUpgrade(greeter.address, GreeterV3);
     const greeter3 = await GreeterV3.at(greeter3ImplAddr);

--- a/packages/plugin-truffle/test/test/uups-linked-libraries.js
+++ b/packages/plugin-truffle/test/test/uups-linked-libraries.js
@@ -12,7 +12,7 @@ contract('Token without flag', function () {
 
     // we need use the flag to deploy in order to have an address to upgrade
     const token = await deployProxy(Token, ['TKN', 10000], { unsafeAllow: ['external-library-linking'], kind: 'uups' });
-    await assert.rejects(upgradeProxy(token.address, Token));
+    await assert.rejects(upgradeProxy(token, Token));
   });
 });
 
@@ -22,7 +22,7 @@ contract('Token with flag', function (accounts) {
 
   it('Deploy and Upgrade Proxy', async function () {
     const token = await deployProxy(Token, ['TKN', 10000], { unsafeAllow: ['external-library-linking'], kind: 'uups' });
-    const token2 = await upgradeProxy(token.address, TokenV2, { unsafeAllow: ['external-library-linking'] });
+    const token2 = await upgradeProxy(token, TokenV2, { unsafeAllow: ['external-library-linking'] });
     assert.strictEqual('10000', (await token2.totalSupply()).toString());
     assert.strictEqual('V1', await token2.getLibraryVersion());
   });
@@ -46,7 +46,7 @@ contract('Token with flag', function (accounts) {
 
     const safeMathLib2 = await SafeMathV2.deployed();
     TokenV2.link('SafeMath', safeMathLib2.address);
-    const token2 = await upgradeProxy(token.address, TokenV2, { unsafeAllow: ['external-library-linking'] });
+    const token2 = await upgradeProxy(token, TokenV2, { unsafeAllow: ['external-library-linking'] });
 
     assert.strictEqual(token.address, token2.address);
     assert.strictEqual('10000', (await token2.totalSupply()).toString());
@@ -61,8 +61,8 @@ contract('Token with flag', function (accounts) {
 
   it('Upgrade Proxy with multiple Libraries', async function () {
     const token = await deployProxy(Token, ['TKN', 10000], { unsafeAllow: ['external-library-linking'], kind: 'uups' });
-    const token2 = await upgradeProxy(token.address, TokenV2, { unsafeAllow: ['external-library-linking'] });
-    const token3 = await upgradeProxy(token2.address, TokenV3, { unsafeAllow: ['external-library-linking'] });
+    const token2 = await upgradeProxy(token, TokenV2, { unsafeAllow: ['external-library-linking'] });
+    const token3 = await upgradeProxy(token2, TokenV3, { unsafeAllow: ['external-library-linking'] });
 
     assert.strictEqual(token.address, token3.address);
     assert.strictEqual('10000', (await token3.totalSupply()).toString());


### PR DESCRIPTION
`upgradeProxy(contract.address, ContractV2)`

becomes

`upgradeProxy(contract, ContractV2)`

But the previous behavior is kept for backwards compatibility.