### PR TITLE
docs: fix typo in writing-upgradeable.adoc

### DIFF
--- a/docs/modules/ROOT/pages/writing-upgradeable.adoc
+++ b/docs/modules/ROOT/pages/writing-upgradeable.adoc
@@ -73,7 +73,7 @@ Another difference between a `constructor` and a regular function is that Solidi
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
-import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract BaseContract is Initializable {
     uint256 public y;


### PR DESCRIPTION
In the latest version of "@openzeppelin/contracts-upgradeable" (v4.1.0 as of writing this), the "Initializable.sol" contract is located in a new "utils" sub-directory.