### PR TITLE
Handle slow eth_getCode providers

### DIFF
--- a/packages/core/src/deployment.test.ts
+++ b/packages/core/src/deployment.test.ts
@@ -55,7 +55,7 @@ test('validates a mined deployment with txHash', async t => {
   const provider = stubProvider();
   const deployment = await resumeOrDeploy(provider, undefined, provider.deploy);
   await waitAndValidateDeployment(provider, deployment);
-  t.is(provider.getMethodCount('eth_getTransactionByHash'), 1);
+  t.is(provider.getMethodCount('eth_getTransactionReceipt'), 1);
   t.is(provider.getMethodCount('eth_getCode'), 1);
 });
 
@@ -64,7 +64,7 @@ test('validates a mined deployment without txHash', async t => {
   const deployment = await resumeOrDeploy(provider, undefined, provider.deploy);
   delete deployment.txHash;
   await waitAndValidateDeployment(provider, deployment);
-  t.is(provider.getMethodCount('eth_getTransactionByHash'), 0);
+  t.is(provider.getMethodCount('eth_getTransactionReceipt'), 0);
   t.is(provider.getMethodCount('eth_getCode'), 1);
 });
 
@@ -76,6 +76,14 @@ test('waits for a deployment to mine', async t => {
   t.is(result, timeout);
   provider.mine();
   await waitAndValidateDeployment(provider, deployment);
+});
+
+test('fails deployment fast if tx reverts', async t => {
+  const provider = stubProvider();
+  const deployment = await resumeOrDeploy(provider, undefined, provider.deploy);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  provider.failTx(deployment.txHash!);
+  await t.throwsAsync(waitAndValidateDeployment(provider, deployment));
 });
 
 test('waits for a deployment to return contract code', async t => {

--- a/packages/core/src/deployment.test.ts
+++ b/packages/core/src/deployment.test.ts
@@ -77,3 +77,14 @@ test('waits for a deployment to mine', async t => {
   provider.mine();
   await waitAndValidateDeployment(provider, deployment);
 });
+
+test('waits for a deployment to return contract code', async t => {
+  const timeout = Symbol('timeout');
+  const provider = stubProvider();
+  const deployment = await resumeOrDeploy(provider, undefined, provider.deploy);
+  provider.removeContract(deployment.address);
+  const result = await Promise.race([waitAndValidateDeployment(provider, deployment), sleep(100).then(() => timeout)]);
+  t.is(result, timeout);
+  provider.addContract(deployment.address);
+  await waitAndValidateDeployment(provider, deployment);
+});

--- a/packages/core/src/deployment.ts
+++ b/packages/core/src/deployment.ts
@@ -85,8 +85,8 @@ export async function waitAndValidateDeployment(provider: EthereumProvider, depl
   }
 
   debug('verifying code in target address', address);
+  const startTime = Date.now();
   while (!(await hasCode(provider, address))) {
-    const startTime = Date.now();
     const elapsedTime = Date.now() - startTime;
     if (elapsedTime >= pollTimeout || txHash === undefined) {
       throw new InvalidDeployment(deployment);

--- a/packages/core/src/provider.test.ts
+++ b/packages/core/src/provider.test.ts
@@ -1,0 +1,43 @@
+import test from 'ava';
+import { EthereumProvider, getTransactionReceipt } from './provider';
+
+const hash = '0x1234';
+
+function makeProviderReturning(result: unknown): EthereumProvider {
+  return { send: (_method: string, _params: unknown[]) => Promise.resolve(result) } as EthereumProvider;
+}
+
+test('getTransactionReceipt returns null', async t => {
+  const provider = makeProviderReturning(null);
+  t.is(await getTransactionReceipt(provider, hash), null);
+});
+
+test('getTransactionReceipt status returns 0x0', async t => {
+  const provider = makeProviderReturning({ status: '0x0' });
+  const receipt = await getTransactionReceipt(provider, hash);
+  t.is(receipt?.status, '0x0');
+});
+
+test('getTransactionReceipt status returns 0x1', async t => {
+  const provider = makeProviderReturning({ status: '0x1' });
+  const receipt = await getTransactionReceipt(provider, hash);
+  t.is(receipt?.status, '0x1');
+});
+
+test('getTransactionReceipt status normalizes to 0x0', async t => {
+  const provider = makeProviderReturning({ status: '0x000000000000000000000000' });
+  const receipt = await getTransactionReceipt(provider, hash);
+  t.is(receipt?.status, '0x0');
+});
+
+test('getTransactionReceipt status normalizes to 0x1', async t => {
+  const provider = makeProviderReturning({ status: '0x000000000000000000000001' });
+  const receipt = await getTransactionReceipt(provider, hash);
+  t.is(receipt?.status, '0x1');
+});
+
+test('getTransactionReceipt status returns empty hex', async t => {
+  const provider = makeProviderReturning({ status: '0x' });
+  const receipt = await getTransactionReceipt(provider, hash);
+  t.is(receipt?.status, '0x');
+});

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -69,7 +69,9 @@ export async function getTransactionReceipt(
   provider: EthereumProvider,
   txHash: string,
 ): Promise<EthereumTransactionReceipt | null> {
-  return provider.send('eth_getTransactionReceipt', [txHash]);
+  const receipt = await provider.send('eth_getTransactionReceipt', [txHash]);
+  receipt.status = receipt.status.replace(/^0x0+/, '0x');
+  return receipt;
 }
 
 export const networkNames: { [chainId in number]?: string } = Object.freeze({

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -7,11 +7,22 @@ export interface EthereumProvider {
   send(method: 'eth_getCode', params: [string, string]): Promise<string>;
   send(method: 'eth_getStorageAt', params: [string, string, string]): Promise<string>;
   send(method: 'eth_getTransactionByHash', params: [string]): Promise<null | EthereumTransaction>;
+  send(method: 'eth_getTransactionReceipt', params: [string]): Promise<null | EthereumTransactionReceipt>;
   send(method: string, params: unknown[]): Promise<unknown>;
 }
 
 interface EthereumTransaction {
   blockHash: string | null;
+}
+
+interface EthereumTransactionReceipt {
+  status: string;
+  to: string | null;
+  from: string;
+  blockHash: string;
+  blockNumber: string;
+  transactionHash: string;
+  transactionIndex: string;
 }
 
 export async function getNetworkId(provider: EthereumProvider): Promise<string> {
@@ -54,6 +65,13 @@ export async function getTransactionByHash(
   return provider.send('eth_getTransactionByHash', [txHash]);
 }
 
+export async function getTransactionReceipt(
+  provider: EthereumProvider,
+  txHash: string,
+): Promise<EthereumTransactionReceipt | null> {
+  return provider.send('eth_getTransactionReceipt', [txHash]);
+}
+
 export const networkNames: { [chainId in number]?: string } = Object.freeze({
   1: 'mainnet',
   2: 'morden',
@@ -74,4 +92,8 @@ export async function isDevelopmentNetwork(provider: EthereumProvider): Promise<
     const [name] = clientVersion.split('/', 1);
     return name === 'HardhatNetwork' || name === 'EthereumJS TestRPC';
   }
+}
+
+export function isReceiptSuccessful(receipt: Pick<EthereumTransactionReceipt, 'status'>): boolean {
+  return receipt.status === '0x1';
 }

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -70,7 +70,9 @@ export async function getTransactionReceipt(
   txHash: string,
 ): Promise<EthereumTransactionReceipt | null> {
   const receipt = await provider.send('eth_getTransactionReceipt', [txHash]);
-  receipt.status = receipt.status.replace(/^0x0+/, '0x');
+  if (receipt?.status) {
+    receipt.status = receipt.status.match(/^0x0+$/) ? '0x0' : receipt.status.replace(/^0x0+/, '0x');
+  }
   return receipt;
 }
 

--- a/packages/core/src/stub-provider.ts
+++ b/packages/core/src/stub-provider.ts
@@ -31,7 +31,7 @@ export function stubProvider(chainId = genChainId(), clientVersion = defaultClie
     contracts.add(address);
     pendingTxs.add(txHash);
     if (immediate) {
-      await mine();
+      mine();
     }
     return {
       address,
@@ -54,6 +54,12 @@ export function stubProvider(chainId = genChainId(), clientVersion = defaultClie
     },
     isContract(address: string) {
       return contracts.has(address);
+    },
+    removeContract(address: string) {
+      return contracts.delete(address);
+    },
+    addContract(address: string) {
+      return contracts.add(address);
     },
     getMethodCount(method: string) {
       return methodCounters.get(method) ?? 0;


### PR DESCRIPTION
If eth_getCode fails to return the code immediately after the tx is mined (which can happen when there is a reorg, or if the provider hits a different node behind a load balancer that has not received that tx yet, or on moonbase), the plugin would return invalid deployment. This change adds a 1-min polling to allow the provider to catch up.