### PR TITLE
Bump @truffle/contract version

### DIFF
--- a/packages/plugin-truffle/package.json
+++ b/packages/plugin-truffle/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@openzeppelin/upgrades-core": "^1.8.0",
-    "@truffle/contract": "^4.2.12",
+    "@truffle/contract": "^4.3.26",
     "solidity-ast": "^0.4.15"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2887,6 +2887,23 @@
     utf8 "^3.0.0"
     web3-utils "1.4.0"
 
+"@truffle/codec@^0.11.6":
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/@truffle/codec/-/codec-0.11.6.tgz#63eef61b568af2c8638f6c211a9c94a976912c23"
+  integrity sha512-eav8HelhXNv28aWAbfUJG3bmP7yg7zAYjQq0O5UlteWyxFJuFUEU9r3fgPs5yfVen8HI4PWEu7ftGUV2FDsfKQ==
+  dependencies:
+    big.js "^5.2.2"
+    bn.js "^5.1.3"
+    cbor "^5.1.0"
+    debug "^4.3.1"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.partition "^4.6.0"
+    lodash.sum "^4.0.2"
+    semver "^7.3.4"
+    utf8 "^3.0.0"
+    web3-utils "1.4.0"
+
 "@truffle/config@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@truffle/config/-/config-1.3.0.tgz#718ce0196aadc2db957a4da469e355b7c75564f8"
@@ -2902,24 +2919,23 @@
     module "^1.2.5"
     original-require "^1.0.1"
 
-"@truffle/contract-schema@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.4.1.tgz#13b404383d438b48960862022a20102970323666"
-  integrity sha512-2gvu6gxJtbbI67H2Bwh2rBuej+1uCV3z4zKFzQZP00hjNoL+QfybrmBcOVB88PflBeEB+oUXuwQfDoKX3TXlnQ==
+"@truffle/contract-schema@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.4.2.tgz#d42cf0a1d4083729c57e677c168d934af9dea41b"
+  integrity sha512-ruTdZFX8omA60SNV6X+gFRONn5WAoJxSim21bGPW1kGGxJioLpffZ8qE2YKB44BI81wVS2awWQPebIv4BYvmxQ==
   dependencies:
     ajv "^6.10.0"
-    crypto-js "^3.1.9-1"
     debug "^4.3.1"
 
-"@truffle/contract@^4.2.12":
-  version "4.3.25"
-  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.3.25.tgz#048909d87f9a7c0b58222a77ad084c5d4f5c654e"
-  integrity sha512-RFtuB6CP7WpVHMYsEisWoRDtds8IoU05YhMnvkHsOQz04puoUz1YB1fxShH7P9pesDUqQZ+1+WFcUJrUrgb2JA==
+"@truffle/contract@^4.3.26":
+  version "4.3.26"
+  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.3.26.tgz#822f258b235d0a1ab43a448ff36896e4b04ac13e"
+  integrity sha512-WWFdIAIjnU+jbfpgOcJSsPA2Lo/gRE5XjZTKLuMVy+5cSdltClu6/Sa1/fKd7Yy+msecpN2olHXaVks9DDuNUQ==
   dependencies:
     "@ensdomains/ensjs" "^2.0.1"
     "@truffle/blockchain-utils" "^0.0.31"
-    "@truffle/contract-schema" "^3.4.1"
-    "@truffle/debug-utils" "^5.1.5"
+    "@truffle/contract-schema" "^3.4.2"
+    "@truffle/debug-utils" "^5.1.6"
     "@truffle/error" "^0.0.14"
     "@truffle/interface-adapter" "^0.5.2"
     bignumber.js "^7.2.1"
@@ -2955,17 +2971,16 @@
     pouchdb-find "^7.0.0"
     web3-utils "1.4.0"
 
-"@truffle/debug-utils@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@truffle/debug-utils/-/debug-utils-5.1.5.tgz#d0c252098bd2911f5914834360c19adc19e9e96c"
-  integrity sha512-BwFFuOya+ZxCT9E1H2+it2v/DVyPBkJe4i7OPSOZVnKQUg1tIJtmgdJf168bcLwKwe7I2fwRhMh29jgP5j3OhQ==
+"@truffle/debug-utils@^5.1.6":
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/@truffle/debug-utils/-/debug-utils-5.1.6.tgz#cb64791ab84272fca1a432ddddc709b2a8ecc349"
+  integrity sha512-TIhhHnnpZHqLVkUhxChyQqqR77NByyK2JOl3m55FWlLPdhu7vKd0HAqzuq+2yfoA1E7h5WHh98gXzj5goMIMOQ==
   dependencies:
-    "@truffle/codec" "^0.11.5"
+    "@truffle/codec" "^0.11.6"
     "@trufflesuite/chromafi" "^2.2.2"
     bn.js "^5.1.3"
     chalk "^2.4.2"
     debug "^4.3.1"
-    highlight.js "^10.4.0"
     highlightjs-solidity "^1.2.0"
 
 "@truffle/debugger@^9.1.6":
@@ -3559,7 +3574,6 @@
 
 "@zondax/filecoin-signing-tools@github:Digital-MOB-Filecoin/filecoin-signing-tools-js":
   version "0.2.0"
-  uid "8f8e92157cac2556d35cab866779e9a8ea8a4e25"
   resolved "https://codeload.github.com/Digital-MOB-Filecoin/filecoin-signing-tools-js/tar.gz/8f8e92157cac2556d35cab866779e9a8ea8a4e25"
   dependencies:
     axios "^0.20.0"
@@ -6134,11 +6148,6 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-crypto-js@^3.1.9-1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
-  integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
 
 crypto-js@^4.0.0:
   version "4.0.0"
@@ -8951,7 +8960,7 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
-highlight.js@^10.4.0, highlight.js@^10.4.1:
+highlight.js@^10.4.1:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==


### PR DESCRIPTION
This PR updates the @truffle/contract dependency in order to work with newer truffle versions.

See [this issue for details](https://github.com/trufflesuite/truffle/issues/4183#issuecomment-888287945)

