### PR TITLE
Support function objects in arguments

### DIFF
--- a/packages/core/contracts/test/FunctionSignatures.sol
+++ b/packages/core/contracts/test/FunctionSignatures.sol
@@ -39,6 +39,14 @@ contract ContractFunctionSignatures {
     function f11(bytes32) public {}
 
     function f12(ContractFunctionSignatures) public {}
+
+    function f13(function(address,uint256,bytes32) external) public {}
+
+    function f14(function(address,uint256,bytes32) external returns (bool)) public {}
+
+    function f15(function(Enum,S1 memory) external returns (bool)) public {}
+
+    function f16(function(Enum,S1 memory) external returns (bool),Enum,S1 memory) public {}
 }
 
 library LibraryFunctionSignatures {

--- a/packages/core/src/utils/function.ts
+++ b/packages/core/src/utils/function.ts
@@ -39,6 +39,10 @@ function serializeTypeName(parameter: VariableDeclaration, deref: ASTDereference
       }
     }
 
+    case 'FunctionTypeName': {
+      return `function`;
+    }
+
     default:
       throw new Error(`Unsuported TypeName node type: ${typeName.nodeType}`);
   }


### PR DESCRIPTION
Fix #405 

Function signature reconstruction did not support functions in the parameters, which caused errors to be thrown.