### PR TITLE
Default to kind:uups if UUPSUpgradeable in inheritance list

### DIFF
--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -18,6 +18,7 @@ import {
   getProxyAdminFactory,
   DeployTransaction,
 } from './utils';
+import { detectUUPS } from './utils/detect-uups';
 
 export interface DeployFunction {
   (ImplFactory: ContractFactory, args?: unknown[], opts?: DeployOptions): Promise<Contract>;
@@ -37,10 +38,16 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
     if (!Array.isArray(args)) {
       opts = args;
       args = [];
-    }
+    } 
 
+    // // Check if upgradeTo is present, set kind::uups
+    // if(opts.kind === undefined && detectUUPS(hre, ImplFactory)) {
+    //   opts.kind === 'uups';
+    // }
+
+    //default:kind occurs in withValidationDefaults
     const requiredOpts = withValidationDefaults(opts);
-    const { kind } = requiredOpts;
+    let { kind } = requiredOpts;
 
     const { provider } = hre.network;
     const manifest = await Manifest.forNetwork(provider);

--- a/packages/plugin-hardhat/src/utils/detect-uups.ts
+++ b/packages/plugin-hardhat/src/utils/detect-uups.ts
@@ -1,0 +1,31 @@
+import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+import type { ContractFactory } from 'ethers';
+
+import {
+    getUnlinkedBytecode,
+    getVersion,
+    getContractNameAndRunValidation
+} from '@openzeppelin/upgrades-core';
+
+import { readValidations } from './validations';
+
+export async function detectUUPS(
+    hre: HardhatRuntimeEnvironment,
+    ImplFactory: ContractFactory,
+): Promise<boolean> {
+    const validations = await readValidations(hre);
+    const unlinkedBytecode = getUnlinkedBytecode(validations, ImplFactory.bytecode);
+    const version = getVersion(unlinkedBytecode, ImplFactory.bytecode);
+
+    const [contractName, runValidation] = getContractNameAndRunValidation(validations, version);
+    const c = runValidation[contractName];
+
+    const selfAndInheritedMethods = c.methods.concat(...c.inherit.map(name => runValidation[name].methods));
+
+    //If the contracts contains the 'upgradeTo function, kind:uups is true'
+    if (selfAndInheritedMethods.includes('upgradeTo(address)')) {
+       return true
+    }
+    //If no 'upgradeTo function exists, return false
+    else return false;
+}


### PR DESCRIPTION
Related to https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/348

Objective: Create detection for the `upgradeTo` function and default to kind:UUPS if the function is present in the contract.

Hint: implementation should be present in `deploy-proxy.ts` and will make use of the AST related functions for detecting `upgradeTo`

Tasks:

- [x] Hardhat Implementation
- [ ] Hardhat Tests
- [ ] Truffle Implementation
- [ ] Truffle Tests