### PR TITLE
Compare layouts including storage reservations

### DIFF
--- a/packages/core/contracts/test/Storage.sol
+++ b/packages/core/contracts/test/Storage.sol
@@ -384,3 +384,24 @@ contract StorageUpgrade_MappingEnumKey_V2_Bad {
     mapping (E1 => uint) m3;
     mapping (uint => uint) m4;
 }
+
+contract StorageUpgrade_Gap_Base {
+    uint public b1;
+    uint[50] private __gap;
+}
+
+contract StorageUpgrade_Gap_V1 is StorageUpgrade_Gap_Base {
+    uint x1;
+    uint[50] private __gap;
+    mapping (uint => uint) m1;
+}
+
+contract StorageUpgrade_Gap_V2 {
+    uint x1;
+    address x2;
+    mapping (string => uint) m0;
+    uint[2] x3;
+    string x4;
+    uint[45] private __gap;
+    mapping (uint => uint) m1;
+}

--- a/packages/core/src/storage/compare.ts
+++ b/packages/core/src/storage/compare.ts
@@ -5,6 +5,7 @@ import { StructMember as _StructMember, isEnumMembers, isStructMembers } from '.
 import { LayoutCompatibilityReport } from './report';
 import { assert } from '../utils/assert';
 import { isValueType } from '../utils/is-value-type';
+import { compareLayouts as _compareLayoutsIncludingReservation } from './reservation';
 
 export type StorageItem = _StorageItem<ParsedTypeDetailed>;
 type StructMember = _StructMember<ParsedTypeDetailed>;
@@ -61,6 +62,7 @@ export class StorageLayoutComparator {
   constructor(readonly unsafeAllowCustomTypes = false, readonly unsafeAllowRenames = false) {}
 
   compareLayouts(original: StorageItem[], updated: StorageItem[]): LayoutCompatibilityReport {
+    _compareLayoutsIncludingReservation(original, updated);
     return new LayoutCompatibilityReport(this.layoutLevenshtein(original, updated, { allowAppend: true }));
   }
 

--- a/packages/core/src/storage/report.test.ts
+++ b/packages/core/src/storage/report.test.ts
@@ -93,3 +93,11 @@ test('replace', t => {
   const report = getReport(v1, v2);
   t.snapshot(report.explain());
 });
+
+test('gap usage', t => {
+  const v1 = t.context.extractStorageLayout('StorageUpgrade_Gap_V1');
+  const v2 = t.context.extractStorageLayout('StorageUpgrade_Gap_V2');
+  const report = getReport(v1, v2);
+  report.explain();
+  // t.snapshot(report.explain());
+});

--- a/packages/core/src/storage/reservation.ts
+++ b/packages/core/src/storage/reservation.ts
@@ -1,0 +1,87 @@
+import { assert } from '../utils/assert';
+import debug from '../utils/debug';
+import { ParsedTypeDetailed, StorageItem as _StorageItem } from './layout';
+
+enum StorageSlotState {
+  Occupied = 1,
+  Reserved, // reserved slot by `_gap` field
+}
+
+export type StorageItem = _StorageItem<ParsedTypeDetailed>;
+type StorageSlot = {
+  state: StorageSlotState;
+  ref?: string;
+};
+
+const GAP_LABEL = '_gap';
+
+export function compareLayouts(original: StorageItem[], updated: StorageItem[]): void {
+  const storageMap: Array<StorageSlot[]> = [[], []];
+  let originalIndex = 0;
+  let updatedIndex = 0;
+
+  // create original map
+  for (const item of original) {
+    const size = getSize(item);
+    const state = item.label.toLowerCase().endsWith(GAP_LABEL)
+      ? { state: StorageSlotState.Reserved }
+      : { state: StorageSlotState.Occupied, ref: getRef(item) };
+    for (let i = 0; i < size; i++) {
+      storageMap[0][originalIndex] = state;
+      originalIndex += 1;
+    }
+  }
+
+  // create updated map
+  for (const item of updated) {
+    const size = getSize(item);
+    for (let i = 0; i < size; i++) {
+      storageMap[1][updatedIndex] = { state: StorageSlotState.Occupied, ref: getRef(item) };
+      updatedIndex += 1;
+    }
+  }
+
+  // do not allow to shrink layout
+  if (originalIndex > updatedIndex) {
+    throw new Error('Storage layout shrink');
+  }
+
+  // validate storage layout update
+  for (let i = 0; i < updatedIndex; i++) {
+    const originalSlot = storageMap[0][i];
+    const updatedSlot = storageMap[1][i];
+    debug(originalSlot?.ref + ' -> ' + updatedSlot?.ref);
+
+    if (!originalSlot && updatedSlot.state === StorageSlotState.Occupied) {
+      // detect storage overgrowth (storage append)
+      throw new Error('Storage layout overgrowth');
+    }
+
+    if (
+      originalSlot.state === StorageSlotState.Occupied &&
+      updatedSlot.state === StorageSlotState.Occupied &&
+      originalSlot.ref !== updatedSlot.ref
+    ) {
+      // detect storage inconsistency
+      throw new Error('Storage layout breage');
+    }
+  }
+}
+
+// TODO: add all data types
+function getSize(item: StorageItem): number {
+  switch (item.type.head) {
+    case 't_array': {
+      const originalLength = item.type.tail?.match(/^(\d+|dyn)/)?.[0];
+      assert(originalLength !== undefined);
+
+      return originalLength === 'dyn' ? 1 : Number(originalLength);
+    }
+    default:
+      return 1;
+  }
+}
+
+function getRef(item: StorageItem): string {
+  return `${item.label}:${item.type.id}`;
+}


### PR DESCRIPTION
https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/276

Draft storage layout gaps support.

Basic comparison of storage layout including reservations(gaps)

TODO:
- [ ] Handle field sizes for all types. Any ideas how to effectively calculate field size?
- [ ] Handle `allow...` parameters
- [ ] Change way of error handling
- [ ] Merge results from both comparers
- [ ] Add tests