### PR TITLE
Support constructorArgs for implementation

### DIFF
--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -25,7 +25,8 @@ export interface DeployFunction {
 }
 
 export interface DeployOptions extends ValidationOptions {
-  initializer?: string | false;
+  initializer?:     string | false;
+  constructorArgs?: unknown[];
 }
 
 export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction {
@@ -54,7 +55,7 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
       }
     }
 
-    const impl = await deployImpl(hre, ImplFactory, requiredOpts);
+    const impl = await deployImpl(hre, ImplFactory, requiredOpts, undefined, opts.constructorArgs);
     const data = getInitializerData(ImplFactory, args, opts.initializer);
 
     let proxyDeployment: Required<ProxyDeployment & DeployTransaction>;

--- a/packages/plugin-hardhat/src/prepare-upgrade.ts
+++ b/packages/plugin-hardhat/src/prepare-upgrade.ts
@@ -1,24 +1,26 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import type { ContractFactory } from 'ethers';
 
-import { ValidationOptions, withValidationDefaults, setProxyKind } from '@openzeppelin/upgrades-core';
+import { withValidationDefaults, setProxyKind } from '@openzeppelin/upgrades-core';
 
 import { ContractAddressOrInstance, deployImpl, getContractAddress } from './utils';
+
+import { DeployOptions } from './deploy-proxy';
 
 export type PrepareUpgradeFunction = (
   proxyAddress: ContractAddressOrInstance,
   ImplFactory: ContractFactory,
-  opts?: ValidationOptions,
+  opts?: DeployOptions,
 ) => Promise<string>;
 
 export function makePrepareUpgrade(hre: HardhatRuntimeEnvironment): PrepareUpgradeFunction {
-  return async function prepareUpgrade(proxy, ImplFactory, opts: ValidationOptions = {}) {
+  return async function prepareUpgrade(proxy, ImplFactory, opts: DeployOptions = {}) {
     const { provider } = hre.network;
 
     const proxyAddress = getContractAddress(proxy);
 
     await setProxyKind(provider, proxyAddress, opts);
 
-    return await deployImpl(hre, ImplFactory, withValidationDefaults(opts), proxyAddress);
+    return await deployImpl(hre, ImplFactory, withValidationDefaults(opts), proxyAddress, opts.constructorArgs);
   };
 }

--- a/packages/plugin-hardhat/src/upgrade-proxy.ts
+++ b/packages/plugin-hardhat/src/upgrade-proxy.ts
@@ -3,7 +3,6 @@ import type { ethers, ContractFactory, Contract, Signer } from 'ethers';
 
 import {
   Manifest,
-  ValidationOptions,
   getAdminAddress,
   withValidationDefaults,
   setProxyKind,
@@ -18,14 +17,16 @@ import {
   ContractAddressOrInstance,
 } from './utils';
 
+import { DeployOptions } from './deploy-proxy';
+
 export type UpgradeFunction = (
   proxy: ContractAddressOrInstance,
   ImplFactory: ContractFactory,
-  opts?: ValidationOptions,
+  opts?: DeployOptions,
 ) => Promise<Contract>;
 
 export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment): UpgradeFunction {
-  return async function upgradeProxy(proxy, ImplFactory, opts: ValidationOptions = {}) {
+  return async function upgradeProxy(proxy, ImplFactory, opts: DeployOptions = {}) {
     const { provider } = hre.network;
 
     const proxyAddress = getContractAddress(proxy);
@@ -33,7 +34,7 @@ export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment): UpgradeFunctio
     await setProxyKind(provider, proxyAddress, opts);
 
     const upgradeTo = await getUpgrader(proxyAddress, ImplFactory.signer);
-    const nextImpl = await deployImpl(hre, ImplFactory, withValidationDefaults(opts), proxyAddress);
+    const nextImpl = await deployImpl(hre, ImplFactory, withValidationDefaults(opts), proxyAddress, opts.constructorArgs);
     const upgradeTx = await upgradeTo(nextImpl);
 
     const inst = ImplFactory.attach(proxyAddress);

--- a/packages/plugin-hardhat/src/utils/deploy-impl.ts
+++ b/packages/plugin-hardhat/src/utils/deploy-impl.ts
@@ -22,6 +22,7 @@ export async function deployImpl(
   ImplFactory: ContractFactory,
   requiredOpts: Required<ValidationOptions>,
   proxyAddress?: string,
+  constructorArgs?: unknown[]
 ): Promise<string> {
   const { provider } = hre.network;
   const validations = await readValidations(hre);
@@ -38,7 +39,7 @@ export async function deployImpl(
   }
 
   return await fetchOrDeploy(version, provider, async () => {
-    const deployment = await deploy(ImplFactory);
+    const deployment = await deploy(ImplFactory, ...(constructorArgs ?? []));
     return { ...deployment, layout };
   });
 }


### PR DESCRIPTION
Sometime its needed to pass argument to an implementation in other to set immutable state variables (which will be shared by all all proxies). 

- [x] hardhat-plugin
- [ ] truffle-plugin
- [ ] documentation