### PR TITLE
Add chalk to dependencies

### DIFF
--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -31,7 +31,8 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@openzeppelin/upgrades-core": "^1.10.0"
+    "@openzeppelin/upgrades-core": "^1.10.0",
+    "chalk": "^4.1.0"
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",

--- a/packages/plugin-truffle/package.json
+++ b/packages/plugin-truffle/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@openzeppelin/upgrades-core": "^1.10.0",
     "@truffle/contract": "^4.3.26",
+    "chalk": "^4.1.0",
     "solidity-ast": "^0.4.15"
   },
   "peerDependencies": {


### PR DESCRIPTION
These packages were implicitly pulling in chalk (via @openzeppelin/upgrades-core); this makes the dependency more explicit.