### PR TITLE
Add configurable transaction polling

### DIFF
--- a/packages/core/src/deployment.ts
+++ b/packages/core/src/deployment.ts
@@ -10,6 +10,7 @@ import {
   isDevelopmentNetwork,
   isReceiptSuccessful,
 } from './provider';
+import { PollingOptions } from '.';
 
 const sleep = promisify(setTimeout);
 
@@ -51,13 +52,8 @@ export async function resumeOrDeploy<T extends Deployment>(
   return deployment;
 }
 
-export async function waitAndValidateDeployment(provider: EthereumProvider, deployment: Deployment): Promise<void> {
+export async function waitAndValidateDeployment(provider: EthereumProvider, deployment: Deployment, { pollTimeout, pollInterval }: Required<PollingOptions>): Promise<void> {
   const { txHash, address } = deployment;
-
-  // Poll for 60 seconds with a 5 second poll interval.
-  // TODO: Make these parameters configurable.
-  const pollTimeout = 60e3;
-  const pollInterval = 5e3;
 
   if (txHash !== undefined) {
     const startTime = Date.now();

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -1,5 +1,6 @@
 export { validate, ValidationRunData, ContractValidation } from './run';
 export { ValidationOptions, withValidationDefaults } from './overrides';
+export { PollingOptions, withPollingDefaults } from './overrides';
 export { ValidationErrors } from './error';
 export { RunValidation, ValidationLog, Validation, ValidationResult } from './compat';
 export { ValidationData, ValidationDataCurrent, isCurrentValidationData, concatRunData } from './data';

--- a/packages/core/src/validate/overrides.ts
+++ b/packages/core/src/validate/overrides.ts
@@ -13,6 +13,11 @@ export interface ValidationOptions {
   kind?: ProxyDeployment['kind'];
 }
 
+export interface PollingOptions {
+  pollTimeout?: number;
+  pollInterval?: number;
+}
+
 export const ValidationErrorUnsafeMessages: Record<ValidationError['kind'], string[]> = {
   'state-variable-assignment': [
     `You are using the \`unsafeAllow.state-variable-assignment\` flag.`,
@@ -60,6 +65,13 @@ export function withValidationDefaults(opts: ValidationOptions): Required<Valida
   const unsafeAllowRenames = opts.unsafeAllowRenames ?? false;
 
   return { unsafeAllowCustomTypes, unsafeAllowLinkedLibraries, unsafeAllowRenames, unsafeAllow, kind };
+}
+
+export function withPollingDefaults(opts: PollingOptions): Required<PollingOptions> {
+  // Poll for 60 seconds with a 5 second poll interval.
+  const pollTimeout = opts.pollTimeout ?? 60e3;
+  const pollInterval = opts.pollInterval ?? 5e3;
+  return { pollTimeout, pollInterval };
 }
 
 export function processExceptions(

--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -11,6 +11,7 @@ import {
   getTransparentUpgradeableProxyFactory,
   getProxyAdminFactory,
   DeployTransaction,
+  withDefaults,
 } from './utils';
 
 export interface DeployFunction {
@@ -45,6 +46,7 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
     }
 
     let proxyDeployment: Required<ProxyDeployment & DeployTransaction>;
+    const fullOpts = withDefaults(opts);
     switch (kind) {
       case 'uups': {
         const ProxyFactory = await getProxyFactory(hre, ImplFactory.signer);
@@ -54,7 +56,7 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
 
       case 'transparent': {
         const AdminFactory = await getProxyAdminFactory(hre, ImplFactory.signer);
-        const adminAddress = await fetchOrDeployAdmin(provider, () => deploy(AdminFactory));
+        const adminAddress = await fetchOrDeployAdmin(provider, () => deploy(AdminFactory), fullOpts);
         const TransparentUpgradeableProxyFactory = await getTransparentUpgradeableProxyFactory(hre, ImplFactory.signer);
         proxyDeployment = Object.assign(
           { kind },

--- a/packages/plugin-hardhat/src/utils/deploy-impl.ts
+++ b/packages/plugin-hardhat/src/utils/deploy-impl.ts
@@ -57,10 +57,12 @@ export async function deployImpl(
     assertStorageUpgradeSafe(currentLayout, layout, fullOpts);
   }
 
-  const impl = await fetchOrDeploy(version, provider, async () => {
+  const deployFunc = async () => {
     const deployment = await deploy(ImplFactory, ...fullOpts.constructorArgs);
     return { ...deployment, layout };
-  });
+  }
+
+  const impl = await fetchOrDeploy(version, provider, deployFunc, fullOpts);
 
   return { impl, kind: opts.kind };
 }

--- a/packages/plugin-hardhat/src/utils/options.ts
+++ b/packages/plugin-hardhat/src/utils/options.ts
@@ -1,12 +1,14 @@
-import { ValidationOptions, withValidationDefaults } from '@openzeppelin/upgrades-core';
+import { ValidationOptions, PollingOptions, withValidationDefaults } from '@openzeppelin/upgrades-core';
+import { withPollingDefaults } from '@openzeppelin/upgrades-core/src/validate/overrides';
 
-export interface Options extends ValidationOptions {
+export interface Options extends ValidationOptions, PollingOptions {
   constructorArgs?: unknown[];
 }
 
 export function withDefaults(opts: Options = {}): Required<Options> {
   return {
     constructorArgs: opts.constructorArgs ?? [],
+    ...withPollingDefaults(opts),
     ...withValidationDefaults(opts),
   };
 }

--- a/packages/plugin-truffle/src/deploy-proxy.ts
+++ b/packages/plugin-truffle/src/deploy-proxy.ts
@@ -45,6 +45,7 @@ export async function deployProxy(
   }
 
   let proxyDeployment: Required<ProxyDeployment>;
+  const fullOpts = withDefaults(opts);
   switch (kind) {
     case 'uups': {
       const ProxyFactory = getProxyFactory(Contract);
@@ -54,7 +55,7 @@ export async function deployProxy(
 
     case 'transparent': {
       const AdminFactory = getProxyAdminFactory(Contract);
-      const adminAddress = await fetchOrDeployAdmin(provider, () => deploy(deployer, AdminFactory));
+      const adminAddress = await fetchOrDeployAdmin(provider, () => deploy(deployer, AdminFactory), fullOpts);
       const TransparentUpgradeableProxyFactory = getTransparentUpgradeableProxyFactory(Contract);
       proxyDeployment = Object.assign(
         { kind },

--- a/packages/plugin-truffle/src/utils/deploy-impl.ts
+++ b/packages/plugin-truffle/src/utils/deploy-impl.ts
@@ -50,10 +50,12 @@ export async function deployImpl(Contract: ContractClass, opts: Options, proxyAd
     assertStorageUpgradeSafe(currentLayout, layout, fullOpts);
   }
 
-  const impl = await fetchOrDeploy(version, provider, async () => {
+  const deployFunc = async () => {
     const deployment = await deploy(fullOpts.deployer, Contract, ...fullOpts.constructorArgs);
     return { ...deployment, layout };
-  });
+  }
+
+  const impl = await fetchOrDeploy(version, provider, deployFunc, fullOpts);
 
   return { impl, kind: fullOpts.kind };
 }

--- a/packages/plugin-truffle/src/utils/options.ts
+++ b/packages/plugin-truffle/src/utils/options.ts
@@ -1,7 +1,7 @@
 import { Deployer, ContractClass, ContractInstance, getTruffleConfig } from './truffle';
-import { ValidationOptions, withValidationDefaults } from '@openzeppelin/upgrades-core';
+import { PollingOptions, ValidationOptions, withPollingDefaults, withValidationDefaults } from '@openzeppelin/upgrades-core';
 
-export interface Options extends ValidationOptions {
+export interface Options extends ValidationOptions, PollingOptions {
   deployer?: Deployer;
   constructorArgs?: unknown[];
 }
@@ -10,6 +10,7 @@ export function withDefaults(opts: Options = {}): Required<Options> {
   return {
     deployer: opts.deployer ?? defaultDeployer,
     constructorArgs: opts.constructorArgs ?? [],
+    ...withPollingDefaults(opts),
     ...withValidationDefaults(opts),
   };
 }


### PR DESCRIPTION
Addresses the `// TODO: Make these parameters configurable.` todo to make the polling timeout and interval configurable when deploying proxy and implementation