### PR TITLE
Override contract deployment address

### DIFF
--- a/packages/plugin-hardhat/src/utils/debug.ts
+++ b/packages/plugin-hardhat/src/utils/debug.ts
@@ -1,0 +1,3 @@
+import debug from 'debug';
+
+export default debug('@openzeppelin:upgrades:hardhat');

--- a/packages/plugin-hardhat/src/utils/deploy.ts
+++ b/packages/plugin-hardhat/src/utils/deploy.ts
@@ -1,5 +1,7 @@
 import type { Deployment } from '@openzeppelin/upgrades-core';
+import debug from './debug';
 import type { ethers, ContractFactory } from 'ethers';
+import { getContractAddress } from 'ethers/lib/utils';
 
 export interface DeployTransaction {
   deployTransaction: ethers.providers.TransactionResponse;
@@ -9,7 +11,24 @@ export async function deploy(
   factory: ContractFactory,
   ...args: unknown[]
 ): Promise<Required<Deployment & DeployTransaction>> {
-  const { address, deployTransaction } = await factory.deploy(...args);
+  const contractInstance = await factory.deploy(...args);
+  const deployTransaction = contractInstance.deployTransaction;
+
+  const address: string = getContractAddress({
+    from: await factory.signer.getAddress(),
+    nonce: deployTransaction.nonce,
+  });
+  if (address !== contractInstance.address) {
+    debug(
+      'overriding contract address from ' +
+        contractInstance.address +
+        ' to ' +
+        address +
+        ' for nonce ' +
+        deployTransaction.nonce,
+    );
+  }
+
   const txHash = deployTransaction.hash;
   return { address, txHash, deployTransaction };
 }

--- a/packages/plugin-hardhat/src/utils/deploy.ts
+++ b/packages/plugin-hardhat/src/utils/deploy.ts
@@ -12,7 +12,7 @@ export async function deploy(
   ...args: unknown[]
 ): Promise<Required<Deployment & DeployTransaction>> {
   const contractInstance = await factory.deploy(...args);
-  const deployTransaction = contractInstance.deployTransaction;
+  const { deployTransaction } = contractInstance;
 
   const address: string = getContractAddress({
     from: await factory.signer.getAddress(),
@@ -20,12 +20,7 @@ export async function deploy(
   });
   if (address !== contractInstance.address) {
     debug(
-      'overriding contract address from ' +
-        contractInstance.address +
-        ' to ' +
-        address +
-        ' for nonce ' +
-        deployTransaction.nonce,
+      `overriding contract address from ${contractInstance.address} to ${address} for nonce ${deployTransaction.nonce}`,
     );
   }
 


### PR DESCRIPTION
When using certain RPC endpoints with Polygon Mumbai, an incorrect contract address can be returned.  This causes the Hardhat plugin to write the wrong addresses to the manifest.

This occurs in:
https://forum.openzeppelin.com/t/error-no-contract-at-address-0x-removed-from-manifest/20609
https://forum.openzeppelin.com/t/invaliddeployment-error-no-contract-at-address-0x-removed-from-manifest/21383

As a workaround, calculate the correct address using the signer's address and the transaction nonce.