### PR TITLE
Update readmes to be consistent with adoc changes for beacon proxies

### DIFF
--- a/docs/modules/ROOT/pages/hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/hardhat-upgrades.adoc
@@ -104,7 +104,7 @@ async function main() {
   await upgrades.upgradeBeacon(BEACON_ADDRESS, BoxV2);
   console.log("Beacon upgraded");
 
-  const box = BoxV2.attach(box.address);
+  const box = BoxV2.attach(BOX_ADDRESS);
 }
 
 main();

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -118,7 +118,7 @@ For example, `deployProxy` does the following:
 
 1. Validate that the implementation is xref:faq.adoc#what-does-it-mean-for-a-contract-to-be-upgrade-safe[upgrade safe].
 
-2. Deploy a xref:faq.adoc#what-is-a-proxy-admin[proxy admin] for your project (if using a transparent proxy).
+2. Deploy a xref:faq.adoc#what-is-a-proxy-admin[proxy admin] for your project (if needed).
 
 3. Deploy the xref:faq.adoc#what-is-an-implementation-contract[implementation contract].
 
@@ -141,7 +141,7 @@ The plugins will keep track of all the implementation contracts you have deploye
 
 The plugins support the UUPS, transparent, and beacon proxy patterns. UUPS and transparent proxies are upgraded individually, whereas any number of beacon proxies can be upgraded atomically at the same time by upgrading the beacon that they point to. For more details on the different proxy patterns available, see the documentation for https://docs.openzeppelin.com/contracts/4.x/api/proxy[Proxies].
 
-For UUPS and transparent proxies, use `deployProxy` and `upgradeProxy` as shown above. For beacon proxies, use `deployBeacon`, `deployBeaconProxy`, and `upgradeBeacon`. See the documentation for xref:truffle-upgrades.adoc[Truffle Upgrades] and xref:hardhat-upgrades.adoc[Hardhat Upgrades] for examples.
+For UUPS and transparent proxies, use `deployProxy` and `upgradeProxy` as shown above. For beacon proxies, use `deployBeacon`, `deployBeaconProxy`, and `upgradeBeacon`. See the documentation for xref:hardhat-upgrades.adoc[Hardhat Upgrades] and xref:truffle-upgrades.adoc[Truffle Upgrades] for examples.
 
 [[managing-ownership]]
 == Managing ownership

--- a/packages/plugin-truffle/README.md
+++ b/packages/plugin-truffle/README.md
@@ -17,6 +17,8 @@ This package requires Truffle [version 5.1.35](https://github.com/trufflesuite/t
 
 ## Usage in migrations
 
+### Proxies
+
 To deploy an upgradeable instance of one of your contracts in your migrations, use the `deployProxy` function:
 
 ```js
@@ -51,9 +53,50 @@ module.exports = async function (deployer) {
 
 The plugin will take care of comparing `BoxV2` to the previous one to ensure they are compatible for the upgrade, deploy the new `BoxV2` implementation contract (unless there is one already from a previous deployment), and upgrade the existing proxy to the new implementation.
 
+### Beacon proxies
+
+You can also use this plugin to deploy an upgradable beacon for your contract with the `deployBeacon` function, then deploy one or more beacon proxies that point to it by using the `deployBeaconProxy` function.
+
+```js
+// migrations/NN_deploy_upgradeable_box.js
+const { deployBeacon, deployBeaconProxy } = require('@openzeppelin/truffle-upgrades');
+
+const Box = artifacts.require('Box');
+
+module.exports = async function (deployer) {
+  const beacon = await deployBeacon(Box);
+  console.log('Beacon deployed', beacon.address);
+
+  const instance = await deployBeaconProxy(beacon, Box, [42], { deployer });
+  console.log('Box deployed', instance.address);
+};
+```
+
+In a future migration, you can use the `erc1967.getBeaconAddress` function to get the beacon address from a deployed beacon proxy instance, then call the `upgradeBeacon` function to upgrade that beacon to a new version. When the beacon is upgraded, all of the beacon proxies that point to it will use the new contract implementation.
+
+```js
+// migrations/MM_upgrade_box_contract.js
+const { erc1967, upgradeBeacon } = require('@openzeppelin/truffle-upgrades');
+
+const Box = artifacts.require('Box');
+const BoxV2 = artifacts.require('BoxV2');
+
+module.exports = async function (deployer) {
+  const existing = await Box.deployed();
+
+  const beaconAddress = await erc1967.getBeaconAddress(existing.address);
+  await upgradeBeacon(beaconAddress, BoxV2, { deployer });
+  console.log("Beacon upgraded", beaconAddress);
+
+  const instance = await BoxV2.at(existing.address);
+};
+```
+
 ## Usage in tests
 
-You can also use the `deployProxy` and `upgradeProxy` functions from your Truffle tests, in case you want to add tests for upgrading your contracts (which you should!). The API is the same as in the migrations, only that without a `deployer` parameter.
+You can also use the plugin's functions from your Truffle tests, in case you want to add tests for upgrading your contracts (which you should!). The API is the same as in the migrations, only that without a `deployer` parameter.
+
+### Proxies
 
 ```js
 const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
@@ -65,6 +108,28 @@ describe('upgrades', () => {
   it('works', async () => {
     const box = await deployProxy(Box, [42]);
     const box2 = await upgradeProxy(box.address, BoxV2);
+
+    const value = await box2.value();
+    assert.equal(value.toString(), '42');
+  });
+});
+```
+
+### Beacon proxies
+
+```js
+const { deployBeacon, deployBeaconProxy, upgradeBeacon } = require('@openzeppelin/truffle-upgrades');
+
+const Box = artifacts.require('Box');
+const BoxV2 = artifacts.require('BoxV2');
+
+describe('upgrades', () => {
+  it('works', async () => {
+    const beacon = await deployBeacon(Box);
+    const box = await deployBeaconProxy(beacon, Box, [42]);
+
+    await upgradeBeacon(beacon, BoxV2);
+    const box2 = await BoxV2.at(box.address);
 
     const value = await box2.value();
     assert.equal(value.toString(), '42');


### PR DESCRIPTION
Identical to https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/497 but for the readmes to match the adocs from the other PR.  
Also fixed a few details in the adocs.