### PR TITLE
Fix normalization of admin in manifest

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Remove `admin.deployTransaction` field written to network manifest. ([#510](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/510))
+
 ## 1.12.0 (2022-01-31)
 
 - Add options `timeout` and `pollingInterval`. ([#55](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/55))

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,6 @@ export {
 
 export { getStorageLayoutForAddress } from './manifest-storage-layout';
 
-
 export * from './scripts/migrate-oz-cli-project';
 
 export { logWarning } from './utils/log';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,6 @@
 export * from './validate';
 export * from './impl-store';
 export * from './version';
-export * from './manifest';
 export * from './storage';
 export * from './eip-1967';
 export * from './provider';
@@ -11,7 +10,17 @@ export * from './deployment';
 export * from './link-refs';
 export * from './error';
 
+export {
+  ManifestData,
+  ImplDeployment,
+  ProxyDeployment,
+  Manifest,
+  migrateManifest,
+  DeploymentNotFound,
+} from './manifest';
+
 export { getStorageLayoutForAddress } from './manifest-storage-layout';
+
 
 export * from './scripts/migrate-oz-cli-project';
 

--- a/packages/core/src/manifest.test.ts
+++ b/packages/core/src/manifest.test.ts
@@ -24,7 +24,7 @@ test('normalize manifest', t => {
     manifestVersion: '3.0',
     admin: deployment,
     impls: { a: deployment },
-    proxies: [ deployment ],
+    proxies: [deployment],
   };
   const norm = normalizeManifestData(input);
   t.like(norm.admin, {

--- a/packages/core/src/manifest.test.ts
+++ b/packages/core/src/manifest.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { Manifest } from './manifest';
+import { Manifest, ManifestData, normalizeManifestData } from './manifest';
 
 test('manifest name for a known network', t => {
   const manifest = new Manifest(1);
@@ -10,4 +10,37 @@ test('manifest name for an unknown network', t => {
   const id = 55555;
   const manifest = new Manifest(id);
   t.is(manifest.file, `.openzeppelin/unknown-${id}.json`);
+});
+
+test('normalize manifest', t => {
+  const deployment = {
+    address: '0x1234',
+    txHash: '0x1234',
+    kind: 'uups' as const,
+    layout: { types: {}, storage: [] },
+    deployTransaction: {},
+  };
+  const input: ManifestData = {
+    manifestVersion: '3.0',
+    admin: deployment,
+    impls: { a: deployment },
+    proxies: [ deployment ],
+  };
+  const norm = normalizeManifestData(input);
+  t.like(norm.admin, {
+    ...deployment,
+    kind: undefined,
+    layout: undefined,
+    deployTransaction: undefined,
+  });
+  t.like(norm.impls.a, {
+    ...deployment,
+    kind: undefined,
+    deployTransaction: undefined,
+  });
+  t.like(norm.proxies[0], {
+    ...deployment,
+    layout: undefined,
+    deployTransaction: undefined,
+  });
 });

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -160,7 +160,7 @@ export function migrateManifest(data: ManifestData): ManifestData {
 
 export class DeploymentNotFound extends Error {}
 
-function normalizeManifestData(input: ManifestData): ManifestData {
+export function normalizeManifestData(input: ManifestData): ManifestData {
   return {
     manifestVersion: input.manifestVersion,
     admin: input.admin && normalizeDeployment(input.admin),

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -162,7 +162,8 @@ export class DeploymentNotFound extends Error {}
 
 function normalizeManifestData(input: ManifestData): ManifestData {
   return {
-    ...pick(input, ['manifestVersion', 'admin']),
+    manifestVersion: input.manifestVersion,
+    admin: input.admin && normalizeDeployment(input.admin),
     proxies: input.proxies.map(p => normalizeDeployment(p, ['kind'])),
     impls: mapValues(input.impls, i => i && normalizeDeployment(i, ['layout'])),
   };


### PR DESCRIPTION
I realized looking at a manifest that we're storing `admin.deployTransaction` with a bunch of data that we shouldn't have there. The admin deployment object wasn't being normalized to remove extra fields.