### PR TITLE
Dont check storage compatibility is current implementation is address(0)

### DIFF
--- a/packages/plugin-hardhat/src/utils/deploy-impl.ts
+++ b/packages/plugin-hardhat/src/utils/deploy-impl.ts
@@ -102,7 +102,7 @@ async function deployImpl(
   assertUpgradeSafe(deployData.validations, deployData.version, deployData.fullOpts);
   const layout = deployData.layout;
 
-  if (currentImplAddress !== undefined) {
+  if (currentImplAddress !== undefined && currentImplAddress !== '0x0000000000000000000000000000000000000000') {
     const manifest = await Manifest.forNetwork(deployData.provider);
     const currentLayout = await getStorageLayoutForAddress(manifest, deployData.validations, currentImplAddress);
     assertStorageUpgradeSafe(currentLayout, deployData.layout, deployData.fullOpts);

--- a/packages/plugin-truffle/src/utils/deploy-impl.ts
+++ b/packages/plugin-truffle/src/utils/deploy-impl.ts
@@ -104,7 +104,7 @@ async function deployImpl(
   assertUpgradeSafe([deployData.validations], deployData.version, deployData.fullOpts);
   const layout = deployData.layout;
 
-  if (currentImplAddress !== undefined) {
+  if (currentImplAddress !== undefined && currentImplAddress !== '0x0000000000000000000000000000000000000000') {
     const manifest = await Manifest.forNetwork(deployData.provider);
     const currentLayout = await getStorageLayoutForAddress(manifest, deployData.validations, currentImplAddress);
     assertStorageUpgradeSafe(currentLayout, deployData.layout, deployData.fullOpts);


### PR DESCRIPTION
Might be useful to deploy the first implementation for beacons that are so far unset.