### PR TITLE
Use lockfile when reading validations.json

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.15.1
+
+- Use a lockfile when reading validations cache to avoid problems with parallel compilation in Hardhat 2.9.0. ([#530](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/530))
+
 ## 1.15.0 (2022-03-01)
 
 - Add `forceImport` function to import an existing proxy or beacon. ([#517](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/517))

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "@openzeppelin/upgrades-core": "^1.13.0",
-    "chalk": "^4.1.0"
+    "chalk": "^4.1.0",
+    "proper-lockfile": "^4.1.1"
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",

--- a/packages/plugin-hardhat/src/utils/validations.ts
+++ b/packages/plugin-hardhat/src/utils/validations.ts
@@ -10,7 +10,8 @@ import {
   isCurrentValidationData,
 } from '@openzeppelin/upgrades-core';
 
-function lock(file: string) {
+async function lock(file: string) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
   return lockfile.lock(file, { retries: 3, realpath: false });
 }
 
@@ -23,7 +24,6 @@ export async function writeValidations(hre: HardhatRuntimeEnvironment, newRunDat
 
     const validations = concatRunData(newRunData, storedData);
 
-    await fs.mkdir(hre.config.paths.cache, { recursive: true });
     await fs.writeFile(cachePath, JSON.stringify(validations, null, 2));
   } catch (e) {
     // If there is no previous data to append to, we ignore the error and write

--- a/packages/plugin-hardhat/src/utils/validations.ts
+++ b/packages/plugin-hardhat/src/utils/validations.ts
@@ -36,7 +36,10 @@ export async function writeValidations(hre: HardhatRuntimeEnvironment, newRunDat
   }
 }
 
-export async function readValidations(hre: HardhatRuntimeEnvironment, acquireLock = true): Promise<ValidationDataCurrent> {
+export async function readValidations(
+  hre: HardhatRuntimeEnvironment,
+  acquireLock = true,
+): Promise<ValidationDataCurrent> {
   const cachePath = getValidationsCachePath(hre);
   let releaseLock;
   try {


### PR DESCRIPTION
Fixes #528 

Lockfile use was copied from Manifest.lock.