### PR TITLE
Support TypeChain in deployProxy function

### DIFF
--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -20,17 +20,19 @@ import {
   getInitializerData,
 } from './utils';
 
+type InstanceOf<F extends ContractFactory> = ReturnType<F['attach']>;
+
 export interface DeployFunction {
-  (ImplFactory: ContractFactory, args?: unknown[], opts?: DeployProxyOptions): Promise<Contract>;
-  (ImplFactory: ContractFactory, opts?: DeployProxyOptions): Promise<Contract>;
+  <F extends ContractFactory>(ImplFactory: F, args?: unknown[], opts?: DeployProxyOptions): Promise<InstanceOf<F>>;
+  <F extends ContractFactory>(ImplFactory: F, opts?: DeployProxyOptions): Promise<InstanceOf<F>>;
 }
 
 export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction {
-  return async function deployProxy(
-    ImplFactory: ContractFactory,
+  return async function deployProxy<F extends ContractFactory>(
+    ImplFactory: F,
     args: unknown[] | DeployProxyOptions = [],
     opts: DeployProxyOptions = {},
-  ) {
+  ): Promise<InstanceOf<F>> {
     if (!Array.isArray(args)) {
       opts = args;
       args = [];
@@ -78,7 +80,7 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
 
     await manifest.addProxy(proxyDeployment);
 
-    const inst = ImplFactory.attach(proxyDeployment.address);
+    const inst = ImplFactory.attach(proxyDeployment.address) as InstanceOf<F>;
     // @ts-ignore Won't be readonly because inst was created through attach.
     inst.deployTransaction = proxyDeployment.deployTransaction;
     return inst;

--- a/packages/plugin-hardhat/src/deploy-proxy.ts
+++ b/packages/plugin-hardhat/src/deploy-proxy.ts
@@ -1,5 +1,5 @@
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
-import type { ContractFactory, Contract } from 'ethers';
+import type { ContractFactory } from 'ethers';
 
 import {
   Manifest,
@@ -20,11 +20,13 @@ import {
   getInitializerData,
 } from './utils';
 
-type InstanceOf<F extends ContractFactory> = ReturnType<F['attach']>;
+type ContractTypeOfFactory<F extends ContractFactory> = ReturnType<F['attach']>;
 
 export interface DeployFunction {
-  <F extends ContractFactory>(ImplFactory: F, args?: unknown[], opts?: DeployProxyOptions): Promise<InstanceOf<F>>;
-  <F extends ContractFactory>(ImplFactory: F, opts?: DeployProxyOptions): Promise<InstanceOf<F>>;
+  <F extends ContractFactory>(ImplFactory: F, args?: unknown[], opts?: DeployProxyOptions): Promise<
+    ContractTypeOfFactory<F>
+  >;
+  <F extends ContractFactory>(ImplFactory: F, opts?: DeployProxyOptions): Promise<ContractTypeOfFactory<F>>;
 }
 
 export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction {
@@ -32,7 +34,7 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
     ImplFactory: F,
     args: unknown[] | DeployProxyOptions = [],
     opts: DeployProxyOptions = {},
-  ): Promise<InstanceOf<F>> {
+  ): Promise<ContractTypeOfFactory<F>> {
     if (!Array.isArray(args)) {
       opts = args;
       args = [];
@@ -80,7 +82,7 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
 
     await manifest.addProxy(proxyDeployment);
 
-    const inst = ImplFactory.attach(proxyDeployment.address) as InstanceOf<F>;
+    const inst = ImplFactory.attach(proxyDeployment.address) as ContractTypeOfFactory<F>;
     // @ts-ignore Won't be readonly because inst was created through attach.
     inst.deployTransaction = proxyDeployment.deployTransaction;
     return inst;


### PR DESCRIPTION
As discussed in https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/325, this change allows `deployProxy` to returned a typed `Contract` instance, so the user can use things like Typechain without loosing contract's types definition.

Usage example in a hardhat script 👇🏽
```
import { ethers, upgrades } from "hardhat";
import { Greeter__factory } from "../typechain";

async function main() {
  const signer = (await ethers.getSigners())[0];
  const factory = new Greeter__factory(signer);
  const greeter = await upgrades.deployProxy<Greeter__factory>(factory, {
    constructorArgs: ["Fran"],
  });

  await greeter.deployed();

  // this is now type safe
  await greeter.greet();
}
```