### PR TITLE
Use default number of retries, lower backoff factor

### DIFF
--- a/packages/plugin-hardhat/src/utils/validations.ts
+++ b/packages/plugin-hardhat/src/utils/validations.ts
@@ -12,7 +12,7 @@ import {
 
 async function lock(file: string) {
   await fs.mkdir(path.dirname(file), { recursive: true });
-  return lockfile.lock(file, { retries: { factor: 1.3 }, realpath: false }); 
+  return lockfile.lock(file, { retries: { factor: 1.3 }, realpath: false });
 }
 
 export async function writeValidations(hre: HardhatRuntimeEnvironment, newRunData: ValidationRunData): Promise<void> {

--- a/packages/plugin-hardhat/src/utils/validations.ts
+++ b/packages/plugin-hardhat/src/utils/validations.ts
@@ -12,7 +12,7 @@ import {
 
 async function lock(file: string) {
   await fs.mkdir(path.dirname(file), { recursive: true });
-  return lockfile.lock(file, { retries: { factor: 1.3 }, realpath: false });
+  return lockfile.lock(file, { retries: { minTimeout: 50, factor: 1.3 }, realpath: false });
 }
 
 export async function writeValidations(hre: HardhatRuntimeEnvironment, newRunData: ValidationRunData): Promise<void> {

--- a/packages/plugin-hardhat/src/utils/validations.ts
+++ b/packages/plugin-hardhat/src/utils/validations.ts
@@ -12,7 +12,7 @@ import {
 
 async function lock(file: string) {
   await fs.mkdir(path.dirname(file), { recursive: true });
-  return lockfile.lock(file, { retries: 3, realpath: false });
+  return lockfile.lock(file, { retries: { factor: 1.3 }, realpath: false }); 
 }
 
 export async function writeValidations(hre: HardhatRuntimeEnvironment, newRunData: ValidationRunData): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/537

Change validations lock settings to have more retries and minimize unnecessary waits between retries:
- settings: retries 10, minimum timeout 50 ms, exponential backoff factor 1.3
- (previously was retries 3, minimum timeout 1000 ms, exponential backoff factor 2)