### PR TITLE
Support importing UUPS proxy with admin

### DIFF
--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -7,7 +7,7 @@ Both `deployProxy` and `upgradeProxy` functions will return instances of https:/
 
 The following options are common to all functions.
 
-* `kind`: (`"uups" | "transparent"`) Choose between a UUPS or Transparent proxy. Defaults to Transparent. See xref:contracts:api:proxy.adoc#transparent-vs-uups[Transparent vs UUPS]. Not applicable for Beacon proxies.
+* `kind`: (`"uups" | "transparent"`) Choose between a UUPS or Transparent proxy. Defaults to Transparent. See xref:contracts:api:proxy.adoc#transparent-vs-uups[Transparent vs UUPS]. Not applicable for Beacon proxies except for xref:#force-import[`forceImport`].
 * `unsafeAllow`: (`ValidationError[]`) Selectively disable one or more validation errors:
 ** `"external-library-linking"`: Allows a deployment with external libraries linked to the implementation contract. (External libraries are otherwise xref:faq.adoc#why-cant-i-use-external-libraries[not yet supported].)
 ** `"struct-definition"`, `"enum-definition"`: Used to be necessary to deploy a contract with structs or enums. No longer necessary.
@@ -133,6 +133,7 @@ async function deployBeaconProxy(
 
 Forces the import of an existing proxy or beacon deployment to be used with this plugin. Provide the address of an existing proxy or beacon and the ethers contract factory of the implementation contract that was deployed. Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons.
 
+* `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
 * See <<common-options>>.
 
 [source,ts]
@@ -140,7 +141,9 @@ Forces the import of an existing proxy or beacon deployment to be used with this
 async function forceImport(
   proxyOrBeaconAddress: string,
   deployedImpl: ethers.ContractFactory,
-  opts: {} = {},
+  opts: {
+    kind?: 'uups' | 'transparent' | 'beacon',
+  } = {},
 ): Promise<ethers.Contract>
 ----
 

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -8,7 +8,7 @@ Both `deployProxy` and `upgradeProxy` functions will return instances of https:/
 The following options are common to all functions.
 
 * `deployer`: Should be set to the Truffle migration deployer during migrations.
-* `kind`: (`"uups" | "transparent"`) Choose between a UUPS or Transparent proxy. Defaults to Transparent. See xref:contracts:api:proxy.adoc#transparent-vs-uups[Transparent vs UUPS]. Not applicable for Beacon proxies.
+* `kind`: (`"uups" | "transparent"`) Choose between a UUPS or Transparent proxy. Defaults to Transparent. See xref:contracts:api:proxy.adoc#transparent-vs-uups[Transparent vs UUPS]. Not applicable for Beacon proxies except for xref:#force-import[`forceImport`].
 * `unsafeAllow`: (`ValidationError[]`) Selectively disable one or more validation errors:
 ** `"external-library-linking"`: Allows a deployment with external libraries linked to the implementation contract. (External libraries are otherwise xref:faq.adoc#why-cant-i-use-external-libraries[not yet supported].)
 ** `"struct-definition"`, `"enum-definition"`: Used to be necessary to deploy a contract with structs or enums. No longer necessary.
@@ -136,6 +136,7 @@ async function deployBeaconProxy(
 
 Forces the import of an existing proxy or beacon deployment to be used with this plugin. Provide the address of an existing proxy or beacon and the Truffle contract class of the implementation contract that was deployed. Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons.
 
+* `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
 * See <<common-options>>.
 
 [source,ts]
@@ -143,7 +144,9 @@ Forces the import of an existing proxy or beacon deployment to be used with this
 async function forceImport(
   proxyOrBeaconAddress: string,
   deployedImpl: ContractClass,
-  opts: {} = {},
+  opts: {
+    kind?: 'uups' | 'transparent' | 'beacon',
+  } = {},
 ): Promise<ContractInstance>
 ----
 

--- a/packages/core/src/proxy-kind.ts
+++ b/packages/core/src/proxy-kind.ts
@@ -62,6 +62,10 @@ export async function processProxyKind(
 /**
  * Detects the kind of proxy at an address by reading its ERC 1967 storage slots.
  *
+ * @deprecated Not reliable since UUPS proxies can have admin storage slot set, which causes
+ * this function to treat it as transparent.  Instead, if implementation contract signatures are
+ * available, infer the proxy kind using `inferProxyKind` instead.
+ *
  * @param provider the Ethereum provider
  * @param proxyAddress the proxy address
  * @returns the proxy kind

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support specifying proxy kind for `forceImport`, fix importing UUPS proxy with admin ([#550](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/550))
+
 ## 1.16.1 (2022-03-15)
 
 - Fix lock file issue with validations cache when compiling a large number of contracts ([#537](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/537))

--- a/packages/plugin-hardhat/contracts/CustomProxy.sol
+++ b/packages/plugin-hardhat/contracts/CustomProxy.sol
@@ -177,3 +177,11 @@ contract CustomProxy {
         }
     }
 }
+
+contract CustomProxyWithAdmin is CustomProxy {
+    bytes32 internal constant _ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    constructor(address _logic, bytes memory _data) CustomProxy(_logic, _data) payable {
+        getAddressSlot(_ADMIN_SLOT).value = msg.sender;
+    }
+}

--- a/packages/plugin-hardhat/test/import.js
+++ b/packages/plugin-hardhat/test/import.js
@@ -39,10 +39,10 @@ function getInitializerData(contractInterface, args) {
 }
 
 const NOT_REGISTERED_ADMIN = 'Proxy admin is not the one registered in the network manifest';
-const NOT_SUPPORTED_FUNCTION = 'Beacon proxies are not supported with the current function';
 const NOT_SUPPORTED_PROXY_OR_BEACON = /Contract at address \S+ doesn't look like a supported proxy or beacon/;
 const ONLY_PROXY_OR_BEACON =
   'Only transparent, UUPS, or beacon proxies or beacons can be used with the forceImport() function.';
+const REQUESTED_UPGRADE_WRONG_KIND = 'Requested an upgrade of kind uups but proxy is transparent';
 
 test('transparent happy path', async t => {
   const { Greeter, GreeterV2, ProxyAdmin, TransparentUpgradableProxy } = t.context;
@@ -155,22 +155,24 @@ test('import proxy using contract instance', async t => {
   t.is(await greeter2.greet(), 'Hello World');
 });
 
-test('ignore kind', async t => {
-  const { Greeter, GreeterV2, UpgradableBeacon, BeaconProxy } = t.context;
+test('wrong kind', async t => {
+  const { GreeterProxiable, GreeterV2Proxiable, ERC1967Proxy } = t.context;
 
-  const impl = await Greeter.deploy();
+  const impl = await GreeterProxiable.deploy();
   await impl.deployed();
-  const beacon = await UpgradableBeacon.deploy(impl.address);
-  await beacon.deployed();
-  const proxy = await BeaconProxy.deploy(beacon.address, getInitializerData(Greeter.interface, ['Hello, Hardhat!']));
+  const proxy = await ERC1967Proxy.deploy(
+    impl.address,
+    getInitializerData(GreeterProxiable.interface, ['Hello, Hardhat!']),
+  );
   await proxy.deployed();
 
-  // specify uups, but import should detect that it is a beacon proxy
-  const greeter = await upgrades.forceImport(proxy.address, Greeter, { kind: 'uups' });
+  // specify wrong kind
+  const greeter = await upgrades.forceImport(proxy.address, GreeterProxiable, { kind: 'transparent' });
+  t.is(await greeter.greet(), 'Hello, Hardhat!');
 
-  // check that it is indeed imported as beacon proxy by trying to upgrade it directly
-  const e = await t.throwsAsync(() => upgrades.upgradeProxy(greeter, GreeterV2));
-  t.true(e.message.startsWith(NOT_SUPPORTED_FUNCTION), e.message);
+  // an error is expected since the user force imported the wrong kind
+  const e = await t.throwsAsync(() => upgrades.upgradeProxy(greeter, GreeterV2Proxiable));
+  t.true(e.message.startsWith(REQUESTED_UPGRADE_WRONG_KIND), e.message);
 });
 
 test('import custom UUPS proxy', async t => {

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support specifying proxy kind for `forceImport`, fix importing UUPS proxy with admin ([#550](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/550))
+
 ## 1.14.0 (2022-03-08)
 
 - Add an option `unsafeSkipStorageCheck` to skip storage layout compatibility check during upgrades. ([#495](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/495))

--- a/packages/plugin-truffle/test/contracts/CustomProxy.sol
+++ b/packages/plugin-truffle/test/contracts/CustomProxy.sol
@@ -175,3 +175,14 @@ contract CustomProxy {
         }
     }
 }
+
+contract CustomProxyWithAdmin is CustomProxy {
+    bytes32 internal constant _ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    constructor(address _logic, bytes memory _data) CustomProxy(_logic, _data) public payable {
+        address sender = msg.sender;
+        assembly {
+            sstore(_ADMIN_SLOT, sender)
+        }
+    }
+}


### PR DESCRIPTION
For https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/548

- Instead of detecting transparent/UUPS proxies kind based on admin storage slot, infer the kind through existence of `upgradeTo(address)` in the provided implementation contract instead.  This will allow UUPS proxies that have an admin to be properly imported as UUPS rather than transparent.
- Support optional `kind` to allow user to force the proxy kind to be uups, transparent, or beacon