### PR TITLE
Bump defender hardhat dependencies

### DIFF
--- a/packages/plugin-defender-hardhat/package.json
+++ b/packages/plugin-defender-hardhat/package.json
@@ -31,8 +31,8 @@
     "sinon": "^13.0.0"
   },
   "dependencies": {
-    "@openzeppelin/hardhat-upgrades": "^1.13.0",
-    "defender-admin-client": "^1.6.0-rc.0",
-    "defender-base-client": "^1.3.1"
+    "@openzeppelin/hardhat-upgrades": "^1.17.0",
+    "defender-admin-client": "^1.21.0",
+    "defender-base-client": "^1.21.0"
   }
 }


### PR DESCRIPTION
Bumping dependencies in order to be able to use latest Hardhat Upgrades features.

For example `unsafeSkipStorageCheck` that was introduced in version 1.14.0