### PR TITLE
Support unsafeSkipStorageCheck option in ValidationOptions

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support unsafeSkipStorageCheck option in ValidationOptions. ([#566](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/566))
+
 ## 1.14.2 (2022-04-18)
 
 - Fix handling of rename annotations when unchanged from one version to the next. ([#558](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/558))

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Support unsafeSkipStorageCheck option in ValidationOptions. ([#566](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/566))
+- Support `unsafeSkipStorageCheck` option in `ValidationOptions`. ([#566](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/566))
 
 ## 1.14.2 (2022-04-18)
 

--- a/packages/core/src/validate/overrides.ts
+++ b/packages/core/src/validate/overrides.ts
@@ -9,6 +9,7 @@ export interface ValidationOptions {
   unsafeAllowCustomTypes?: boolean;
   unsafeAllowLinkedLibraries?: boolean;
   unsafeAllowRenames?: boolean;
+  unsafeSkipStorageCheck?: boolean;
   unsafeAllow?: ValidationError['kind'][];
   kind?: ProxyDeployment['kind'];
 }
@@ -58,8 +59,9 @@ export function withValidationDefaults(opts: ValidationOptions): Required<Valida
   const kind = opts.kind ?? 'transparent';
 
   const unsafeAllowRenames = opts.unsafeAllowRenames ?? false;
+  const unsafeSkipStorageCheck = opts.unsafeSkipStorageCheck ?? false;
 
-  return { unsafeAllowCustomTypes, unsafeAllowLinkedLibraries, unsafeAllowRenames, unsafeAllow, kind };
+  return { unsafeAllowCustomTypes, unsafeAllowLinkedLibraries, unsafeAllowRenames, unsafeSkipStorageCheck, unsafeAllow, kind };
 }
 
 export function processExceptions(

--- a/packages/core/src/validate/overrides.ts
+++ b/packages/core/src/validate/overrides.ts
@@ -61,7 +61,14 @@ export function withValidationDefaults(opts: ValidationOptions): Required<Valida
   const unsafeAllowRenames = opts.unsafeAllowRenames ?? false;
   const unsafeSkipStorageCheck = opts.unsafeSkipStorageCheck ?? false;
 
-  return { unsafeAllowCustomTypes, unsafeAllowLinkedLibraries, unsafeAllowRenames, unsafeSkipStorageCheck, unsafeAllow, kind };
+  return {
+    unsafeAllowCustomTypes,
+    unsafeAllowLinkedLibraries,
+    unsafeAllowRenames,
+    unsafeSkipStorageCheck,
+    unsafeAllow,
+    kind,
+  };
 }
 
 export function processExceptions(


### PR DESCRIPTION
Add `unsafeSkipStorageCheck` into `ValidationOptions` which was added in [@openzeppelin/hardhat-upgrades@1.16.0](https://github.com/OpenZeppelin/openzeppelin-upgrades/releases/tag/%40openzeppelin%2Fhardhat-upgrades%401.16.0)