### PR TITLE
Defender Hardhat: Require multisig address when UUPS proxy 

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export { setProxyKind, processProxyKind, detectProxyKind } from './proxy-kind';
 
 export { UpgradeableContract } from './standalone';
 
-export { isTransparentOrUUPSProxy, isBeaconProxy } from './eip-1967-type';
+export { isTransparentOrUUPSProxy, isBeaconProxy, isTransparentProxy } from './eip-1967-type';
 export { getImplementationAddressFromBeacon, getImplementationAddressFromProxy } from './impl-address';
 export { isBeacon } from './beacon';
 export { addProxyToManifest } from './add-proxy-to-manifest';

--- a/packages/plugin-defender-hardhat/src/propose-upgrade.ts
+++ b/packages/plugin-defender-hardhat/src/propose-upgrade.ts
@@ -52,7 +52,7 @@ export function makeProposeUpgrade(hre: HardhatRuntimeEnvironment): ProposeUpgra
       (await isTransparentOrUUPSProxy(hre.network.provider, proxyAddress)) &&
       !(await isTransparentProxy(hre.network.provider, proxyAddress))
     ) {
-      throw new Error(`Multisig address is a required property for UUPS Proxies`);
+      throw new Error(`Multisig address is a required property for UUPS proxies`);
     } else {
       // try getting the implementation address so that it will give an error if it's not a transparent/uups proxy
       await getImplementationAddress(hre.network.provider, proxyAddress);

--- a/packages/plugin-defender-hardhat/src/propose-upgrade.ts
+++ b/packages/plugin-defender-hardhat/src/propose-upgrade.ts
@@ -5,6 +5,8 @@ import {
   isBeacon,
   isBeaconProxy,
   ValidationOptions,
+  isTransparentProxy,
+  isTransparentOrUUPSProxy,
 } from '@openzeppelin/upgrades-core';
 import { AdminClient, ProposalResponse } from 'defender-admin-client';
 import type { ContractFactory } from 'ethers';
@@ -45,6 +47,12 @@ export function makeProposeUpgrade(hre: HardhatRuntimeEnvironment): ProposeUpgra
       throw new Error(`Beacon proxy is not currently supported with defender.proposeUpgrade()`);
     } else if (await isBeacon(hre.network.provider, proxyAddress)) {
       throw new Error(`Beacon is not currently supported with defender.proposeUpgrade()`);
+    } else if (
+      !multisig &&
+      (await isTransparentOrUUPSProxy(hre.network.provider, proxyAddress)) &&
+      !(await isTransparentProxy(hre.network.provider, proxyAddress))
+    ) {
+      throw new Error(`Multisig address is a required property for UUPS Proxies`);
     } else {
       // try getting the implementation address so that it will give an error if it's not a transparent/uups proxy
       await getImplementationAddress(hre.network.provider, proxyAddress);

--- a/packages/plugin-defender-hardhat/test/propose-upgrade-uups.js
+++ b/packages/plugin-defender-hardhat/test/propose-upgrade-uups.js
@@ -138,6 +138,6 @@ test('fails if multisig address is missing from UUPS proxy', async t => {
   const { proposeUpgrade, fakeClient, greeter, GreeterV2 } = t.context;
   sinon.assert.notCalled(fakeClient.proposeUpgrade);
   await t.throwsAsync(() => proposeUpgrade(greeter.address, GreeterV2), {
-    message: 'Multisig address is a required property for UUPS Proxies',
+    message: 'Multisig address is a required property for UUPS proxies',
   });
 });

--- a/packages/plugin-defender-hardhat/test/propose-upgrade-uups.js
+++ b/packages/plugin-defender-hardhat/test/propose-upgrade-uups.js
@@ -8,6 +8,7 @@ const { FormatTypes } = require('ethers/lib/utils');
 const { AdminClient } = require('defender-admin-client');
 
 const proposalUrl = 'https://example.com';
+const multisig = '0xc0889725c22e2e36c524F41AECfddF5650432464';
 
 test.beforeEach(async t => {
   t.context.fakeClient = sinon.createStubInstance(AdminClient);
@@ -38,7 +39,7 @@ test('proposes an upgrade', async t => {
 
   const title = 'My upgrade';
   const description = 'My contract upgrade';
-  const proposal = await proposeUpgrade(greeter.address, GreeterV2, { title, description });
+  const proposal = await proposeUpgrade(greeter.address, GreeterV2, { title, description, multisig });
 
   t.is(proposal.url, proposalUrl);
   sinon.assert.calledWithExactly(
@@ -48,7 +49,7 @@ test('proposes an upgrade', async t => {
       title,
       description,
       proxyAdmin: undefined,
-      via: undefined,
+      via: multisig,
       viaType: undefined,
     },
     {
@@ -66,7 +67,6 @@ test('proposes an upgrade with explicit multisig and proxy admin', async t => {
   const title = 'My upgrade';
   const description = 'My contract upgrade';
   const proxyAdmin = '0x20cE6FeEf8862CbCe65fd1cafA59ac8bbC77e445';
-  const multisig = '0xc0889725c22e2e36c524F41AECfddF5650432464';
   const multisigType = 'Gnosis Safe';
   const opts = { title, description, proxyAdmin, multisig, multisigType };
   const proposal = await proposeUpgrade(greeter.address, GreeterV2, opts);
@@ -95,7 +95,7 @@ test('proposes an upgrade reusing prepared implementation', async t => {
   fakeClient.proposeUpgrade.resolves({ url: proposalUrl });
 
   const greeterV2Impl = await upgrades.prepareUpgrade(greeter.address, GreeterV2);
-  const proposal = await proposeUpgrade(greeter.address, GreeterV2);
+  const proposal = await proposeUpgrade(greeter.address, GreeterV2, { multisig });
 
   t.is(proposal.url, proposalUrl);
   sinon.assert.calledWithExactly(
@@ -105,7 +105,7 @@ test('proposes an upgrade reusing prepared implementation', async t => {
       title: undefined,
       description: undefined,
       proxyAdmin: undefined,
-      via: undefined,
+      via: multisig,
       viaType: undefined,
     },
     {
@@ -132,4 +132,12 @@ test('fails if defender config is missing', async t => {
     message: 'Missing Defender API key and secret in hardhat config',
   });
   hre.config.defender = defender;
+});
+
+test('fails if multisig address is missing from UUPS proxy', async t => {
+  const { proposeUpgrade, fakeClient, greeter, GreeterV2 } = t.context;
+  sinon.assert.notCalled(fakeClient.proposeUpgrade);
+  await t.throwsAsync(() => proposeUpgrade(greeter.address, GreeterV2), {
+    message: 'Multisig address is a required property for UUPS Proxies',
+  });
 });


### PR DESCRIPTION
This PR makes the multisig property a required field when the user is making a proposal to upgrade a UUPS proxy