### PR TITLE
Fix task redefinition error

### DIFF
--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -274,14 +274,14 @@ To use this task, ensure you have https://hardhat.org/plugins/nomiclabs-hardhat-
 npm install --save-dev @nomiclabs/hardhat-etherscan
 ----
 
-Then import the `@nomiclabs/hardhat-etherscan` plugin before the `@openzeppelin/hardhat-upgrades` plugin in your Hardhat configuration.
-For example, if you are using JavaScript, import the plugins in the following order in `hardhat.config.js`:
+Then import the `@nomiclabs/hardhat-etherscan` plugin along with the `@openzeppelin/hardhat-upgrades` plugin in your Hardhat configuration.
+For example, if you are using JavaScript, import the plugins in `hardhat.config.js`:
 [source,js]
 ----
 require("@nomiclabs/hardhat-etherscan");
 require("@openzeppelin/hardhat-upgrades");
 ----
-Or if you are using TypeScript, import the plugins in the following order in `hardhat.config.ts`:
+Or if you are using TypeScript, import the plugins in `hardhat.config.ts`:
 [source,ts]
 ----
 import "@nomiclabs/hardhat-etherscan";

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix task redefinition error with hardhat-etherscan. ([#586](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/586))
+
 ## 1.18.0 (2022-05-31)
 
 - Support verifying a proxy on Etherscan using Hardhat. ([#579](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/579))

--- a/packages/plugin-hardhat/src/index.ts
+++ b/packages/plugin-hardhat/src/index.ts
@@ -78,6 +78,11 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE, async (args: RunCompilerArgs, hre, runSup
 });
 
 extendEnvironment(hre => {
+  task('verify').setAction(async (args, hre, runSuper) => {
+    const { verify } = await import('./verify-proxy');
+    return await verify(args, hre, runSuper);
+  });
+
   hre.upgrades = lazyObject((): HardhatUpgrades => {
     const {
       silenceWarnings,
@@ -132,9 +137,4 @@ extendConfig((config: HardhatConfig) => {
       compiler.settings.outputSelection['*']['*'].push('storageLayout');
     }
   }
-});
-
-task('verify').setAction(async (args, hre, runSuper) => {
-  const { verify } = await import('./verify-proxy');
-  return await verify(args, hre, runSuper);
 });

--- a/packages/plugin-hardhat/src/verify-proxy.ts
+++ b/packages/plugin-hardhat/src/verify-proxy.ts
@@ -311,6 +311,8 @@ async function searchEvent(
   });
   throw new EventNotFound(
     `Could not find an event with any of the following topics in the logs for address ${address}: ${events.join(', ')}`,
+    () =>
+      'If the proxy was recently deployed, the transaction may not be available on Etherscan yet. Try running the verify task again after waiting a few blocks.',
   );
 }
 


### PR DESCRIPTION
- Changes the `verify` task definition to be within the Hardhat environment extension to ensure that it overrides hardhat-etherscan's `verify`.  This allows the plugins to be imported in any order.

- Also improves error message if contract logs are not found, possibly due to the transaction not being seen on Etherscan yet.

Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/586