### PR TITLE
Bump @openzeppelin/hardhat-upgrades in @openzeppelin/hardhat-defender

### DIFF
--- a/packages/plugin-defender-hardhat/CHANGELOG.md
+++ b/packages/plugin-defender-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix version dependency. ([#590](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/590))
+
 ## 1.6.1 (2022-05-31)
 
 - Require multisig address for `proposeUpgrade` with UUPS proxy. ([#568](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/568))

--- a/packages/plugin-defender-hardhat/package.json
+++ b/packages/plugin-defender-hardhat/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",
-    "@openzeppelin/upgrades-core": "^1.11.0",
+    "@openzeppelin/upgrades-core": "^1.15.0",
     "@types/mocha": "^7.0.2",
     "ava": "^4.0.0",
     "ethers": "^5.0.5",
@@ -31,7 +31,7 @@
     "sinon": "^14.0.0"
   },
   "dependencies": {
-    "@openzeppelin/hardhat-upgrades": "^1.18.0",
+    "@openzeppelin/hardhat-upgrades": "^1.18.1",
     "defender-admin-client": "^1.6.0-rc.0",
     "defender-base-client": "^1.3.1"
   }

--- a/packages/plugin-defender-hardhat/package.json
+++ b/packages/plugin-defender-hardhat/package.json
@@ -31,7 +31,7 @@
     "sinon": "^14.0.0"
   },
   "dependencies": {
-    "@openzeppelin/hardhat-upgrades": "^1.13.0",
+    "@openzeppelin/hardhat-upgrades": "^1.18.0",
     "defender-admin-client": "^1.6.0-rc.0",
     "defender-base-client": "^1.3.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,15 +1974,6 @@
     lodash.startcase "^4.4.0"
     minimist "^1.2.0"
 
-"@openzeppelin/hardhat-upgrades@1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.18.0.tgz#81d1b6e099fd91bf7f7157dea6b739af18284870"
-  integrity sha512-iPJNTDJ+vfW9y/XkxeMEqCmg2taiM/KKJ85YIdpP9SooXZoEd18Ft6kuIgiUUVIaPX5My5yOv6IUaxSHuc3Pzw==
-  dependencies:
-    "@openzeppelin/upgrades-core" "^1.15.0"
-    chalk "^4.1.0"
-    proper-lockfile "^4.1.1"
-
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,6 +1974,15 @@
     lodash.startcase "^4.4.0"
     minimist "^1.2.0"
 
+"@openzeppelin/hardhat-upgrades@1.18.0":
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.18.0.tgz#81d1b6e099fd91bf7f7157dea6b739af18284870"
+  integrity sha512-iPJNTDJ+vfW9y/XkxeMEqCmg2taiM/KKJ85YIdpP9SooXZoEd18Ft6kuIgiUUVIaPX5My5yOv6IUaxSHuc3Pzw==
+  dependencies:
+    "@openzeppelin/upgrades-core" "^1.15.0"
+    chalk "^4.1.0"
+    proper-lockfile "^4.1.1"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -3106,7 +3115,6 @@
 
 "@zondax/filecoin-signing-tools@github:trufflesuite/filecoin-signing-tools-js":
   version "0.2.0"
-  uid "2786fdb8a2b71bd1c7789c0701da41bb644a098f"
   resolved "https://codeload.github.com/trufflesuite/filecoin-signing-tools-js/tar.gz/2786fdb8a2b71bd1c7789c0701da41bb644a098f"
   dependencies:
     axios "0.26.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3106,6 +3106,7 @@
 
 "@zondax/filecoin-signing-tools@github:trufflesuite/filecoin-signing-tools-js":
   version "0.2.0"
+  uid "2786fdb8a2b71bd1c7789c0701da41bb644a098f"
   resolved "https://codeload.github.com/trufflesuite/filecoin-signing-tools-js/tar.gz/2786fdb8a2b71bd1c7789c0701da41bb644a098f"
   dependencies:
     axios "0.26.1"


### PR DESCRIPTION
### Description

We got a support request via email with this error:

![image](https://user-images.githubusercontent.com/33379285/171934668-04d4ce1e-6507-4269-ba8b-ebf3e1096df8.png)

The issue was introduced [here](https://github.com/OpenZeppelin/openzeppelin-upgrades/commit/052a09900804fdb66be4deec7f19f1930b45487e#diff-8f628b53d0a150cddf2068194e438f596bb7091f5503d69c6a18a5ddc0ef0cfcR53), and seems like it has to be with the `@openzeppelin/hardhat-upgrades` version

