### PR TITLE
Fix `missing apiKey` error

### DIFF
--- a/packages/plugin-hardhat/src/utils/etherscan-api.ts
+++ b/packages/plugin-hardhat/src/utils/etherscan-api.ts
@@ -44,7 +44,7 @@ export async function callEtherscanApi(etherscanApi: EtherscanAPIConfig, params:
 export async function getEtherscanAPIConfig(hre: HardhatRuntimeEnvironment): Promise<EtherscanAPIConfig> {
   const endpoints = await hre.run('verify:get-etherscan-endpoint');
   const etherscanConfig: EtherscanConfig = (hre.config as any).etherscan;
-  const key = resolveEtherscanApiKey(etherscanConfig, endpoints.network);
+  const key = resolveEtherscanApiKey(etherscanConfig.apiKey, endpoints.network);
   return { key, endpoints };
 }
 


### PR DESCRIPTION
Pass apiKey object/string in `resolveEtherscanApiKey` method instead of whole etherscan object.

Fixes: [#592 ](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/592)