### PR TITLE
Fix VM execution error when checking isBeacon

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix VM execution error in `proposeUpgrade` with Gnosis Chain. ([#597](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/597))
+
 ## 1.16.0 (2022-06-16)
 
 - Return ethers transaction response with `proposeUpgrade`. ([#554](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/554))

--- a/packages/core/src/impl-address.ts
+++ b/packages/core/src/impl-address.ts
@@ -34,7 +34,8 @@ export async function getImplementationAddressFromBeacon(
       !(
         e.message.includes('function selector was not recognized') ||
         e.message.includes('invalid opcode') ||
-        e.message.includes('revert')
+        e.message.includes('revert') ||
+        e.message.includes('execution error')
       )
     ) {
       throw e;


### PR DESCRIPTION
When using Gnosis Chain, `defender.proposeUpgrade` encounters this error in `isBeacon`

```
ProviderError: VM execution error.
    at HttpProvider.request (/Users/.../DefenderUpgrade/node_modules/hardhat/src/internal/core/providers/http.ts:78:19)
    at LocalAccountsProvider.request (/Users/.../DefenderUpgrade/node_modules/hardhat/src/internal/core/providers/accounts.ts:188:34)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at getImplementationAddressFromBeacon (/Users/.../node_modules/@openzeppelin/upgrades-core/src/impl-address.ts:30:25)
    at isBeacon (/Users/.../node_modules/@openzeppelin/upgrades-core/src/beacon.ts:11:5)
    at Proxy.proposeUpgrade (/Users/.../node_modules/@openzeppelin/hardhat-defender/src/propose-upgrade.ts:48:16)
    at main (/Users/.../DefenderUpgrade/scripts/propose-upgrade.js:17:20)
```

This fix is to include this in the list of expected errors.

Originally reported in https://forum.openzeppelin.com/t/making-upgrade-proposal-using-defender-proposeupgrade-on-gnosis-chain-returns-providererror-vm-execution-error/29461