### PR TITLE
plugins: Add missing debug and ethers dependencies

### DIFF
--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -25,7 +25,6 @@
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@types/mocha": "^7.0.2",
     "ava": "^4.0.0",
-    "ethers": "^5.0.5",
     "fgbg": "^0.1.4",
     "hardhat": "^2.0.2",
     "promisified": "^0.5.0",
@@ -40,6 +39,7 @@
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
+    "ethers": "^5.0.5",
     "hardhat": "^2.0.2"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@openzeppelin/upgrades-core": "^1.16.0",
     "chalk": "^4.1.0",
+    "debug": "^4.1.1",
     "proper-lockfile": "^4.1.1"
   },
   "peerDependencies": {

--- a/packages/plugin-truffle/package.json
+++ b/packages/plugin-truffle/package.json
@@ -27,6 +27,7 @@
     "@openzeppelin/upgrades-core": "^1.14.1",
     "@truffle/contract": "^4.3.26",
     "chalk": "^4.1.0",
+    "debug": "^4.1.1",
     "solidity-ast": "^0.4.15"
   },
   "peerDependencies": {


### PR DESCRIPTION
`debug` is imported as a util and `ethers` is used directly in `plugin-hardhat`, so both of these should be declared as dependencies. I chose to declare `ethers` as a peerDependency to match `@nomiclabs/hardhat-ethers`.