### PR TITLE
Remove BN.js in favor of native BigInt

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Remove BN.js in favor of native BigInt.
+
 ## 1.15.0 (2022-05-31)
 
 - Support `unsafeSkipStorageCheck` option in `ValidationOptions`. ([#566](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/566))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,6 @@
     "@nomiclabs/hardhat-etherscan": "^3.0.0",
     "@openzeppelin/contracts": "4.1.0",
     "@openzeppelin/contracts-upgradeable": "4.1.0",
-    "@types/bn.js": "^5.0.0",
     "@types/cbor": "^5.0.0",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^7.0.2",
@@ -51,7 +50,6 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
-    "bn.js": "^5.1.2",
     "cbor": "^8.0.0",
     "chalk": "^4.1.0",
     "compare-versions": "^4.0.0",

--- a/packages/core/src/eip-1967.ts
+++ b/packages/core/src/eip-1967.ts
@@ -1,4 +1,3 @@
-import BN from 'bn.js';
 import { keccak256 } from 'ethereumjs-util';
 import { UpgradesError } from './error';
 import { EthereumProvider, getStorageAt } from './provider';
@@ -64,13 +63,12 @@ export function toFallbackEip1967Hash(label: string): string {
 
 export function toEip1967Hash(label: string): string {
   const hash = keccak256(Buffer.from(label));
-  const bigNumber = new BN(hash).sub(new BN(1));
+  const bigNumber = BigInt('0x' + hash.toString('hex')) - 1n;
   return '0x' + bigNumber.toString(16);
 }
 
 export function isEmptySlot(storage: string): boolean {
-  storage = storage.replace(/^0x/, '');
-  return new BN(storage, 'hex').isZero();
+  return BigInt(storage.replace(/^(0x)?/, '0x')) === 0n;
 }
 
 function parseAddressFromStorage(storage: string): string {

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -1,5 +1,3 @@
-import BN from 'bn.js';
-
 export interface EthereumProvider {
   send(method: 'web3_clientVersion', params: []): Promise<string>;
   send(method: 'net_version', params: []): Promise<string>;
@@ -33,7 +31,7 @@ export async function getNetworkId(provider: EthereumProvider): Promise<string> 
 
 export async function getChainId(provider: EthereumProvider): Promise<number> {
   const id = await provider.send('eth_chainId', []);
-  return new BN(id.replace(/^0x/, ''), 'hex').toNumber();
+  return parseInt(id.replace(/^0x/, ''), 16);
 }
 
 export async function getClientVersion(provider: EthereumProvider): Promise<string> {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "incremental": true,
-    "target": "es2019",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2752,7 +2752,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/bn.js@^5.0.0", "@types/bn.js@^5.1.0":
+"@types/bn.js@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
   integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
@@ -3106,7 +3106,6 @@
 
 "@zondax/filecoin-signing-tools@github:trufflesuite/filecoin-signing-tools-js":
   version "0.2.0"
-  uid "2786fdb8a2b71bd1c7789c0701da41bb644a098f"
   resolved "https://codeload.github.com/trufflesuite/filecoin-signing-tools-js/tar.gz/2786fdb8a2b71bd1c7789c0701da41bb644a098f"
   dependencies:
     axios "0.26.1"


### PR DESCRIPTION
BigInt is supported in Node.js 10 and above as well as modern browsers although that is less important for this library.

There is still some use of BN.js for testing of Truffle, that makes less sense to remove because the Truffle contract abstraction directly returns BN.js instances.