### PR TITLE
Add condition to use UUPS/Transparent if the adminAddress is zero in the getUpgrader func

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improve check for admin contract in `upgradeProxy`. ([#604](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/604))
+
 ## 1.19.0 (2022-06-16)
 
 - Return ethers transaction response with `proposeUpgrade`. ([#554](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/554))

--- a/packages/plugin-hardhat/src/upgrade-proxy.ts
+++ b/packages/plugin-hardhat/src/upgrade-proxy.ts
@@ -42,7 +42,7 @@ export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment): UpgradeFunctio
     const adminAddress = await getAdminAddress(provider, proxyAddress);
     const adminBytecode = await getCode(provider, adminAddress);
 
-    if (adminBytecode === '0x') {
+    if (adminAddress === '0x0000000000000000000000000000000000000000' || adminBytecode === '0x') {
       // No admin contract: use TransparentUpgradeableProxyFactory to get proxiable interface
       const TransparentUpgradeableProxyFactory = await getTransparentUpgradeableProxyFactory(hre, signer);
       const proxy = TransparentUpgradeableProxyFactory.attach(proxyAddress);

--- a/packages/plugin-hardhat/src/upgrade-proxy.ts
+++ b/packages/plugin-hardhat/src/upgrade-proxy.ts
@@ -1,7 +1,7 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import type { ethers, ContractFactory, Contract, Signer } from 'ethers';
 
-import { Manifest, getAdminAddress, getCode } from '@openzeppelin/upgrades-core';
+import { Manifest, getAdminAddress, getCode, isEmptySlot } from '@openzeppelin/upgrades-core';
 
 import {
   UpgradeProxyOptions,
@@ -42,7 +42,7 @@ export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment): UpgradeFunctio
     const adminAddress = await getAdminAddress(provider, proxyAddress);
     const adminBytecode = await getCode(provider, adminAddress);
 
-    if (adminAddress === '0x0000000000000000000000000000000000000000' || adminBytecode === '0x') {
+    if (isEmptySlot(adminAddress) || adminBytecode === '0x') {
       // No admin contract: use TransparentUpgradeableProxyFactory to get proxiable interface
       const TransparentUpgradeableProxyFactory = await getTransparentUpgradeableProxyFactory(hre, signer);
       const proxy = TransparentUpgradeableProxyFactory.attach(proxyAddress);

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improve check for admin contract in `upgradeProxy`. ([#604](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/604))
+
 ## 1.15.0 (2022-03-29)
 
 - Fix "The requested contract was not found" error when importing from an interface ([#549](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/549))

--- a/packages/plugin-truffle/src/upgrade-proxy.ts
+++ b/packages/plugin-truffle/src/upgrade-proxy.ts
@@ -1,4 +1,4 @@
-import { Manifest, getAdminAddress, getCode, EthereumProvider } from '@openzeppelin/upgrades-core';
+import { Manifest, getAdminAddress, getCode, EthereumProvider, isEmptySlot } from '@openzeppelin/upgrades-core';
 
 import {
   ContractClass,
@@ -42,7 +42,7 @@ async function getUpgrader(
   const adminAddress = await getAdminAddress(provider, proxyAddress);
   const adminBytecode = await getCode(provider, adminAddress);
 
-  if (adminAddress === '0x0000000000000000000000000000000000000000' || adminBytecode === '0x') {
+  if (isEmptySlot(adminAddress) || adminBytecode === '0x') {
     // No admin contract: use TransparentUpgradeableProxyFactory to get proxiable interface
     const TransparentUpgradeableProxyFactory = getTransparentUpgradeableProxyFactory(contractTemplate);
     const proxy = new TransparentUpgradeableProxyFactory(proxyAddress);

--- a/packages/plugin-truffle/src/upgrade-proxy.ts
+++ b/packages/plugin-truffle/src/upgrade-proxy.ts
@@ -42,7 +42,7 @@ async function getUpgrader(
   const adminAddress = await getAdminAddress(provider, proxyAddress);
   const adminBytecode = await getCode(provider, adminAddress);
 
-  if (adminBytecode === '0x') {
+  if (adminAddress === '0x0000000000000000000000000000000000000000' || adminBytecode === '0x') {
     // No admin contract: use TransparentUpgradeableProxyFactory to get proxiable interface
     const TransparentUpgradeableProxyFactory = getTransparentUpgradeableProxyFactory(contractTemplate);
     const proxy = new TransparentUpgradeableProxyFactory(proxyAddress);


### PR DESCRIPTION
I am developing dApp on Klaytn network. (EVM Based)

The null address in the Klaytn network is contract, so a bytecode exists.
(You can see the code [here](https://scope.klaytn.com/account/0x0000000000000000000000000000000000000000?tabId=contractCode))

Therefore, with UUPS, I cannot upgrade the Implementation of the proxy.

![image](https://user-images.githubusercontent.com/1664863/175818002-d3e63e41-b46c-41ad-b72d-32d4a4d4920d.png)


The solution I thought of is to add a condition to make sure that adminAddress is null.