### PR TITLE
Fix missing module

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix missing module.
+- Fix missing module. ([#652](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/652))
 
 ## 1.19.0 (2022-09-10)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix missing module.
+
 ## 1.19.0 (2022-09-10)
 
 - Add support for avalanche and avalanche-fuji to manifest file names. ([#622](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/622))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "/artifacts/@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol",
     "/artifacts/@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol",
     "/artifacts/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol",
-    "/artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json ",
+    "/artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json",
     "/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json",
     "/artifacts/build-info.json"
   ],


### PR DESCRIPTION
Fixes the following error in upgrades-core version 1.19.0:
```
Error: Cannot find module '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json'
```