### PR TITLE
Ignore unset Defender API key unless necessary

### DIFF
--- a/packages/plugin-defender-hardhat/src/index.ts
+++ b/packages/plugin-defender-hardhat/src/index.ts
@@ -33,7 +33,7 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
     if (!userConfig.defender || !userConfig.defender.apiKey || !userConfig.defender.apiSecret) {
       const sampleConfig = JSON.stringify({ apiKey: 'YOUR_API_KEY', apiSecret: 'YOUR_API_SECRET' }, null, 2);
       console.warn(
-        `Defender API key and secret are not set. Add the following to your hardhat.config.js exported configuration:\n${sampleConfig}\n`,
+        `Defender API key and secret are not set. Add the following to your hardhat.config.js exported configuration:\ndefender: ${sampleConfig}\n`,
       );
     }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/plugin-defender-hardhat/src/index.ts
+++ b/packages/plugin-defender-hardhat/src/index.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import '@nomiclabs/hardhat-ethers';
-import { extendConfig, extendEnvironment } from 'hardhat/config';
+import { extendEnvironment } from 'hardhat/config';
 import { lazyFunction, lazyObject } from 'hardhat/plugins';
-import { HardhatConfig, HardhatUserConfig } from 'hardhat/types';
 import type { ProposeUpgradeFunction } from './propose-upgrade';
+import './type-extensions';
 import type {
   GetBytecodeDigestFunction,
   GetVerifyDeployArtifactFunction,
@@ -12,7 +12,6 @@ import type {
   VerifyDeployFunction,
   VerifyDeployWithUploadedArtifactFunction,
 } from './verify-deployment';
-import './type-extensions';
 
 export interface HardhatDefender {
   proposeUpgrade: ProposeUpgradeFunction;
@@ -27,19 +26,6 @@ export interface HardhatDefenderConfig {
   apiKey: string;
   apiSecret: string;
 }
-
-extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
-  config.defender = lazyObject((): HardhatDefenderConfig => {
-    if (!userConfig.defender || !userConfig.defender.apiKey || !userConfig.defender.apiSecret) {
-      const sampleConfig = JSON.stringify({ apiKey: 'YOUR_API_KEY', apiSecret: 'YOUR_API_SECRET' }, null, 2);
-      console.warn(
-        `Defender API key and secret are not set. Add the following to your hardhat.config.js exported configuration:\ndefender: ${sampleConfig}\n`,
-      );
-    }
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return userConfig.defender!;
-  });
-});
 
 extendEnvironment(hre => {
   hre.defender = lazyObject((): HardhatDefender => {

--- a/packages/plugin-defender-hardhat/src/index.ts
+++ b/packages/plugin-defender-hardhat/src/index.ts
@@ -29,13 +29,16 @@ export interface HardhatDefenderConfig {
 }
 
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
-  if (!userConfig.defender || !userConfig.defender.apiKey || !userConfig.defender.apiSecret) {
-    const sampleConfig = JSON.stringify({ apiKey: 'YOUR_API_KEY', apiSecret: 'YOUR_API_SECRET' }, null, 2);
-    console.warn(
-      `Defender API key and secret are not set. Add the following to your hardhat.config.js exported configuration:\n\n${sampleConfig}\n`,
-    );
-  }
-  config.defender = userConfig.defender;
+  config.defender = lazyObject((): HardhatDefenderConfig => {
+    if (!userConfig.defender || !userConfig.defender.apiKey || !userConfig.defender.apiSecret) {
+      const sampleConfig = JSON.stringify({ apiKey: 'YOUR_API_KEY', apiSecret: 'YOUR_API_SECRET' }, null, 2);
+      console.warn(
+        `Defender API key and secret are not set. Add the following to your hardhat.config.js exported configuration:\n${sampleConfig}\n`,
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return userConfig.defender!;
+  });
 });
 
 extendEnvironment(hre => {

--- a/packages/plugin-defender-hardhat/src/propose-upgrade.ts
+++ b/packages/plugin-defender-hardhat/src/propose-upgrade.ts
@@ -1,20 +1,18 @@
+import { UpgradeOptions } from '@openzeppelin/hardhat-upgrades';
 import '@openzeppelin/hardhat-upgrades/dist/type-extensions';
 import {
-  getChainId,
   getImplementationAddress,
   isBeacon,
   isBeaconProxy,
-  isTransparentProxy,
   isTransparentOrUUPSProxy,
+  isTransparentProxy,
 } from '@openzeppelin/upgrades-core';
 import { ProposalResponse } from 'defender-admin-client';
 import { ContractFactory, ethers } from 'ethers';
 import { FormatTypes, getContractAddress } from 'ethers/lib/utils';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { fromChainId } from 'defender-base-client';
-import { UpgradeOptions } from '@openzeppelin/hardhat-upgrades';
+import { getAdminClient, getNetwork } from './utils';
 import type { VerificationResponse } from './verify-deployment';
-import { getAdminClient } from './utils';
 
 export interface ExtendedProposalResponse extends ProposalResponse {
   txResponse?: ethers.providers.TransactionResponse;
@@ -39,11 +37,7 @@ export interface ProposalOptions extends UpgradeOptions {
 export function makeProposeUpgrade(hre: HardhatRuntimeEnvironment): ProposeUpgradeFunction {
   return async function proposeUpgrade(proxyAddress, contractNameOrImplFactory, opts = {}) {
     const client = getAdminClient(hre);
-    const chainId = await getChainId(hre.network.provider);
-    const network = fromChainId(chainId);
-    if (network === undefined) {
-      throw new Error(`Network ${chainId} is not supported in Defender Admin`);
-    }
+    const network = await getNetwork(hre);
 
     const { title, description, proxyAdmin, multisig, multisigType, ...moreOpts } = opts;
 

--- a/packages/plugin-defender-hardhat/src/propose-upgrade.ts
+++ b/packages/plugin-defender-hardhat/src/propose-upgrade.ts
@@ -7,13 +7,14 @@ import {
   isTransparentProxy,
   isTransparentOrUUPSProxy,
 } from '@openzeppelin/upgrades-core';
-import { AdminClient, ProposalResponse } from 'defender-admin-client';
+import { ProposalResponse } from 'defender-admin-client';
 import { ContractFactory, ethers } from 'ethers';
 import { FormatTypes, getContractAddress } from 'ethers/lib/utils';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { fromChainId } from 'defender-base-client';
 import { UpgradeOptions } from '@openzeppelin/hardhat-upgrades';
 import type { VerificationResponse } from './verify-deployment';
+import { getAdminClient } from './utils';
 
 export interface ExtendedProposalResponse extends ProposalResponse {
   txResponse?: ethers.providers.TransactionResponse;
@@ -37,11 +38,7 @@ export interface ProposalOptions extends UpgradeOptions {
 
 export function makeProposeUpgrade(hre: HardhatRuntimeEnvironment): ProposeUpgradeFunction {
   return async function proposeUpgrade(proxyAddress, contractNameOrImplFactory, opts = {}) {
-    if (!hre.config.defender) {
-      throw new Error(`Missing Defender API key and secret in hardhat config`);
-    }
-    const client = new AdminClient(hre.config.defender);
-
+    const client = getAdminClient(hre);
     const chainId = await getChainId(hre.network.provider);
     const network = fromChainId(chainId);
     if (network === undefined) {

--- a/packages/plugin-defender-hardhat/src/utils.ts
+++ b/packages/plugin-defender-hardhat/src/utils.ts
@@ -3,10 +3,14 @@ import { fromChainId, Network } from 'defender-base-client';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 export function getAdminClient(hre: HardhatRuntimeEnvironment): AdminClient {
-  if (!hre.config.defender) {
-    throw new Error(`Missing Defender API key and secret in hardhat config`);
+  const cfg = hre.config.defender;
+  if (!cfg || !cfg.apiKey || !cfg.apiSecret) {
+    const sampleConfig = JSON.stringify({ apiKey: 'YOUR_API_KEY', apiSecret: 'YOUR_API_SECRET' }, null, 2);
+    throw new Error(
+      `Missing Defender API key and secret in hardhat config. Add the following to your hardhat.config.js configuration:\ndefender: ${sampleConfig}\n`,
+    );
   }
-  return new AdminClient(hre.config.defender);
+  return new AdminClient(cfg);
 }
 
 export async function getNetwork(hre: HardhatRuntimeEnvironment): Promise<Network> {

--- a/packages/plugin-defender-hardhat/test/propose-upgrade-beacon.js
+++ b/packages/plugin-defender-hardhat/test/propose-upgrade-beacon.js
@@ -12,13 +12,9 @@ test.beforeEach(async t => {
   t.context.fakeClient = sinon.createStubInstance(AdminClient);
   t.context.fakeChainId = 'goerli';
   t.context.proposeUpgrade = proxyquire('../dist/propose-upgrade', {
-    'defender-admin-client': {
-      AdminClient: function () {
-        return t.context.fakeClient;
-      },
-    },
-    'defender-base-client': {
-      fromChainId: () => t.context.fakeChainId,
+    './utils': {
+      getNetwork: () => t.context.fakeChainId,
+      getAdminClient: () => t.context.fakeClient,
     },
   }).makeProposeUpgrade(hre);
 

--- a/packages/plugin-defender-hardhat/test/propose-upgrade-transparent.js
+++ b/packages/plugin-defender-hardhat/test/propose-upgrade-transparent.js
@@ -13,13 +13,9 @@ test.beforeEach(async t => {
   t.context.fakeClient = sinon.createStubInstance(AdminClient);
   t.context.fakeChainId = 'goerli';
   t.context.proposeUpgrade = proxyquire('../dist/propose-upgrade', {
-    'defender-admin-client': {
-      AdminClient: function () {
-        return t.context.fakeClient;
-      },
-    },
-    'defender-base-client': {
-      fromChainId: () => t.context.fakeChainId,
+    './utils': {
+      getNetwork: () => t.context.fakeChainId,
+      getAdminClient: () => t.context.fakeClient,
     },
   }).makeProposeUpgrade(hre);
 
@@ -83,22 +79,4 @@ test('proposes an upgrade reusing prepared implementation', async t => {
       abi: GreeterV2.interface.format(FormatTypes.json),
     },
   );
-});
-
-test('fails if chain id is not accepted', async t => {
-  const { proposeUpgrade, greeter, GreeterV2 } = t.context;
-  t.context.fakeChainId = undefined;
-
-  await t.throwsAsync(() => proposeUpgrade(greeter.address, GreeterV2), { message: /Network \d+ is not supported/ });
-});
-
-test('fails if defender config is missing', async t => {
-  const { proposeUpgrade, greeter, GreeterV2 } = t.context;
-  const { defender } = hre.config;
-  delete hre.config.defender;
-
-  await t.throwsAsync(() => proposeUpgrade(greeter.address, GreeterV2), {
-    message: 'Missing Defender API key and secret in hardhat config',
-  });
-  hre.config.defender = defender;
 });

--- a/packages/plugin-defender-hardhat/test/propose-upgrade-unsafeAllow.js
+++ b/packages/plugin-defender-hardhat/test/propose-upgrade-unsafeAllow.js
@@ -13,13 +13,9 @@ test.beforeEach(async t => {
   t.context.fakeClient = sinon.createStubInstance(AdminClient);
   t.context.fakeChainId = 'goerli';
   t.context.proposeUpgrade = proxyquire('../dist/propose-upgrade', {
-    'defender-admin-client': {
-      AdminClient: function () {
-        return t.context.fakeClient;
-      },
-    },
-    'defender-base-client': {
-      fromChainId: () => t.context.fakeChainId,
+    './utils': {
+      getNetwork: () => t.context.fakeChainId,
+      getAdminClient: () => t.context.fakeClient,
     },
   }).makeProposeUpgrade(hre);
 

--- a/packages/plugin-defender-hardhat/test/propose-upgrade-use-deployed.js
+++ b/packages/plugin-defender-hardhat/test/propose-upgrade-use-deployed.js
@@ -14,13 +14,9 @@ test.beforeEach(async t => {
   t.context.fakeClient = sinon.createStubInstance(AdminClient);
   t.context.fakeChainId = 'goerli';
   t.context.proposeUpgrade = proxyquire('../dist/propose-upgrade', {
-    'defender-admin-client': {
-      AdminClient: function () {
-        return t.context.fakeClient;
-      },
-    },
-    'defender-base-client': {
-      fromChainId: () => t.context.fakeChainId,
+    './utils': {
+      getNetwork: () => t.context.fakeChainId,
+      getAdminClient: () => t.context.fakeClient,
     },
   }).makeProposeUpgrade(hre);
 

--- a/packages/plugin-defender-hardhat/test/propose-upgrade-uups.js
+++ b/packages/plugin-defender-hardhat/test/propose-upgrade-uups.js
@@ -15,13 +15,9 @@ test.beforeEach(async t => {
   t.context.fakeDefender = { verifyDeployment: sinon.stub() };
   t.context.fakeChainId = 'goerli';
   t.context.proposeUpgrade = proxyquire('../dist/propose-upgrade', {
-    'defender-admin-client': {
-      AdminClient: function () {
-        return t.context.fakeClient;
-      },
-    },
-    'defender-base-client': {
-      fromChainId: () => t.context.fakeChainId,
+    './utils': {
+      getNetwork: () => t.context.fakeChainId,
+      getAdminClient: () => t.context.fakeClient,
     },
   }).makeProposeUpgrade({
     ...hre,
@@ -182,24 +178,6 @@ test('proposes an upgrade reusing prepared implementation', async t => {
       abi: GreeterV2.interface.format(FormatTypes.json),
     },
   );
-});
-
-test('fails if chain id is not accepted', async t => {
-  const { proposeUpgrade, greeter, GreeterV2 } = t.context;
-  t.context.fakeChainId = undefined;
-
-  await t.throwsAsync(() => proposeUpgrade(greeter.address, GreeterV2), { message: /Network \d+ is not supported/ });
-});
-
-test('fails if defender config is missing', async t => {
-  const { proposeUpgrade, greeter, GreeterV2 } = t.context;
-  const { defender } = hre.config;
-  delete hre.config.defender;
-
-  await t.throwsAsync(() => proposeUpgrade(greeter.address, GreeterV2), {
-    message: 'Missing Defender API key and secret in hardhat config',
-  });
-  hre.config.defender = defender;
 });
 
 test('fails if multisig address is missing from UUPS proxy', async t => {

--- a/packages/plugin-defender-hardhat/test/utils.js
+++ b/packages/plugin-defender-hardhat/test/utils.js
@@ -1,0 +1,44 @@
+const test = require('ava');
+const sinon = require('sinon');
+const { getNetwork, getAdminClient } = require(' ../../../dist/utils');
+
+test.beforeEach(async t => {
+  t.context.fakeChainId = '0x05';
+  t.context.fakeHre = {
+    config: { defender: { apiKey: 'API_KEY', apiSecret: 'API_SECRET' } },
+    network: { provider: { send: async () => t.context.fakeChainId } },
+  };
+});
+
+test.afterEach.always(() => {
+  sinon.restore();
+});
+
+test('returns defender network definition', async t => {
+  const network = await getNetwork(t.context.fakeHre);
+  t.is(network, 'goerli');
+});
+
+test('fails if chain id is not accepted', async t => {
+  t.context.fakeChainId = '0x123456';
+  await t.throwsAsync(() => getNetwork(t.context.fakeHre), { message: /Network \d+ is not supported/ });
+});
+
+test('returns admin client', async t => {
+  const client = getAdminClient(t.context.fakeHre);
+  t.is(typeof client.createProposal, 'function');
+});
+
+test('fails if defender config is missing', async t => {
+  delete t.context.fakeHre.config.defender;
+  t.throws(() => getAdminClient(t.context.fakeHre), {
+    message: /Missing Defender API key and secret in hardhat config/,
+  });
+});
+
+test('fails if defender api key is missing in config', async t => {
+  delete t.context.fakeHre.config.defender.apiKey;
+  t.throws(() => getAdminClient(t.context.fakeHre), {
+    message: /Missing Defender API key and secret in hardhat config/,
+  });
+});


### PR DESCRIPTION
Fixes #661

Example runs with no API secret set:

```
~/Projects/upgrades/examples/propose-upgrade-on-defender (master)$ yarn hardhat console --network rinkeby
yarn run v1.19.1
$ /home/spalladino/Projects/upgrades/node_modules/.bin/hardhat console --network rinkeby
Welcome to Node.js v14.20.0.
Type ".help" for more information.
> 
(To exit, press Ctrl+C again or Ctrl+D or type .exit)
> 
Done in 2.78s.


~/Projects/upgrades/examples/propose-upgrade-on-defender (master)$ yarn hardhat run scripts/transparent.js --network rinkeby
yarn run v1.19.1
$ /home/spalladino/Projects/upgrades/node_modules/.bin/hardhat run scripts/transparent.js --network rinkeby
Proposing upgrade to V2...
Defender API key and secret are not set. Add the following to your hardhat.config.js exported configuration:
{
  "apiKey": "YOUR_API_KEY",
  "apiSecret": "YOUR_API_SECRET"
}

Error: API secret is required
    at new BaseApiClient (/home/spalladino/Projects/upgrades/node_modules/defender-base-client/lib/api/client.js:10:19)
    at new AdminClient (/home/spalladino/Projects/upgrades/node_modules/defender-admin-client/lib/api.js:7:1)
    at Proxy.proposeUpgrade (/home/spalladino/Projects/upgrades/packages/plugin-defender-hardhat/src/propose-upgrade.ts:43:20)
    at Object.handler.apply (/home/spalladino/Projects/upgrades/node_modules/hardhat/src/internal/util/lazy.ts:237:22)
    at proposeUpgrade (/home/spalladino/Projects/upgrades/examples/propose-upgrade-on-defender/scripts/transparent.js:32:35)
    at main (/home/spalladino/Projects/upgrades/examples/propose-upgrade-on-defender/scripts/transparent.js:45:3)
error Command failed with exit code 1.
```