### PR TITLE
Use underlying value when storage layout is not available

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
- - Use underlying type of user defined value types in the storage layout for layout comparison.
+ - Use underlying type of user defined value types in the storage layout for layout comparison. ([#682](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/682))
 
 ## 1.20.2 (2022-10-26)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+ - Use underlying type of user defined value types in the storage layout for layout comparison.
+
 ## 1.20.2 (2022-10-26)
 
 - Add underlying type of user defined value types in the storage layout. ([#681](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/681))

--- a/packages/core/contracts/test/Storage089.sol
+++ b/packages/core/contracts/test/Storage089.sol
@@ -12,3 +12,10 @@ contract Storage089_V2 {
 
   uint x;
 }
+
+contract Storage089_V3 {
+  type MyUserValueType is uint8;
+  MyUserValueType my_user_value;
+
+  uint x;
+}

--- a/packages/core/src/storage-0.8.test.ts
+++ b/packages/core/src/storage-0.8.test.ts
@@ -77,26 +77,23 @@ test('user defined value types - no layout info', async t => {
   t.snapshot(stabilizeStorageLayout(layout));
 });
 
-test('user defined value types - no layout info - bad upgrade from 0.8.8 to 0.8.9', async t => {
+test('user defined value types - no layout info - from 0.8.8 to 0.8.9', async t => {
   const v1 = await t.context.extractStorageLayout('Storage088', false);
   const v2 = await t.context.extractStorageLayout('Storage089', false);
   const comparison = getStorageUpgradeErrors(v1, v2);
-  t.like(comparison, {
-    length: 1,
-    0: {
-      kind: 'typechange',
-      change: {
-        kind: 'unknown',
-      },
-      original: { label: 'my_user_value' },
-      updated: { label: 'my_user_value' },
-    },
-  });
+  t.deepEqual(comparison, []);
 });
 
-test('user defined value types - no layout info - bad upgrade', async t => {
+test('user defined value types comparison - no layout info', async t => {
   const v1 = await t.context.extractStorageLayout('Storage089', false);
   const v2 = await t.context.extractStorageLayout('Storage089_V2', false);
+  const comparison = getStorageUpgradeErrors(v1, v2);
+  t.deepEqual(comparison, []);
+});
+
+test('user defined value types - no layout info - bad underlying type', async t => {
+  const v1 = await t.context.extractStorageLayout('Storage089', false);
+  const v2 = await t.context.extractStorageLayout('Storage089_V3', false);
   const comparison = getStorageUpgradeErrors(v1, v2);
   t.like(comparison, {
     length: 1,

--- a/packages/core/src/storage/compare.ts
+++ b/packages/core/src/storage/compare.ts
@@ -171,7 +171,7 @@ export class StorageLayoutComparator {
     const retypedFromOriginal = original.type.item.label === updated.retypedFrom?.trim();
     const typeChange = !retypedFromOriginal && this.getTypeChange(original.type, updated.type, { allowAppend: false });
     const layoutChange = this.getLayoutChange(original, updated);
-
+    
     if (updated.retypedFrom && layoutChange && (!layoutChange.uncertain || !layoutChange.knownCompatible)) {
       return { kind: 'layoutchange', original, updated, change: layoutChange, cost: LAYOUTCHANGE_COST };
     } else if (nameChange && endMatchesGap(original, updated)) {
@@ -362,6 +362,9 @@ export class StorageLayoutComparator {
       }
 
       case 't_userDefinedValueType': {
+        if(original.item.underlying && updated.item.underlying && original.item.underlying.id == updated.item.underlying.id){
+          return undefined;
+        }
         if (original.item.numberOfBytes === undefined || updated.item.numberOfBytes === undefined) {
           return { kind: 'unknown', original, updated };
         }

--- a/packages/core/src/storage/compare.ts
+++ b/packages/core/src/storage/compare.ts
@@ -363,8 +363,8 @@ export class StorageLayoutComparator {
 
       case 't_userDefinedValueType': {
         const underlyingMatch =
-          original.item.underlying &&
-          updated.item.underlying &&
+          original.item.underlying !== undefined &&
+          updated.item.underlying !== undefined &&
           original.item.underlying.id === updated.item.underlying.id;
 
         if (

--- a/packages/core/src/storage/compare.ts
+++ b/packages/core/src/storage/compare.ts
@@ -362,10 +362,9 @@ export class StorageLayoutComparator {
       }
 
       case 't_userDefinedValueType': {
-        if(original.item.underlying && updated.item.underlying && original.item.underlying.id == updated.item.underlying.id){
-          return undefined;
-        }
-        if (original.item.numberOfBytes === undefined || updated.item.numberOfBytes === undefined) {
+        const underlyingMatch = original.item.underlying && updated.item.underlying && original.item.underlying.id == updated.item.underlying.id;
+        
+        if ((original.item.numberOfBytes === undefined || updated.item.numberOfBytes === undefined) && !underlyingMatch) {
           return { kind: 'unknown', original, updated };
         }
         if (original.item.numberOfBytes !== updated.item.numberOfBytes) {

--- a/packages/core/src/storage/compare.ts
+++ b/packages/core/src/storage/compare.ts
@@ -365,7 +365,7 @@ export class StorageLayoutComparator {
         const underlyingMatch =
           original.item.underlying &&
           updated.item.underlying &&
-          original.item.underlying.id == updated.item.underlying.id;
+          original.item.underlying.id === updated.item.underlying.id;
 
         if (
           (original.item.numberOfBytes === undefined || updated.item.numberOfBytes === undefined) &&

--- a/packages/core/src/storage/compare.ts
+++ b/packages/core/src/storage/compare.ts
@@ -362,9 +362,15 @@ export class StorageLayoutComparator {
       }
 
       case 't_userDefinedValueType': {
-        const underlyingMatch = original.item.underlying && updated.item.underlying && original.item.underlying.id == updated.item.underlying.id;
-        
-        if ((original.item.numberOfBytes === undefined || updated.item.numberOfBytes === undefined) && !underlyingMatch) {
+        const underlyingMatch =
+          original.item.underlying &&
+          updated.item.underlying &&
+          original.item.underlying.id == updated.item.underlying.id;
+
+        if (
+          (original.item.numberOfBytes === undefined || updated.item.numberOfBytes === undefined) &&
+          !underlyingMatch
+        ) {
           return { kind: 'unknown', original, updated };
         }
         if (original.item.numberOfBytes !== updated.item.numberOfBytes) {

--- a/packages/core/src/storage/compare.ts
+++ b/packages/core/src/storage/compare.ts
@@ -171,7 +171,7 @@ export class StorageLayoutComparator {
     const retypedFromOriginal = original.type.item.label === updated.retypedFrom?.trim();
     const typeChange = !retypedFromOriginal && this.getTypeChange(original.type, updated.type, { allowAppend: false });
     const layoutChange = this.getLayoutChange(original, updated);
-    
+
     if (updated.retypedFrom && layoutChange && (!layoutChange.uncertain || !layoutChange.knownCompatible)) {
       return { kind: 'layoutchange', original, updated, change: layoutChange, cost: LAYOUTCHANGE_COST };
     } else if (nameChange && endMatchesGap(original, updated)) {


### PR DESCRIPTION
Support contracts that have user defined value types, when there is not a storage layout. Truffle does not provide a storage layout so in order to support user defined value types we need to use the underlying type to compare between the original and the updated contract.