### PR TITLE
Support multiple contracts with same name

### DIFF
--- a/docs/modules/ROOT/pages/api-core.adoc
+++ b/docs/modules/ROOT/pages/api-core.adoc
@@ -18,6 +18,8 @@ This class represents the implementation for an upgradeable contract and gives a
 new UpgradeableContract(name, solcInput, solcOutput, opts?);
 ```
 
+`name` is the name of the implementation contract as either a fully qualified name or contract name. If multiple contracts have the same name, you must use the fully qualified name e.g., `contracts/Bar.sol:Bar`
+
 `opts` is an object with options as defined in xref:api-hardhat-upgrades.adoc#common-options[Common Options].
 
 TIP: In Hardhat, `solcInput` and `solcOutput` can be obtained from the Build Info file, which itself can be retrieved with `hre.artifacts.getBuildInfo`.

--- a/docs/modules/ROOT/pages/api-core.adoc
+++ b/docs/modules/ROOT/pages/api-core.adoc
@@ -18,7 +18,7 @@ This class represents the implementation for an upgradeable contract and gives a
 new UpgradeableContract(name, solcInput, solcOutput, opts?);
 ```
 
-`name` is the name of the implementation contract as either a fully qualified name or contract name. If multiple contracts have the same name, you must use the fully qualified name e.g., `contracts/Bar.sol:Bar`
+`name` is the name of the implementation contract as either a fully qualified name or contract name. If multiple contracts have the same name, you must use the fully qualified name e.g., `contracts/Bar.sol:Bar`.
 
 `opts` is an object with options as defined in xref:api-hardhat-upgrades.adoc#common-options[Common Options].
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support multiple contracts with same name. ([#263](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/263))
+
 ## 1.20.3 (2022-11-02)
 
 - Use underlying type of user defined value types in the storage layout for layout comparison. ([#682](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/682))

--- a/packages/core/contracts/test/ValidationsSameNameSafe.sol
+++ b/packages/core/contracts/test/ValidationsSameNameSafe.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.8;
+
+// This helps the tests by hinting Hardhat to compile the two files together.
+import './Storage.sol';
+
+contract SameName {
+  function d() public {
+  }
+}

--- a/packages/core/contracts/test/ValidationsSameNameUnsafe.sol
+++ b/packages/core/contracts/test/ValidationsSameNameUnsafe.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.8;
+
+// This helps the tests by hinting Hardhat to compile the two files together.
+import './Storage.sol';
+
+contract SameName {
+  function d() public {
+    (bool s, ) = msg.sender.delegatecall("");
+    s;
+  }
+}

--- a/packages/core/src/manifest-storage-layout.test.ts
+++ b/packages/core/src/manifest-storage-layout.test.ts
@@ -28,7 +28,7 @@ test.before(async t => {
 });
 
 test('getStorageLayoutForAddress - update layout', async t => {
-  const { version } = t.context.validationRun['ManifestMigrateUnique'];
+  const { version } = t.context.validationRun['contracts/test/ManifestMigrate.sol:ManifestMigrateUnique'];
   assert(version !== undefined);
   const updatedLayout = getStorageLayout(t.context.validationData, version);
   const outdatedLayout = removeStorageLayoutMembers(updatedLayout);
@@ -60,7 +60,7 @@ test('getStorageLayoutForAddress - update layout', async t => {
 });
 
 test('getUpdatedLayout - unique layout match', async t => {
-  const { version } = t.context.validationRun['ManifestMigrateUnique'];
+  const { version } = t.context.validationRun['contracts/test/ManifestMigrate.sol:ManifestMigrateUnique'];
   assert(version !== undefined);
   const targetLayout = getStorageLayout(t.context.validationData, version);
   const outdatedLayout = removeStorageLayoutMembers(targetLayout);
@@ -69,8 +69,10 @@ test('getUpdatedLayout - unique layout match', async t => {
 });
 
 test('getUpdatedLayout - multiple unambiguous layout matches', async t => {
-  const { version: version1 } = t.context.validationRun['ManifestMigrateUnambiguous1'];
-  const { version: version2 } = t.context.validationRun['ManifestMigrateUnambiguous2'];
+  const { version: version1 } =
+    t.context.validationRun['contracts/test/ManifestMigrate.sol:ManifestMigrateUnambiguous1'];
+  const { version: version2 } =
+    t.context.validationRun['contracts/test/ManifestMigrate.sol:ManifestMigrateUnambiguous2'];
   assert(version1 !== undefined && version2 !== undefined);
   t.is(version1.withoutMetadata, version2.withoutMetadata, 'version is meant to be ambiguous');
   t.not(version1.withMetadata, version2.withMetadata, 'version with metadata should be different');
@@ -81,8 +83,8 @@ test('getUpdatedLayout - multiple unambiguous layout matches', async t => {
 });
 
 test('getUpdatedLayout - multiple ambiguous layout matches', async t => {
-  const { version: version1 } = t.context.validationRun['ManifestMigrateAmbiguous1'];
-  const { version: version2 } = t.context.validationRun['ManifestMigrateAmbiguous2'];
+  const { version: version1 } = t.context.validationRun['contracts/test/ManifestMigrate.sol:ManifestMigrateAmbiguous1'];
+  const { version: version2 } = t.context.validationRun['contracts/test/ManifestMigrate.sol:ManifestMigrateAmbiguous2'];
   assert(version1 !== undefined && version2 !== undefined);
   t.is(version1.withoutMetadata, version2.withoutMetadata, 'version is meant to be ambiguous');
   t.not(version1.withMetadata, version2.withMetadata, 'version with metadata should be different');

--- a/packages/core/src/standalone.test.ts
+++ b/packages/core/src/standalone.test.ts
@@ -27,6 +27,17 @@ test('reports unsafe operation', t => {
   t.true(report.errors[0].kind === 'delegatecall');
 });
 
+test('reports unsafe operation - fully qualified name', t => {
+  const impl = new UpgradeableContract(
+    'contracts/test/Standalone.sol:StandaloneV1',
+    t.context.solcInput,
+    t.context.solcOutput,
+  );
+  const report = impl.getErrorReport();
+  t.false(report.ok);
+  t.true(report.errors[0].kind === 'delegatecall');
+});
+
 test('reports storage upgrade errors', t => {
   const v1 = new UpgradeableContract('StandaloneV1', t.context.solcInput, t.context.solcOutput);
 

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -133,3 +133,17 @@ testValid('UsesExplicitSafeExternalLibraryNatspec', 'transparent', true);
 testValid('UsesExplicitUnsafeInternalLibraryNatspec', 'transparent', true);
 testValid('UsesExplicitUnsafeExternalLibraryNatspec', 'transparent', true);
 testValid('TransitiveLibraryIsUnsafe', 'transparent', false);
+
+testValid('contracts/test/ValidationsSameNameSafe.sol:SameName', 'transparent', true);
+testValid('contracts/test/ValidationsSameNameUnsafe.sol:SameName', 'transparent', false);
+
+test('ambiguous name', t => {
+  const getAmbiguousName = () => getContractVersion(t.context.validation, 'SameName');
+  const error = t.throws(getAmbiguousName);
+  t.is(
+    error?.message,
+    'Contract SameName is ambiguous. Use one of the following:\n' +
+      'contracts/test/ValidationsSameNameSafe.sol:SameName\n' +
+      'contracts/test/ValidationsSameNameUnsafe.sol:SameName',
+  );
+});

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -138,8 +138,7 @@ testValid('contracts/test/ValidationsSameNameSafe.sol:SameName', 'transparent', 
 testValid('contracts/test/ValidationsSameNameUnsafe.sol:SameName', 'transparent', false);
 
 test('ambiguous name', t => {
-  const getAmbiguousName = () => getContractVersion(t.context.validation, 'SameName');
-  const error = t.throws(getAmbiguousName);
+  const error = t.throws(() => getContractVersion(t.context.validation, 'SameName'));
   t.is(
     error?.message,
     'Contract SameName is ambiguous. Use one of the following:\n' +

--- a/packages/core/src/validate/data.ts
+++ b/packages/core/src/validate/data.ts
@@ -7,10 +7,10 @@ type ValidationDataV1 = ValidationRunData;
 type ValidationDataV2 = ValidationRunData[];
 
 const currentMajor = '3';
-const currentVersion = '3.3';
+const currentVersion = '3.4';
 
 interface ValidationDataV3 {
-  version: '3' | '3.1' | '3.2' | '3.3';
+  version: '3' | '3.1' | '3.2' | '3.3' | '3.4';
   log: ValidationRunData[];
 }
 

--- a/packages/core/src/validate/query.ts
+++ b/packages/core/src/validate/query.ts
@@ -33,11 +33,7 @@ export function getContractVersion(runData: ValidationRunData, contractName: str
   if (contractName.includes(':')) {
     version = runData[contractName].version;
   } else {
-    const foundNames = Object.keys(runData).filter(element => {
-      if (element.endsWith(`:${contractName}`)) {
-        return true;
-      }
-    });
+    const foundNames = Object.keys(runData).filter(element => element.endsWith(`:${contractName}`));
     if (foundNames.length > 1) {
       throw new Error(`Contract ${contractName} is ambiguous. Use one of the following:\n${foundNames.join('\n')}`);
     } else if (foundNames.length === 1) {

--- a/packages/core/src/validate/query.ts
+++ b/packages/core/src/validate/query.ts
@@ -11,54 +11,85 @@ const upgradeToSignature = 'upgradeTo(address)';
 
 export function assertUpgradeSafe(data: ValidationData, version: Version, opts: ValidationOptions): void {
   const dataV3 = normalizeValidationData(data);
-  const [contractName] = getContractNameAndRunValidation(dataV3, version);
+  const [fullContractName] = getContractNameAndRunValidation(dataV3, version);
 
   const errors = getErrors(dataV3, version, opts);
 
   if (errors.length > 0) {
-    throw new ValidationErrors(contractName, errors);
+    throw new ValidationErrors(fullContractName, errors);
   }
 }
 
+/**
+ * Gets the contract version object from the given validation run data and contract name (either fully qualified or simple contract name).
+ *
+ * @param runData The validation run data
+ * @param contractName Fully qualified or simple contract name
+ * @returns contract version object
+ * @throws {Error} if the given contract name is not found or is ambiguous
+ */
 export function getContractVersion(runData: ValidationRunData, contractName: string): Version {
-  const { version } = runData[contractName];
+  let version = undefined;
+  if (contractName.includes(':')) {
+    version = runData[contractName].version;
+  } else {
+    const foundNames = Object.keys(runData).filter(element => {
+      if (element.endsWith(`:${contractName}`)) {
+        return true;
+      }
+    });
+    if (foundNames.length > 1) {
+      throw new Error(`Contract ${contractName} is ambiguous. Use one of the following:\n${foundNames.join('\n')}`);
+    } else if (foundNames.length === 1) {
+      version = runData[foundNames[0]].version;
+    }
+  }
+
   if (version === undefined) {
     throw new Error(`Contract ${contractName} is abstract`);
   }
+
   return version;
 }
 
+/**
+ * Gets the fully qualified contract name and validation run data.
+ *
+ * @param data The validation data
+ * @param version The contract Version
+ * @returns fully qualified contract name and validation run data
+ */
 export function getContractNameAndRunValidation(data: ValidationData, version: Version): [string, ValidationRunData] {
   const dataV3 = normalizeValidationData(data);
 
   let runValidation;
-  let contractName;
+  let fullContractName;
 
   for (const validation of dataV3.log) {
-    contractName = Object.keys(validation).find(
+    fullContractName = Object.keys(validation).find(
       name => validation[name].version?.withMetadata === version.withMetadata,
     );
-    if (contractName !== undefined) {
+    if (fullContractName !== undefined) {
       runValidation = validation;
       break;
     }
   }
 
-  if (contractName === undefined || runValidation === undefined) {
+  if (fullContractName === undefined || runValidation === undefined) {
     throw new Error('The requested contract was not found. Make sure the source code is available for compilation');
   }
 
-  return [contractName, runValidation];
+  return [fullContractName, runValidation];
 }
 
 export function getStorageLayout(data: ValidationData, version: Version): StorageLayout {
   const dataV3 = normalizeValidationData(data);
-  const [contractName, runValidation] = getContractNameAndRunValidation(dataV3, version);
-  return unfoldStorageLayout(runValidation, contractName);
+  const [fullContractName, runValidation] = getContractNameAndRunValidation(dataV3, version);
+  return unfoldStorageLayout(runValidation, fullContractName);
 }
 
-export function unfoldStorageLayout(runData: ValidationRunData, contractName: string): StorageLayout {
-  const c = runData[contractName];
+export function unfoldStorageLayout(runData: ValidationRunData, fullContractName: string): StorageLayout {
+  const c = runData[fullContractName];
   const { solcVersion } = c;
   if (c.layout.flat) {
     return {
@@ -68,7 +99,7 @@ export function unfoldStorageLayout(runData: ValidationRunData, contractName: st
     };
   } else {
     const layout: StorageLayout = { solcVersion, storage: [], types: {} };
-    for (const name of [contractName].concat(c.inherit)) {
+    for (const name of [fullContractName].concat(c.inherit)) {
       layout.storage.unshift(...runData[name].layout.storage);
       Object.assign(layout.types, runData[name].layout.types);
     }
@@ -113,12 +144,14 @@ export function getUnlinkedBytecode(data: ValidationData, bytecode: string): str
 
 export function getErrors(data: ValidationData, version: Version, opts: ValidationOptions = {}): ValidationError[] {
   const dataV3 = normalizeValidationData(data);
-  const [contractName, runValidation] = getContractNameAndRunValidation(dataV3, version);
-  const c = runValidation[contractName];
+  const [fullContractName, runValidation] = getContractNameAndRunValidation(dataV3, version);
+  const c = runValidation[fullContractName];
 
-  const errors = getUsedContractsAndLibraries(contractName, runValidation).flatMap(name => runValidation[name].errors);
+  const errors = getUsedContractsAndLibraries(fullContractName, runValidation).flatMap(
+    name => runValidation[name].errors,
+  );
 
-  const selfAndInheritedMethods = getAllMethods(runValidation, contractName);
+  const selfAndInheritedMethods = getAllMethods(runValidation, fullContractName);
 
   if (!selfAndInheritedMethods.includes(upgradeToSignature)) {
     errors.push({
@@ -127,11 +160,11 @@ export function getErrors(data: ValidationData, version: Version, opts: Validati
     });
   }
 
-  return processExceptions(contractName, errors, opts);
+  return processExceptions(fullContractName, errors, opts);
 }
 
-function getAllMethods(runValidation: ValidationRunData, contractName: string): string[] {
-  const c = runValidation[contractName];
+function getAllMethods(runValidation: ValidationRunData, fullContractName: string): string[] {
+  const c = runValidation[fullContractName];
   return c.methods.concat(...c.inherit.map(name => runValidation[name].methods));
 }
 
@@ -155,8 +188,8 @@ export function isUpgradeSafe(data: ValidationData, version: Version): boolean {
 
 export function inferProxyKind(data: ValidationData, version: Version): ProxyDeployment['kind'] {
   const dataV3 = normalizeValidationData(data);
-  const [contractName, runValidation] = getContractNameAndRunValidation(dataV3, version);
-  const methods = getAllMethods(runValidation, contractName);
+  const [fullContractName, runValidation] = getContractNameAndRunValidation(dataV3, version);
+  const methods = getAllMethods(runValidation, fullContractName);
   if (methods.includes(upgradeToSignature)) {
     return 'uups';
   } else {

--- a/packages/plugin-hardhat/test/implementation-functions.js
+++ b/packages/plugin-hardhat/test/implementation-functions.js
@@ -12,6 +12,10 @@ test.before(async t => {
   t.context.GreeterStorageConflictProxiable = await ethers.getContractFactory('GreeterStorageConflictProxiable');
 });
 
+function getUpgradeUnsafeRegex(contractName) {
+  return new RegExp(`Contract \`.*:${contractName}\` is not upgrade safe`);
+}
+
 test('validate implementation - happy paths', async t => {
   const { Greeter, GreeterProxiable } = t.context;
 
@@ -26,7 +30,7 @@ test('validate implementation - invalid', async t => {
   const { Invalid } = t.context;
 
   await t.throwsAsync(() => upgrades.validateImplementation(Invalid), {
-    message: /(Contract `Invalid` is not upgrade safe)/,
+    message: getUpgradeUnsafeRegex('Invalid'),
   });
 });
 
@@ -34,7 +38,7 @@ test('validate implementation uups - no upgrade function', async t => {
   const { Greeter } = t.context;
 
   await t.throwsAsync(() => upgrades.validateImplementation(Greeter, { kind: 'uups' }), {
-    message: /(Contract `Greeter` is not upgrade safe)/,
+    message: getUpgradeUnsafeRegex('Greeter'),
   });
 });
 
@@ -91,14 +95,14 @@ test('deploy implementation - invalid', async t => {
   const { Invalid } = t.context;
 
   await t.throwsAsync(() => upgrades.deployImplementation(Invalid), {
-    message: /(Contract `Invalid` is not upgrade safe)/,
+    message: getUpgradeUnsafeRegex('Invalid'),
   });
 });
 
 test('deploy implementation uups - no upgrade function', async t => {
   const { Greeter } = t.context;
   await t.throwsAsync(() => upgrades.deployImplementation(Greeter, { kind: 'uups' }), {
-    message: /(Contract `Greeter` is not upgrade safe)/,
+    message: getUpgradeUnsafeRegex('Greeter'),
   });
 });
 
@@ -185,7 +189,7 @@ test('validate upgrade uups - no upgrade function', async t => {
 
   const greeter = await upgrades.deployProxy(GreeterProxiable, ['Hola mundo!']);
   await t.throwsAsync(() => upgrades.validateUpgrade(greeter, GreeterV2, { kind: 'uups' }), {
-    message: /(Contract `GreeterV2` is not upgrade safe)/,
+    message: getUpgradeUnsafeRegex('GreeterV2'),
   });
 });
 
@@ -214,7 +218,7 @@ test('validate upgrade - contracts only - uups inferred - no upgrade function', 
   const { GreeterProxiable, GreeterV2 } = t.context;
 
   await t.throwsAsync(() => upgrades.validateUpgrade(GreeterProxiable, GreeterV2), {
-    message: /(Contract `GreeterV2` is not upgrade safe)/,
+    message: getUpgradeUnsafeRegex('GreeterV2'),
   });
 });
 
@@ -222,7 +226,7 @@ test('validate upgrade - contracts only - uups - no upgrade function', async t =
   const { GreeterProxiable, GreeterV2 } = t.context;
 
   await t.throwsAsync(() => upgrades.validateUpgrade(GreeterProxiable, GreeterV2, { kind: 'uups' }), {
-    message: /(Contract `GreeterV2` is not upgrade safe)/,
+    message: getUpgradeUnsafeRegex('GreeterV2'),
   });
 });
 
@@ -269,6 +273,6 @@ test('validate upgrade on deployed implementation - kind uups - no upgrade funct
 
   const greeter = await upgrades.deployImplementation(GreeterProxiable);
   await t.throwsAsync(() => upgrades.validateUpgrade(greeter, GreeterV2, { kind: 'uups' }), {
-    message: /(Contract `GreeterV2` is not upgrade safe)/,
+    message: getUpgradeUnsafeRegex('GreeterV2'),
   });
 });

--- a/packages/plugin-truffle/test/test/implementation-functions.js
+++ b/packages/plugin-truffle/test/test/implementation-functions.js
@@ -17,6 +17,10 @@ const Invalid = artifacts.require('Invalid');
 const GreeterStorageConflict = artifacts.require('GreeterStorageConflict');
 const GreeterStorageConflictProxiable = artifacts.require('GreeterStorageConflictProxiable');
 
+function getUpgradeUnsafeRegex(contractName) {
+  return new RegExp(`Contract \`.*:${contractName}\` is not upgrade safe`);
+}
+
 contract('Greeter', function () {
   it('validate implementation - happy paths', async function () {
     await validateImplementation(Greeter);
@@ -28,13 +32,13 @@ contract('Greeter', function () {
 
   it('validate implementation - invalid', async function () {
     await assert.rejects(validateImplementation(Invalid), error =>
-      error.message.includes('Contract `Invalid` is not upgrade safe'),
+      getUpgradeUnsafeRegex('Invalid').test(error.message),
     );
   });
 
   it('validate implementation uups - no upgrade function', async function () {
     await assert.rejects(validateImplementation(Greeter, { kind: 'uups' }), error =>
-      error.message.includes('Contract `Greeter` is not upgrade safe'),
+      getUpgradeUnsafeRegex('Greeter').test(error.message),
     );
   });
 
@@ -66,14 +70,12 @@ contract('Greeter', function () {
   });
 
   it('deploy implementation - invalid', async function () {
-    await assert.rejects(deployImplementation(Invalid), error =>
-      error.message.includes('Contract `Invalid` is not upgrade safe'),
-    );
+    await assert.rejects(deployImplementation(Invalid), error => getUpgradeUnsafeRegex('Invalid').test(error.message));
   });
 
   it('deploy implementation uups - no upgrade function', async function () {
     await assert.rejects(deployImplementation(Greeter, { kind: 'uups' }), error =>
-      error.message.includes('Contract `Greeter` is not upgrade safe'),
+      getUpgradeUnsafeRegex('Greeter').test(error.message),
     );
   });
 
@@ -138,7 +140,7 @@ contract('Greeter', function () {
   it('validate upgrade uups - no upgrade function', async function () {
     const greeter = await deployProxy(GreeterProxiable, ['Hello, Hardhat!']);
     await assert.rejects(validateUpgrade(greeter, GreeterV2, { kind: 'uups' }), error =>
-      error.message.includes('Contract `GreeterV2` is not upgrade safe'),
+      getUpgradeUnsafeRegex('GreeterV2').test(error.message),
     );
   });
 
@@ -159,13 +161,13 @@ contract('Greeter', function () {
 
   it('validate upgrade - uups contracts only - uups inferred - no upgrade function', async function () {
     await assert.rejects(validateUpgrade(GreeterProxiable, GreeterV2), error =>
-      error.message.includes('Contract `GreeterV2` is not upgrade safe'),
+      getUpgradeUnsafeRegex('GreeterV2').test(error.message),
     );
   });
 
   it('validate upgrade - uups contracts only - uups - no upgrade function', async function () {
     await assert.rejects(validateUpgrade(GreeterProxiable, GreeterV2, { kind: 'uups' }), error =>
-      error.message.includes('Contract `GreeterV2` is not upgrade safe'),
+      getUpgradeUnsafeRegex('GreeterV2').test(error.message),
     );
   });
 
@@ -199,7 +201,7 @@ contract('Greeter', function () {
   it('validate upgrade on deployed implementation - kind uups - no upgrade function', async function () {
     const greeter = await deployImplementation(GreeterProxiable);
     await assert.rejects(validateUpgrade(greeter, GreeterV2, { kind: 'uups' }), error =>
-      error.message.includes('Contract `GreeterV2` is not upgrade safe'),
+      getUpgradeUnsafeRegex('GreeterV2').test(error.message),
     );
   });
 });


### PR DESCRIPTION
Validations were stored as a map with the contract names as the keys.  However, there could be multiple contracts with the same name in different Solidity files, which can lead to the wrong contract being validated.  Instead, use fully qualified contract names (e.g. `path/file.sol:ContractName`) as the keys instead.

Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/263