### PR TITLE
Avoid printing empty hint

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix display issue in storage layout reports. ([#699](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/699))
+
 ## 1.20.5 (2022-11-25)
 
 - Fix incompatible type error when upgrading from mapping with strings ([#689](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/689))

--- a/packages/core/src/storage/report.ts
+++ b/packages/core/src/storage/report.ts
@@ -73,12 +73,10 @@ function getExpectedGapSize(original: StorageField, updated: StorageField) {
   return expectedSizeBytes / bytesPerItem;
 }
 
-function suggestGapSize(original: StorageField, updated: StorageField): string {
+function suggestGapSize(original: StorageField, updated: StorageField): string | undefined {
   const expectedSize = getExpectedGapSize(original, updated);
   if (expectedSize !== undefined) {
     return `Set __gap array to size ${expectedSize}`;
-  } else {
-    return '';
   }
 }
 
@@ -97,7 +95,10 @@ function explainStorageOperation(op: StorageOperation<StorageField>, ctx: Storag
           : [];
       const hints = [];
       if (isGap(op.original) && op.change.kind === 'array shrink') {
-        hints.push(suggestGapSize(op.original, op.updated));
+        const suggestion = suggestGapSize(op.original, op.updated);
+        if (suggestion) {
+          hints.push(suggestion);
+        }
       }
       return printWithHints({
         title: `Upgraded ${label(op.updated)} to an incompatible type\n` + itemize(basic, ...details),

--- a/packages/core/src/storage/report.ts
+++ b/packages/core/src/storage/report.ts
@@ -123,7 +123,10 @@ function explainStorageOperation(op: StorageOperation<StorageField>, ctx: Storag
       const hints = [];
 
       if (isGap(op.original)) {
-        hints.push(suggestGapSize(op.original, op.updated));
+        const suggestion = suggestGapSize(op.original, op.updated);
+        if (suggestion) {
+          hints.push(suggestion);
+        }
       }
 
       return printWithHints({ title, hints });


### PR DESCRIPTION
Fixing small storage report error seen [in the forum](https://forum.openzeppelin.com/t/bad-storage-gap-resize/33668/5?u=frangio):

![image](https://user-images.githubusercontent.com/481465/207440502-2fc2d65a-6022-47ed-b0bd-9a8cfc0fd92c.png)

(Notice empty `>` line.)