### PR TITLE
Handle getLogs error for blockscout explorer

### DIFF
--- a/packages/plugin-hardhat/src/verify-proxy.ts
+++ b/packages/plugin-hardhat/src/verify-proxy.ts
@@ -467,7 +467,7 @@ async function getContractCreationTxHash(
   if (responseBody.status === RESPONSE_OK) {
     const result = responseBody.result;
     return result[0].transactionHash; // get the txhash from the first instance of this event
-  } else if (responseBody.message === 'No records found') {
+  } else if (responseBody.message === 'No records found' || responseBody.message === 'No logs found') {
     debug(`no result found for event topic ${topic} at address ${address}`);
     return undefined;
   } else {


### PR DESCRIPTION
https://github.com/blockscout/blockscout/blob/620178117fc008d0a926fb0c989864515f897487/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/logs_controller.ex#L6-L22

blockscout will return `No logs found` error message if no logs for the request.