### PR TITLE
Improve regex for unsafe-allow annotations

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add support for celo and celo-alfajores to manifest file names. ([#710](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/710))
 - Only consider errors from functions in use. Validate free functions. ([#702](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/702))
-- Improve handling of NatSpec comments. ([#717](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/717))
+- Improve handling of NatSpec comments. ([#717](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/717)) ([#720](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/720))
 
 ## 1.20.6 (2022-12-15)
 

--- a/packages/core/src/validate/run.test.ts
+++ b/packages/core/src/validate/run.test.ts
@@ -40,3 +40,10 @@ test('getAnnotationArgs multiline with spaces and comments', t => {
   t.deepEqual(getAnnotationArgs(doc, 'oz-upgrades-unsafe-allow'), ['constructor', 'selfdestruct']);
   t.deepEqual(getAnnotationArgs(doc, 'oz-upgrades-unsafe-allow-reachable'), ['delegatecall']);
 });
+
+test('getAnnotationArgs multiline multiple preceding spaces', t => {
+  const doc =
+    ' @custom:oz-upgrades-unsafe-allow constructor selfdestruct \n         @custom:oz-upgrades-unsafe-allow-reachable delegatecall    ';
+  t.deepEqual(getAnnotationArgs(doc, 'oz-upgrades-unsafe-allow'), ['constructor', 'selfdestruct']);
+  t.deepEqual(getAnnotationArgs(doc, 'oz-upgrades-unsafe-allow-reachable'), ['delegatecall']);
+});

--- a/packages/core/src/validate/run.ts
+++ b/packages/core/src/validate/run.ts
@@ -120,7 +120,7 @@ function getAllowed(node: Node, reachable: boolean): string[] {
 export function getAnnotationArgs(doc: string, tag: string) {
   const result: string[] = [];
   for (const { groups } of execall(
-    /^\s*(?:@(?<title>\w+)(?::(?<tag>[a-z][a-z-]*))? )?(?<args>(?:(?!^\s@\w+)[^])*)/m,
+    /^\s*(?:@(?<title>\w+)(?::(?<tag>[a-z][a-z-]*))? )?(?<args>(?:(?!^\s*@\w+)[^])*)/m,
     doc,
   )) {
     if (groups && groups.title === 'custom' && groups.tag === tag) {


### PR DESCRIPTION
Fixes the case where
```
/**
 * @custom:oz-upgrades-unsafe-allow constructor
 *     @custom:oz-upgrades-unsafe-allow-reachable delegatecall
 */
```
gives an error:
```
NatSpec: oz-upgrades-unsafe-allow argument not recognized: @custom:oz-upgrades-unsafe-allow-reachable
```