### PR TITLE
Fix runtime type error on undefined source

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for celo and celo-alfajores to manifest file names. ([#710](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/710))
 - Only consider errors from functions in use. Validate free functions. ([#702](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/702))
 - Improve handling of NatSpec comments. ([#717](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/717)) ([#720](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/720))
+- Fix runtime type error. ([#721](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/721))
 
 ## 1.20.6 (2022-12-15)
 

--- a/packages/core/src/src-decoder.ts
+++ b/packages/core/src/src-decoder.ts
@@ -19,7 +19,7 @@ export function solcInputOutputDecoder(solcInput: SolcInput, solcOutput: SolcOut
       if (sourcePath === undefined) {
         throw new Error(`Source file not available`);
       }
-      const content = solcInput.sources[sourcePath].content;
+      const content = solcInput.sources[sourcePath]?.content;
       const name = path.relative(basePath, sourcePath);
       if (content === undefined) {
         throw new Error(`Content for ${name} not available`);


### PR DESCRIPTION
See https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/713.

This does not fix the issue (I don't know what the issue is) but it properly catches the error instead of causing a TypeError and should give us the name of the file that's causing the issue.