### PR TITLE
Use global caches for opcode validations

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improve compilation performance for validations. ([#724](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/724))
+
 ## 1.21.0 (2023-01-18)
 
 - Add support for celo and celo-alfajores to manifest file names. ([#710](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/710))

--- a/packages/core/src/validate/run.ts
+++ b/packages/core/src/validate/run.ts
@@ -302,9 +302,7 @@ function* getContractOpcodeErrors(
 function* getCached(key: number, scope: string, cache: Cache) {
   const cached = scope === 'main' ? cache.mainContractErrors.get(key) : cache.inheritedContractErrors.get(key);
   if (cached !== undefined) {
-    for (const r of cached) {
-      yield r;
-    }
+    yield* cached;
   } // else the node is currently being visited at a shallower level of recursion, so no need to report its errors at this level
 }
 
@@ -386,9 +384,7 @@ function* cacheAndYieldResult(key: number, scope: string, cache: Cache, result: 
   } else {
     cache.inheritedContractErrors.set(key, result);
   }
-  for (const r of result) {
-    yield r;
-  }
+  yield* result;
 }
 
 function tryDerefFunction(deref: ASTDereferencer, referencedDeclaration: number): FunctionDefinition | undefined {

--- a/packages/core/src/validate/run.ts
+++ b/packages/core/src/validate/run.ts
@@ -264,7 +264,7 @@ function* getOpcodeErrors(
   decodeSrc: SrcDecoder,
   delegateCallCache: OpcodeCache,
   selfDestructCache: OpcodeCache,
-): Generator<ValidationErrorOpcode> {
+): Generator<ValidationErrorOpcode, void, undefined> {
   yield* getContractOpcodeErrors(contractDef, deref, decodeSrc, OPCODES.delegatecall, 'main', delegateCallCache);
   yield* getContractOpcodeErrors(contractDef, deref, decodeSrc, OPCODES.selfdestruct, 'main', selfDestructCache);
 }
@@ -281,7 +281,7 @@ function* getContractOpcodeErrors(
   opcode: OpcodePattern,
   scope: Scope,
   cache: OpcodeCache,
-): Generator<ValidationErrorOpcode> {
+): Generator<ValidationErrorOpcode, void, undefined> {
   if (wasVisited(contractDef.id, scope, cache.visitedNodeIds)) {
     yield* getCached(contractDef.id, scope, cache);
   } else {
@@ -312,7 +312,7 @@ function* getFunctionOpcodeErrors(
   opcode: OpcodePattern,
   scope: Scope,
   cache: OpcodeCache,
-): Generator<ValidationErrorOpcode> {
+): Generator<ValidationErrorOpcode, void, undefined> {
   const parentContractDef = getParentDefinition(deref, contractOrFunctionDef);
   if (parentContractDef === undefined || !skipCheck(opcode.kind, parentContractDef)) {
     yield* getDirectFunctionOpcodeErrors(contractOrFunctionDef, decodeSrc, opcode, scope);


### PR DESCRIPTION
Improves compilation performance by using global caches for delegatecall and selfdestruct opcodes during validations. 

Fixes LIB-648