### PR TITLE
Document function params, options, returns, and since version

### DIFF
--- a/docs/modules/ROOT/pages/api-core.adoc
+++ b/docs/modules/ROOT/pages/api-core.adoc
@@ -13,39 +13,50 @@ import { UpgradeableContract } from '@openzeppelin/upgrades-core';
 
 This class represents the implementation for an upgradeable contract and gives access to error reports.
 
+=== new UpgradeableContract
 [.hljs-theme-light.nopadding]
 ```javascript
 new UpgradeableContract(name, solcInput, solcOutput, opts?);
 ```
 
-`name` is the name of the implementation contract as either a fully qualified name or contract name. If multiple contracts have the same name, you must use the fully qualified name e.g., `contracts/Bar.sol:Bar`.
+Creates a new instance of `UpgradeableContract`.
 
-`opts` is an object with options as defined in xref:api-hardhat-upgrades.adoc#common-options[Common Options].
+*Parameters:*
+
+* `name` - the name of the implementation contract as either a fully qualified name or contract name. If multiple contracts have the same name, you must use the fully qualified name e.g., `contracts/Bar.sol:Bar`.
+* `solcInput` - the Solidity input JSON object for the implementation contract.
+* `solcOutput` - the Solidity output JSON object for the implementation contract.
+* `opts` - an object with options as defined in xref:api-hardhat-upgrades.adoc#common-options[Common Options].
 
 TIP: In Hardhat, `solcInput` and `solcOutput` can be obtained from the Build Info file, which itself can be retrieved with `hre.artifacts.getBuildInfo`.
 
 === getErrorReport
-
-Returns a report about errors pertaining to proxied contracts, e.g. the use of `selfdestruct`.
-
 [.hljs-theme-light.nopadding]
 ```javascript
 contract.getErrorReport()
 ```
 
+**Returns:**
+
+* a report about errors pertaining to proxied contracts, e.g. the use of `selfdestruct`.
+
 === getStorageUpgradeReport
-
-Compares the storage layout of an upgradeable contract with that of a proposed upgrade. Receives as an argument another instance of `UpgradeableContract`.
-
 [.hljs-theme-light.nopadding]
 ```javascript
 contract.getStorageUpgradeReport(upgradedContract)
 ```
 
+Compares the storage layout of an upgradeable contract with that of a proposed upgrade.
+
+*Parameters:*
+
+* `upgradedContract` - another instance of `UpgradeableContract` representing the proposed upgrade.
+
+**Returns:**
+
+* a report about errors pertaining to proxied contracts, e.g. the use of `selfdestruct`, and storage layout conflicts.
+
 == Report
-
-An object that represents the results of an analysis.
-
 [.hljs-theme-light.nopadding]
 ```typescript
 interface Report {
@@ -54,7 +65,11 @@ interface Report {
 }
 ```
 
-The field `ok` is `false` if any errors were found, and `true` otherwise.
+An object that represents the results of an analysis.
 
-The method `explain()` will return a message explaining the errors in detail, if any.
+**Members:**
+
+* `ok` - `false` if any errors were found, otherwise `true`.
+
+* `explain()` - returns a message explaining the errors in detail, if any.
 

--- a/docs/modules/ROOT/pages/api-core.adoc
+++ b/docs/modules/ROOT/pages/api-core.adoc
@@ -43,7 +43,7 @@ TIP: In Hardhat, `solcInput` and `solcOutput` can be obtained from the Build Inf
 === .getErrorReport
 [source,ts]
 ----
-.getErrorReport(): Report
+getErrorReport(): Report
 ----
 
 **Returns:**
@@ -53,7 +53,7 @@ TIP: In Hardhat, `solcInput` and `solcOutput` can be obtained from the Build Inf
 === .getStorageUpgradeReport
 [source,ts]
 ----
-.getStorageUpgradeReport(
+getStorageUpgradeReport(
   upgradedContract: UpgradeableContract,
   opts?: {
     unsafeAllow?: ValidationError[],

--- a/docs/modules/ROOT/pages/api-core.adoc
+++ b/docs/modules/ROOT/pages/api-core.adoc
@@ -4,16 +4,18 @@ The core logic to check for upgrade safety as well as storage layout compatibili
 
 The package exports a standalone interface that works with https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description[Solidity input and output JSON objects].
 
-```javascript
+[source,ts]
+----
 import { UpgradeableContract } from '@openzeppelin/upgrades-core';
-```
+----
 
 == UpgradeableContract
 
 This class represents the implementation for an upgradeable contract and gives access to error reports.
 
 === constructor UpgradeableContract
-```javascript
+[source,ts]
+----
 constructor UpgradeableContract(
   name: string,
   solcInput: SolcInput,
@@ -25,7 +27,7 @@ constructor UpgradeableContract(
     kind?: 'uups' | 'transparent' | 'beacon',
   },
 ): UpgradeableContract
-```
+----
 
 Creates a new instance of `UpgradeableContract`.
 
@@ -39,16 +41,18 @@ Creates a new instance of `UpgradeableContract`.
 TIP: In Hardhat, `solcInput` and `solcOutput` can be obtained from the Build Info file, which itself can be retrieved with `hre.artifacts.getBuildInfo`.
 
 === .getErrorReport
-```javascript
+[source,ts]
+----
 .getErrorReport(): Report
-```
+----
 
 **Returns:**
 
 * a report about errors pertaining to proxied contracts, e.g. the use of `selfdestruct`.
 
 === .getStorageUpgradeReport
-```javascript
+[source,ts]
+----
 .getStorageUpgradeReport(
   upgradedContract: UpgradeableContract,
   opts?: {
@@ -58,7 +62,7 @@ TIP: In Hardhat, `solcInput` and `solcOutput` can be obtained from the Build Inf
     kind?: 'uups' | 'transparent' | 'beacon',
   },
 ): Report
-```
+----
 
 Compares the storage layout of an upgradeable contract with that of a proposed upgrade.
 
@@ -73,12 +77,13 @@ Compares the storage layout of an upgradeable contract with that of a proposed u
 * a report about errors pertaining to proxied contracts, e.g. the use of `selfdestruct`, and storage layout conflicts.
 
 == Report
-```typescript
+[source,ts]
+----
 interface Report {
   ok: boolean;
   explain(color?: boolean): string;
 }
-```
+----
 
 An object that represents the results of an analysis.
 

--- a/docs/modules/ROOT/pages/api-core.adoc
+++ b/docs/modules/ROOT/pages/api-core.adoc
@@ -4,7 +4,6 @@ The core logic to check for upgrade safety as well as storage layout compatibili
 
 The package exports a standalone interface that works with https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description[Solidity input and output JSON objects].
 
-[.hljs-theme-light.nopadding]
 ```javascript
 import { UpgradeableContract } from '@openzeppelin/upgrades-core';
 ```
@@ -13,10 +12,19 @@ import { UpgradeableContract } from '@openzeppelin/upgrades-core';
 
 This class represents the implementation for an upgradeable contract and gives access to error reports.
 
-=== new UpgradeableContract
-[.hljs-theme-light.nopadding]
+=== constructor UpgradeableContract
 ```javascript
-new UpgradeableContract(name, solcInput, solcOutput, opts?);
+constructor UpgradeableContract(
+  name: string,
+  solcInput: SolcInput,
+  solcOutput: SolcOutput,
+  opts?: {
+    unsafeAllow?: ValidationError[],
+    unsafeAllowRenames?: boolean,
+    unsafeSkipStorageCheck?: boolean,
+    kind?: 'uups' | 'transparent' | 'beacon',
+  },
+): UpgradeableContract
 ```
 
 Creates a new instance of `UpgradeableContract`.
@@ -30,20 +38,26 @@ Creates a new instance of `UpgradeableContract`.
 
 TIP: In Hardhat, `solcInput` and `solcOutput` can be obtained from the Build Info file, which itself can be retrieved with `hre.artifacts.getBuildInfo`.
 
-=== getErrorReport
-[.hljs-theme-light.nopadding]
+=== .getErrorReport
 ```javascript
-contract.getErrorReport()
+.getErrorReport(): Report
 ```
 
 **Returns:**
 
 * a report about errors pertaining to proxied contracts, e.g. the use of `selfdestruct`.
 
-=== getStorageUpgradeReport
-[.hljs-theme-light.nopadding]
+=== .getStorageUpgradeReport
 ```javascript
-contract.getStorageUpgradeReport(upgradedContract)
+.getStorageUpgradeReport(
+  upgradedContract: UpgradeableContract,
+  opts?: {
+    unsafeAllow?: ValidationError[],
+    unsafeAllowRenames?: boolean,
+    unsafeSkipStorageCheck?: boolean,
+    kind?: 'uups' | 'transparent' | 'beacon',
+  },
+): Report
 ```
 
 Compares the storage layout of an upgradeable contract with that of a proposed upgrade.
@@ -52,12 +66,13 @@ Compares the storage layout of an upgradeable contract with that of a proposed u
 
 * `upgradedContract` - another instance of `UpgradeableContract` representing the proposed upgrade.
 
+* `opts` - an object with options as defined in xref:api-hardhat-upgrades.adoc#common-options[Common Options].
+
 **Returns:**
 
 * a report about errors pertaining to proxied contracts, e.g. the use of `selfdestruct`, and storage layout conflicts.
 
 == Report
-[.hljs-theme-light.nopadding]
 ```typescript
 interface Report {
   ok: boolean;

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -33,13 +33,6 @@ The following options have been deprecated.
 [[deploy-proxy]]
 == deployProxy
 
-Creates a UUPS or Transparent proxy given an ethers contract factory to use as implementation, and returns a contract instance with the proxy address and the implementation interface. If `args` is set, will call an initializer function `initialize` with the supplied args during proxy deployment.
-
-If you call `deployProxy` several times for the same implementation contract, several proxies will be deployed, but only one implementation contract will be used.
-
-* `initializer`: set a different initializer function to call (see link:++https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments++[Specifying Fragments]), or specify `false` to disable initialization
-* See <<common-options>>.
-
 [source,ts]
 ----
 async function deployProxy(
@@ -57,13 +50,17 @@ async function deployProxy(
 ): Promise<ethers.Contract>
 ----
 
+Creates a UUPS or Transparent proxy given an ethers contract factory to use as implementation, and returns a contract instance with the proxy address and the implementation interface. If `args` is set, will call an initializer function `initialize` with the supplied args during proxy deployment.
+
+If you call `deployProxy` several times for the same implementation contract, several proxies will be deployed, but only one implementation contract will be used.
+
+*Options:*
+
+* `initializer`: set a different initializer function to call (see link:++https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments++[Specifying Fragments]), or specify `false` to disable initialization
+* See <<common-options>>.
+
 [[upgrade-proxy]]
 == upgradeProxy
-
-Upgrades a UUPS or Transparent proxy at a specified address to a new implementation contract, and returns a contract instance with the proxy address and the new implementation interface.
-
-* `call`: enables the execution of an arbitrary function call during the upgrade process. This call is described using a function name, signature, or selector (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), and optional arguments. It is batched into the upgrade transaction, making it safe to call migration initializing functions.
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -84,12 +81,15 @@ async function upgradeProxy(
 ): Promise<ethers.Contract>
 ----
 
+Upgrades a UUPS or Transparent proxy at a specified address to a new implementation contract, and returns a contract instance with the proxy address and the new implementation interface.
+
+*Options:*
+
+* `call`: enables the execution of an arbitrary function call during the upgrade process. This call is described using a function name, signature, or selector (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), and optional arguments. It is batched into the upgrade transaction, making it safe to call migration initializing functions.
+* See <<common-options>>.
+
 [[deploy-beacon]]
 == deployBeacon
-
-Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] given an ethers contract factory to use as implementation, and returns the beacon contract instance.
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -105,14 +105,18 @@ async function deployBeacon(
 ): Promise<ethers.Contract>
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.13.0`
+Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] given an ethers contract factory to use as implementation, and returns the beacon contract instance.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/hardhat-upgrades@1.13.0`
 
 [[upgrade-beacon]]
 == upgradeBeacon
-
-Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] at a specified address to a new implementation contract, and returns the beacon contract instance.
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -131,14 +135,18 @@ async function upgradeBeacon(
 ): Promise<ethers.Contract>
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.13.0`
+Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] at a specified address to a new implementation contract, and returns the beacon contract instance.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since*:
+
+* `@openzeppelin/hardhat-upgrades@1.13.0`
 
 [[deploy-beacon-proxy]]
 == deployBeaconProxy
-
-Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beacon proxy] given an existing beacon contract address and an ethers contract factory corresponding to the beacon's current implementation contract, and returns a contract instance with the beacon proxy address and the implementation interface. If `args` is set, will call an initializer function `initialize` with the supplied args during proxy deployment.
-
-* `initializer`: set a different initializer function to call (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), or specify `false` to disable initialization
 
 [source,ts]
 ----
@@ -152,19 +160,18 @@ async function deployBeaconProxy(
 ): Promise<ethers.Contract>
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.13.0`
+Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beacon proxy] given an existing beacon contract address and an ethers contract factory corresponding to the beacon's current implementation contract, and returns a contract instance with the beacon proxy address and the implementation interface. If `args` is set, will call an initializer function `initialize` with the supplied args during proxy deployment.
+
+*Options:*
+
+* `initializer`: set a different initializer function to call (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), or specify `false` to disable initialization
+
+*Since:*
+
+* `@openzeppelin/hardhat-upgrades@1.13.0`
 
 [[force-import]]
 == forceImport
-
-Forces the import of an existing proxy, beacon, or implementation contract deployment to be used with this plugin. Provide the address of an existing proxy, beacon or implementation, along with the ethers contract factory of the implementation contract that was deployed.  
-
-CAUTION: When importing a proxy or beacon, the `deployedImpl` argument must be the contract factory of the *current* implementation contract version that is being used, not the version that you are planning to upgrade to.
-
-Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons and implementation contracts.
-
-* `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -177,14 +184,23 @@ async function forceImport(
 ): Promise<ethers.Contract>
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.15.0`
+Forces the import of an existing proxy, beacon, or implementation contract deployment to be used with this plugin. Provide the address of an existing proxy, beacon or implementation, along with the ethers contract factory of the implementation contract that was deployed.
+
+CAUTION: When importing a proxy or beacon, the `deployedImpl` argument must be the contract factory of the *current* implementation contract version that is being used, not the version that you are planning to upgrade to.
+
+Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons and implementation contracts.
+
+*Options:*
+
+* `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
+* See <<common-options>>.
+
+*Since*
+
+* `@openzeppelin/hardhat-upgrades@1.15.0`
 
 [[validate-implementation]]
 == validateImplementation
-
-Validates an implementation contract without deploying it.
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -197,15 +213,18 @@ async function validateImplementation(
 ): Promise<void>
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.20.0`
+Validates an implementation contract without deploying it.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/hardhat-upgrades@1.20.0`
 
 [[deploy-implementation]]
 == deployImplementation
-
-Validates and deploys an implementation contract, and returns its address.
-
-* `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -223,14 +242,19 @@ async function deployImplementation(
 ): Promise<string | ethers.providers.TransactionResponse>
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.20.0`
+Validates and deploys an implementation contract, and returns its address.
+
+*Options:*
+
+* `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/hardhat-upgrades@1.20.0`
 
 [[validate-upgrade]]
 == validateUpgrade
-
-Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract (given a proxy or beacon address that uses the current implementation, or an address or ethers contract factory corresponding to the current implementation) to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required. 
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -246,7 +270,17 @@ async function validateUpgrade(
 ): Promise<void>
 ----
 
-*Examples*
+Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract (given a proxy or beacon address that uses the current implementation, or an address or ethers contract factory corresponding to the current implementation) to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/hardhat-upgrades@1.20.0`
+
+*Examples:*
 
 Validate upgrading an existing proxy to a new contract (replace `PROXY_ADDRESS` with the address of your proxy):
 [source,ts]
@@ -267,15 +301,8 @@ const BoxV2 = await ethers.getContractFactory('BoxV2');
 await upgrades.validateUpgrade(Box, BoxV2);
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.20.0`
-
 [[prepare-upgrade]]
 == prepareUpgrade
-
-Validates and deploys a new implementation contract, and returns its address. Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from Hardhat. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons.
-
-* `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -296,21 +323,15 @@ async function prepareUpgrade(
 ): Promise<string | ethers.providers.TransactionResponse>
 ----
 
+Validates and deploys a new implementation contract, and returns its address. Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from Hardhat. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons.
+
+*Options:*
+
+* `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
+* See <<common-options>>.
+
 [[defender-propose-upgrade]]
 == defender.proposeUpgrade
-
-NOTE: This method requires the https://www.npmjs.com/package/@openzeppelin/hardhat-defender[`@openzeppelin/hardhat-defender`] package, as well as configuring a Defender Team API Key.
-
-Similar to `prepareUpgrade`. This method validates and deploys the new implementation contract, but also creates an upgrade proposal in https://docs.openzeppelin.com/defender/admin[Defender Admin], for review and approval by the upgrade administrators. Supported for UUPS or Transparent proxies. Not currently supported for beacon proxies or beacons. For beacons, use `prepareUpgrade` along with a custom action in Defender Admin to upgrade the beacon to the deployed implementation.
-
-Returns an object with the URL of the Defender proposal and the ethers transaction response corresponding to the deployment of the new implementation contract. Note that if the new implementation contract was originally imported as a result of `forceImport`, the ethers transaction response will be undefined.
-
-* `title`: title of the upgrade proposal as seen in Defender Admin, defaults to `Upgrade to 0x12345678` (using the first 8 digits of the new implementation address)
-* `description`: description of the upgrade proposal as seen in Defender Admin, defaults to the full implementation address.
-* `multisig`: address of the multisignature wallet contract with the rights to execute the upgrade. This is autodetected in https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[Transparent proxies], but required for https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable[UUPS proxies] (read more https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent-vs-uups[here]). Both Gnosis Safe and Gnosis MultisigWallet multisigs are supported.
-* `proxyAdmin`: address of the https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[`ProxyAdmin`] contract that manages the proxy, if exists. This is autodetected in https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[Transparent proxies], but required for https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable[UUPS proxies] (read more https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent-vs-uups[here]), though UUPS proxies typically do not require the usage of a ProxyAdmin.
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -337,12 +358,23 @@ async function proposeUpgrade(
   }>
 ----
 
-[[deploy-proxy-admin]]
-== deployProxyAdmin
+NOTE: This method requires the https://www.npmjs.com/package/@openzeppelin/hardhat-defender[`@openzeppelin/hardhat-defender`] package, as well as configuring a Defender Team API Key.
 
-Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy admin] contract and returns its address if one was not already deployed on the current network, or just returns the address of the proxy admin if one was already deployed. Note that this plugin currently only supports using one proxy admin per network.
+Similar to `prepareUpgrade`. This method validates and deploys the new implementation contract, but also creates an upgrade proposal in https://docs.openzeppelin.com/defender/admin[Defender Admin], for review and approval by the upgrade administrators. Supported for UUPS or Transparent proxies. Not currently supported for beacon proxies or beacons. For beacons, use `prepareUpgrade` along with a custom action in Defender Admin to upgrade the beacon to the deployed implementation.
+
+Returns an object with the URL of the Defender proposal and the ethers transaction response corresponding to the deployment of the new implementation contract. Note that if the new implementation contract was originally imported as a result of `forceImport`, the ethers transaction response will be undefined.
+
+*Options:*
+
+* `title`: title of the upgrade proposal as seen in Defender Admin, defaults to `Upgrade to 0x12345678` (using the first 8 digits of the new implementation address)
+* `description`: description of the upgrade proposal as seen in Defender Admin, defaults to the full implementation address.
+* `multisig`: address of the multisignature wallet contract with the rights to execute the upgrade. This is autodetected in https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[Transparent proxies], but required for https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable[UUPS proxies] (read more https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent-vs-uups[here]). Both Gnosis Safe and Gnosis MultisigWallet multisigs are supported.
+* `proxyAdmin`: address of the https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[`ProxyAdmin`] contract that manages the proxy, if exists. This is autodetected in https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[Transparent proxies], but required for https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable[UUPS proxies] (read more https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent-vs-uups[here]), though UUPS proxies typically do not require the usage of a ProxyAdmin.
 
 * See <<common-options>>.
+
+[[deploy-proxy-admin]]
+== deployProxyAdmin
 
 [source,ts]
 ----
@@ -355,12 +387,18 @@ async function deployProxyAdmin(
 ): Promise<string>
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.20.0`
+Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy admin] contract and returns its address if one was not already deployed on the current network, or just returns the address of the proxy admin if one was already deployed. Note that this plugin currently only supports using one proxy admin per network.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/hardhat-upgrades@1.20.0`
 
 [[admin-change-proxy-admin]]
 == admin.changeProxyAdmin
-
-Changes the admin for a specific proxy. Receives the address of the proxy to change, and the new admin address.
 
 [source,ts]
 ----
@@ -370,10 +408,10 @@ async function changeProxyAdmin(
 ): Promise<void>
 ----
 
+Changes the admin for a specific proxy. Receives the address of the proxy to change, and the new admin address.
+
 [[admin-transfer-proxy-admin-ownership]]
 == admin.transferProxyAdminOwnership
-
-Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies. Receives the new admin address.
 
 [source,ts]
 ----
@@ -382,10 +420,10 @@ async function transferProxyAdminOwnership(
 ): Promise<void>
 ----
 
+Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies. Receives the new admin address.
+
 [[erc1967]]
 == erc1967
-
-Functions in this module provide access to the https://eips.ethereum.org/EIPS/eip-1967[ERC1967] variables of a proxy contract.
 
 [source,ts]
 ----
@@ -394,28 +432,32 @@ async function erc1967.getBeaconAddress(proxyAddress: string): Promise<string>;
 async function erc1967.getAdminAddress(proxyAddress: string): Promise<string>;
 ----
 
+Functions in this module provide access to the https://eips.ethereum.org/EIPS/eip-1967[ERC1967] variables of a proxy contract.
+
 [[beacon]]
 == beacon
-
-This module provides a convenience function to get the implementation address from a beacon contract.
 
 [source,ts]
 ----
 async function beacon.getImplementationAddress(beaconAddress: string): Promise<string>;
 ----
 
-* Since: `@openzeppelin/hardhat-upgrades@1.13.0`
+This module provides a convenience function to get the implementation address from a beacon contract.
+
+*Since:*
+
+* `@openzeppelin/hardhat-upgrades@1.13.0`
 
 == silenceWarnings
-
-Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
-
-NOTE: This function is useful for tests, but its use in production deployment scripts is discouraged.
 
 [source,ts]
 ----
 function silenceWarnings()
 ----
+
+Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
+
+NOTE: This function is useful for tests, but its use in production deployment scripts is discouraged.
 
 [[verify]]
 == verify
@@ -430,6 +472,12 @@ The following contracts will be verified when you run this task on your proxy ad
 * https://docs.openzeppelin.com/contracts/4.x/api/proxy#ERC1967Proxy[ERC1967Proxy] or https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[TransparentUpgradeableProxy] or https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[BeaconProxy] (for UUPS, transparent, or beacon proxies, respectively)
 * https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[ProxyAdmin] (with transparent proxies)
 * https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[UpgradeableBeacon] (with beacon proxies)
+
+*Since:*
+
+* `@openzeppelin/hardhat-upgrades@1.18.0`
+
+*Examples:*
 
 To use this task, ensure you have hardhat-etherscan installed:
 [source,sh]
@@ -465,5 +513,3 @@ await hre.run("verify:verify", {
 ----
 
 Note that you do not need to include constructor arguments when verifying if your implementation contract only uses initializers.  However, if your implementation contract has an actual constructor with arguments (such as to set immutable variables), then include constructor arguments according to the usage information for the https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan#usage[task] or https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan#using-programmatically[subtask].
-
-* Since: `@openzeppelin/hardhat-upgrades@1.18.0`

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -477,7 +477,7 @@ The following contracts will be verified when you run this task on your proxy ad
 
 * `@openzeppelin/hardhat-upgrades@1.18.0`
 
-*Examples:*
+*Usage:*
 
 To use this task, ensure you have hardhat-etherscan installed:
 [source,sh]

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -54,7 +54,7 @@ Creates a UUPS or Transparent proxy given an ethers contract factory to use as i
 
 If you call `deployProxy` several times for the same implementation contract, several proxies will be deployed, but only one implementation contract will be used.
 
-==== Parameters:
+*Parameters:*
 
 * `Contract` - an ethers contract factory to use as the implementation.
 * `args` - arguments for the initializer function.

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -289,14 +289,14 @@ Validates and deploys an implementation contract, and returns its address.
 
 *Parameters:*
 
-* `Contract` - the ethers contract factory of the implementation contract.
+* `Contract` - an ethers contract factory to use as the implementation.
 * `opts` - an object with options:
 ** `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
 ** See <<common-options>>.
 
 *Returns:*
 
-* the address or an ethers transaction response corresponding to the deployment of the new implementation contract.
+* the address or an ethers transaction response corresponding to the deployment of the implementation contract.
 
 *Since:*
 
@@ -359,7 +359,7 @@ await upgrades.validateUpgrade(Box, BoxV2);
 [source,ts]
 ----
 async function prepareUpgrade(
-  proxyOrBeaconAddress: string | ethers.Contract,
+  proxyOrBeacon: string | ethers.Contract,
   Contract: ethers.ContractFactory,
   opts?: {
     unsafeAllow?: ValidationError[],
@@ -379,7 +379,7 @@ Validates and deploys a new implementation contract, and returns its address. Us
 
 *Parameters:*
 
-* `proxyOrBeaconAddress` - the proxy or beacon address or contract instance.
+* `proxyOrBeacon` - the proxy or beacon address or contract instance.
 * `Contract` - the new implementation contract.
 * `opts` - an object with options:
 ** `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -58,16 +58,13 @@ If you call `deployProxy` several times for the same implementation contract, se
 
 * `Contract` - an ethers contract factory to use as the implementation.
 * `args` - arguments for the initializer function.
-* `opts` - the options below.
+* `opts` - an object with options:
+** `initializer`: set a different initializer function to call (see link:++https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments++[Specifying Fragments]), or specify `false` to disable initialization.
+** See <<common-options>>.
 
 *Returns:*
 
 * a contract instance with the proxy address and the implementation interface.
-
-*Options:*
-
-* `initializer`: set a different initializer function to call (see link:++https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments++[Specifying Fragments]), or specify `false` to disable initialization.
-* See <<common-options>>.
 
 [[upgrade-proxy]]
 == upgradeProxy
@@ -97,16 +94,13 @@ Upgrades a UUPS or Transparent proxy at a specified address to a new implementat
 
 * `proxy` - the proxy address or proxy contract instance.
 * `Contract` - an ethers contract factory to use as the new implementation.
-* `opts` - the options below.
+* `opts` - an object with options:
+** `call`: enables the execution of an arbitrary function call during the upgrade process. This call is described using a function name, signature, or selector (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), and optional arguments. It is batched into the upgrade transaction, making it safe to call migration initializing functions.
+** See <<common-options>>.
 
 *Returns:*
 
 * a contract instance with the proxy address and the new implementation interface.
-
-*Options:*
-
-* `call`: enables the execution of an arbitrary function call during the upgrade process. This call is described using a function name, signature, or selector (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), and optional arguments. It is batched into the upgrade transaction, making it safe to call migration initializing functions.
-* See <<common-options>>.
 
 [[deploy-beacon]]
 == deployBeacon
@@ -130,15 +124,12 @@ Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeac
 *Parameters:*
 
 * `Contract` - an ethers contract factory to use as the implementation.
-* `opts` - the options below.
+* `opts` - an object with options:
+** See <<common-options>>.
 
 *Returns:*
 
 * the beacon contract instance.
-
-*Options:*
-
-* See <<common-options>>.
 
 *Since:*
 
@@ -170,15 +161,12 @@ Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBea
 
 * `beacon` - the beacon address or beacon contract instance.
 * `Contract` - an ethers contract factory to use as the new implementation.
-* `opts` - the options below.
+* `opts` - an object with options:
+** See <<common-options>>.
 
 *Returns:*
 
 * the beacon contract instance.
-
-*Options:*
-
-* See <<common-options>>.
 
 *Since*:
 
@@ -206,15 +194,12 @@ Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beac
 * `beacon` - the beacon address or beacon contract instance.
 * `attachTo` - an ethers contract factory corresponding to the beacon's current implementation contract.
 * `args` - arguments for the initializer function.
-* `opts` - the options below.
+* `opts` - an object with options:
+** `initializer`: set a different initializer function to call (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), or specify `false` to disable initialization
 
 *Returns:*
 
 * a contract instance with the beacon proxy address and the implementation interface.
-
-*Options:*
-
-* `initializer`: set a different initializer function to call (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), or specify `false` to disable initialization
 
 *Since:*
 
@@ -240,10 +225,16 @@ CAUTION: When importing a proxy or beacon, the `deployedImpl` argument must be t
 
 Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons and implementation contracts.
 
-*Options:*
+*Parameters:*
 
-* `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
-* See <<common-options>>.
+* `address` - the address of an existing proxy, beacon or implementation.
+* `deployedImpl` - the ethers contract factory of the implementation contract that was deployed.
+* `opts` - an object with options:
+** `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
+
+*Returns:*
+
+* a contract instance representing the imported proxy, beacon or implementation.
 
 *Since*
 
@@ -265,9 +256,11 @@ async function validateImplementation(
 
 Validates an implementation contract without deploying it.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `Contract` - the ethers contract factory of the implementation contract.
+* `opts` - an object with options:
+** See <<common-options>>.
 
 *Since:*
 
@@ -294,10 +287,16 @@ async function deployImplementation(
 
 Validates and deploys an implementation contract, and returns its address.
 
-*Options:*
+*Parameters:*
 
-* `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
-* See <<common-options>>.
+* `Contract` - the ethers contract factory of the implementation contract.
+* `opts` - an object with options:
+** `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
+** See <<common-options>>.
+
+*Returns:*
+
+* the address or an ethers transaction response corresponding to the deployment of the new implementation contract.
 
 *Since:*
 
@@ -320,11 +319,14 @@ async function validateUpgrade(
 ): Promise<void>
 ----
 
-Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract (given a proxy or beacon address that uses the current implementation, or an address or ethers contract factory corresponding to the current implementation) to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required.
+Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `referenceAddressOrContract` - a proxy or beacon address that uses the current implementation, or an address or ethers contract factory corresponding to the current implementation.
+* `newContract` - the new implementation contract.
+* `opts` - an object with options:
+** See <<common-options>>.
 
 *Since:*
 
@@ -357,7 +359,7 @@ await upgrades.validateUpgrade(Box, BoxV2);
 [source,ts]
 ----
 async function prepareUpgrade(
-  proxyOrBeaconAddress: string,
+  proxyOrBeaconAddress: string | ethers.Contract,
   Contract: ethers.ContractFactory,
   opts?: {
     unsafeAllow?: ValidationError[],
@@ -375,10 +377,17 @@ async function prepareUpgrade(
 
 Validates and deploys a new implementation contract, and returns its address. Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from Hardhat. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons.
 
-*Options:*
+*Parameters:*
 
-* `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
-* See <<common-options>>.
+* `proxyOrBeaconAddress` - the proxy or beacon address or contract instance.
+* `Contract` - the new implementation contract.
+* `opts` - an object with options:
+** `getTxResponse`: if set to `true`, causes this function to return an ethers transaction response corresponding to the deployment of the new implementation contract instead of its address. Note that if the new implementation contract was originally imported as a result of `forceImport`, only the address will be returned.
+** See <<common-options>>.
+
+*Returns:*
+
+* the address or an ethers transaction response corresponding to the deployment of the new implementation contract.
 
 [[defender-propose-upgrade]]
 == defender.proposeUpgrade
@@ -412,16 +421,20 @@ NOTE: This method requires the https://www.npmjs.com/package/@openzeppelin/hardh
 
 Similar to `prepareUpgrade`. This method validates and deploys the new implementation contract, but also creates an upgrade proposal in https://docs.openzeppelin.com/defender/admin[Defender Admin], for review and approval by the upgrade administrators. Supported for UUPS or Transparent proxies. Not currently supported for beacon proxies or beacons. For beacons, use `prepareUpgrade` along with a custom action in Defender Admin to upgrade the beacon to the deployed implementation.
 
-Returns an object with the URL of the Defender proposal and the ethers transaction response corresponding to the deployment of the new implementation contract. Note that if the new implementation contract was originally imported as a result of `forceImport`, the ethers transaction response will be undefined.
+*Parameters:*
 
-*Options:*
+* `proxyAddress` - the proxy address.
+* `ImplFactory` - the new implementation contract.
+* `opts` - an object with options:
+** `title`: title of the upgrade proposal as seen in Defender Admin, defaults to `Upgrade to 0x12345678` (using the first 8 digits of the new implementation address)
+** `description`: description of the upgrade proposal as seen in Defender Admin, defaults to the full implementation address.
+** `multisig`: address of the multisignature wallet contract with the rights to execute the upgrade. This is autodetected in https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[Transparent proxies], but required for https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable[UUPS proxies] (read more https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent-vs-uups[here]). Both Gnosis Safe and Gnosis MultisigWallet multisigs are supported.
+** `proxyAdmin`: address of the https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[`ProxyAdmin`] contract that manages the proxy, if exists. This is autodetected in https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[Transparent proxies], but required for https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable[UUPS proxies] (read more https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent-vs-uups[here]), though UUPS proxies typically do not require the usage of a ProxyAdmin.
+** See <<common-options>>.
 
-* `title`: title of the upgrade proposal as seen in Defender Admin, defaults to `Upgrade to 0x12345678` (using the first 8 digits of the new implementation address)
-* `description`: description of the upgrade proposal as seen in Defender Admin, defaults to the full implementation address.
-* `multisig`: address of the multisignature wallet contract with the rights to execute the upgrade. This is autodetected in https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[Transparent proxies], but required for https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable[UUPS proxies] (read more https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent-vs-uups[here]). Both Gnosis Safe and Gnosis MultisigWallet multisigs are supported.
-* `proxyAdmin`: address of the https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[`ProxyAdmin`] contract that manages the proxy, if exists. This is autodetected in https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy[Transparent proxies], but required for https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable[UUPS proxies] (read more https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent-vs-uups[here]), though UUPS proxies typically do not require the usage of a ProxyAdmin.
+*Returns:*
 
-* See <<common-options>>.
+* an object with the URL of the Defender proposal, and the ethers transaction response corresponding to the deployment of the new implementation contract. Note that if the new implementation contract was originally imported as a result of `forceImport`, the ethers transaction response will be undefined.
 
 [[deploy-proxy-admin]]
 == deployProxyAdmin
@@ -439,9 +452,15 @@ async function deployProxyAdmin(
 
 Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy admin] contract and returns its address if one was not already deployed on the current network, or just returns the address of the proxy admin if one was already deployed. Note that this plugin currently only supports using one proxy admin per network.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `Signer` - the signer to use for deployment.
+* `opts` - an object with options:
+** See <<common-options>>.
+
+*Returns:*
+
+* the address of the proxy admin.
 
 *Since:*
 
@@ -458,7 +477,12 @@ async function changeProxyAdmin(
 ): Promise<void>
 ----
 
-Changes the admin for a specific proxy. Receives the address of the proxy to change, and the new admin address.
+Changes the admin for a specific proxy.
+
+*Parameters:*
+
+* `proxyAddress` - the address of the proxy to change.
+* `newAdmin` - the new admin address.
 
 [[admin-transfer-proxy-admin-ownership]]
 == admin.transferProxyAdminOwnership
@@ -470,7 +494,11 @@ async function transferProxyAdminOwnership(
 ): Promise<void>
 ----
 
-Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies. Receives the new admin address.
+Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies.
+
+*Parameters:*
+
+* `newAdmin` - the new admin address.
 
 [[erc1967]]
 == erc1967
@@ -484,6 +512,14 @@ async function erc1967.getAdminAddress(proxyAddress: string): Promise<string>;
 
 Functions in this module provide access to the https://eips.ethereum.org/EIPS/eip-1967[ERC1967] variables of a proxy contract.
 
+*Parameters:*
+
+* `proxyAddress` - the proxy address.
+
+*Returns:*
+
+* the implementation, beacon, or admin address depending on the function called.
+
 [[beacon]]
 == beacon
 
@@ -493,6 +529,14 @@ async function beacon.getImplementationAddress(beaconAddress: string): Promise<s
 ----
 
 This module provides a convenience function to get the implementation address from a beacon contract.
+
+*Parameters:*
+
+* `beaconAddress` - the beacon address.
+
+*Returns:*
+
+* the implementation address.
 
 *Since:*
 

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -178,7 +178,7 @@ Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBea
 [source,ts]
 ----
 async function deployBeaconProxy(
-  beacon: string,
+  beacon: string | ethers.Contract,
   attachTo: ethers.ContractFactory,
   args: unknown[] = [],
   opts?: {
@@ -195,7 +195,7 @@ Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beac
 * `attachTo` - an ethers contract factory corresponding to the beacon's current implementation contract.
 * `args` - arguments for the initializer function.
 * `opts` - an object with options:
-** `initializer`: set a different initializer function to call (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), or specify `false` to disable initialization
+** `initializer`: set a different initializer function to call (see https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments[Specifying Fragments]), or specify `false` to disable initialization.
 
 *Returns:*
 

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -54,9 +54,19 @@ Creates a UUPS or Transparent proxy given an ethers contract factory to use as i
 
 If you call `deployProxy` several times for the same implementation contract, several proxies will be deployed, but only one implementation contract will be used.
 
+*Parameters:*
+
+* `Contract` - an ethers contract factory to use as the implementation.
+* `args` - arguments for the initializer function.
+* `opts` - the options below.
+
+*Returns:*
+
+* a contract instance with the proxy address and the implementation interface.
+
 *Options:*
 
-* `initializer`: set a different initializer function to call (see link:++https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments++[Specifying Fragments]), or specify `false` to disable initialization
+* `initializer`: set a different initializer function to call (see link:++https://docs.ethers.io/v5/api/utils/abi/interface/#Interface--specifying-fragments++[Specifying Fragments]), or specify `false` to disable initialization.
 * See <<common-options>>.
 
 [[upgrade-proxy]]
@@ -65,7 +75,7 @@ If you call `deployProxy` several times for the same implementation contract, se
 [source,ts]
 ----
 async function upgradeProxy(
-  proxyAddress: string,
+  proxy: string | ethers.Contract,
   Contract: ethers.ContractFactory,
   opts?: {
     call?: string | { fn: string; args?: unknown[] },
@@ -82,6 +92,16 @@ async function upgradeProxy(
 ----
 
 Upgrades a UUPS or Transparent proxy at a specified address to a new implementation contract, and returns a contract instance with the proxy address and the new implementation interface.
+
+*Parameters:*
+
+* `proxy` - the proxy address or proxy contract instance.
+* `Contract` - an ethers contract factory to use as the new implementation.
+* `opts` - the options below.
+
+*Returns:*
+
+* a contract instance with the proxy address and the new implementation interface.
 
 *Options:*
 
@@ -107,6 +127,15 @@ async function deployBeacon(
 
 Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] given an ethers contract factory to use as implementation, and returns the beacon contract instance.
 
+*Parameters:*
+
+* `Contract` - an ethers contract factory to use as the implementation.
+* `opts` - the options below.
+
+*Returns:*
+
+* the beacon contract instance.
+
 *Options:*
 
 * See <<common-options>>.
@@ -121,7 +150,7 @@ Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeac
 [source,ts]
 ----
 async function upgradeBeacon(
-  beaconAddress: string,
+  beacon: string | ethers.Contract,
   Contract: ethers.ContractFactory,
   opts?: {
     unsafeAllow?: ValidationError[],
@@ -137,6 +166,16 @@ async function upgradeBeacon(
 
 Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] at a specified address to a new implementation contract, and returns the beacon contract instance.
 
+*Parameters:*
+
+* `beacon` - the beacon address or beacon contract instance.
+* `Contract` - an ethers contract factory to use as the new implementation.
+* `opts` - the options below.
+
+*Returns:*
+
+* the beacon contract instance.
+
 *Options:*
 
 * See <<common-options>>.
@@ -151,7 +190,7 @@ Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBea
 [source,ts]
 ----
 async function deployBeaconProxy(
-  beaconAddress: string,
+  beacon: string,
   attachTo: ethers.ContractFactory,
   args: unknown[] = [],
   opts?: {
@@ -161,6 +200,17 @@ async function deployBeaconProxy(
 ----
 
 Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beacon proxy] given an existing beacon contract address and an ethers contract factory corresponding to the beacon's current implementation contract, and returns a contract instance with the beacon proxy address and the implementation interface. If `args` is set, will call an initializer function `initialize` with the supplied args during proxy deployment.
+
+*Parameters:*
+
+* `beacon` - the beacon address or beacon contract instance.
+* `attachTo` - an ethers contract factory corresponding to the beacon's current implementation contract.
+* `args` - arguments for the initializer function.
+* `opts` - the options below.
+
+*Returns:*
+
+* a contract instance with the beacon proxy address and the implementation interface.
 
 *Options:*
 

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -105,6 +105,8 @@ async function deployBeacon(
 ): Promise<ethers.Contract>
 ----
 
+* Since: `@openzeppelin/hardhat-upgrades@1.13.0`
+
 [[upgrade-beacon]]
 == upgradeBeacon
 
@@ -129,6 +131,8 @@ async function upgradeBeacon(
 ): Promise<ethers.Contract>
 ----
 
+* Since: `@openzeppelin/hardhat-upgrades@1.13.0`
+
 [[deploy-beacon-proxy]]
 == deployBeaconProxy
 
@@ -147,6 +151,8 @@ async function deployBeaconProxy(
   },
 ): Promise<ethers.Contract>
 ----
+
+* Since: `@openzeppelin/hardhat-upgrades@1.13.0`
 
 [[force-import]]
 == forceImport
@@ -171,6 +177,8 @@ async function forceImport(
 ): Promise<ethers.Contract>
 ----
 
+* Since: `@openzeppelin/hardhat-upgrades@1.15.0`
+
 [[validate-implementation]]
 == validateImplementation
 
@@ -188,6 +196,8 @@ async function validateImplementation(
   },
 ): Promise<void>
 ----
+
+* Since: `@openzeppelin/hardhat-upgrades@1.20.0`
 
 [[deploy-implementation]]
 == deployImplementation
@@ -212,6 +222,8 @@ async function deployImplementation(
   },
 ): Promise<string | ethers.providers.TransactionResponse>
 ----
+
+* Since: `@openzeppelin/hardhat-upgrades@1.20.0`
 
 [[validate-upgrade]]
 == validateUpgrade
@@ -254,6 +266,8 @@ const Box = await ethers.getContractFactory('Box');
 const BoxV2 = await ethers.getContractFactory('BoxV2');
 await upgrades.validateUpgrade(Box, BoxV2);
 ----
+
+* Since: `@openzeppelin/hardhat-upgrades@1.20.0`
 
 [[prepare-upgrade]]
 == prepareUpgrade
@@ -341,6 +355,8 @@ async function deployProxyAdmin(
 ): Promise<string>
 ----
 
+* Since: `@openzeppelin/hardhat-upgrades@1.20.0`
+
 [[admin-change-proxy-admin]]
 == admin.changeProxyAdmin
 
@@ -387,6 +403,8 @@ This module provides a convenience function to get the implementation address fr
 ----
 async function beacon.getImplementationAddress(beaconAddress: string): Promise<string>;
 ----
+
+* Since: `@openzeppelin/hardhat-upgrades@1.13.0`
 
 == silenceWarnings
 
@@ -447,3 +465,5 @@ await hre.run("verify:verify", {
 ----
 
 Note that you do not need to include constructor arguments when verifying if your implementation contract only uses initializers.  However, if your implementation contract has an actual constructor with arguments (such as to set immutable variables), then include constructor arguments according to the usage information for the https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan#usage[task] or https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan#using-programmatically[subtask].
+
+* Since: `@openzeppelin/hardhat-upgrades@1.18.0`

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -455,9 +455,9 @@ This module provides a convenience function to get the implementation address fr
 function silenceWarnings()
 ----
 
-Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
-
 NOTE: This function is useful for tests, but its use in production deployment scripts is discouraged.
+
+Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
 
 [[verify]]
 == verify

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -54,7 +54,7 @@ Creates a UUPS or Transparent proxy given an ethers contract factory to use as i
 
 If you call `deployProxy` several times for the same implementation contract, several proxies will be deployed, but only one implementation contract will be used.
 
-*Parameters:*
+==== Parameters:
 
 * `Contract` - an ethers contract factory to use as the implementation.
 * `args` - arguments for the initializer function.

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -56,10 +56,17 @@ If `args` is set, will call an initializer function `initialize` with the suppli
 
 If you call `deployProxy` several times for the same implementation contract, several proxies will be deployed, but only one implementation contract will be used.
 
-*Options:*
+*Parameters:*
 
-* `initializer`: set a different initializer function to call, or specify `false` to disable initialization
-* See <<common-options>>.
+* `Contract` - an Truffle contract class to use as the implementation.
+* `args` - arguments for the initializer function.
+* `opts` - an object with options:
+** `initializer`: set a different initializer function to call, or specify `false` to disable initialization
+** See <<common-options>>.
+
+*Returns:*
+
+* a contract instance with the proxy address and the implementation interface.
 
 [[upgrade-proxy]]
 == upgradeProxy
@@ -86,10 +93,17 @@ async function upgradeProxy(
 
 Upgrades a UUPS or Transparent proxy at a specified address to a new implementation contract, and returns a contract instance with the proxy address and the new implementation interface.
 
-*Options:*
+*Parameters:*
 
-* `call`: enables the execution of an arbitrary function call during the upgrade process. This call is described using a function name or signature and optional arguments. It is batched into the upgrade transaction, making it safe to call migration initializing functions.
-* See <<common-options>>.
+* `proxy` - the proxy address or proxy contract instance.
+* `Contract` - a Truffle contract class to use as the new implementation.
+* `opts` - an object with options:
+** `call`: enables the execution of an arbitrary function call during the upgrade process. This call is described using a function name or signature and optional arguments. It is batched into the upgrade transaction, making it safe to call migration initializing functions.
+** See <<common-options>>.
+
+*Returns:*
+
+* a contract instance with the proxy address and the new implementation interface.
 
 [[deploy-beacon]]
 == deployBeacon
@@ -111,9 +125,15 @@ async function deployBeacon(
 
 Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] given a Truffle contract class to use as implementation, and returns the beacon contract instance.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `Contract` - a Truffle contract class to use as the implementation.
+* `opts` - an object with options:
+** See <<common-options>>.
+
+*Returns:*
+
+* the beacon contract instance.
 
 *Since:*
 
@@ -125,7 +145,7 @@ Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeac
 [source,ts]
 ----
 async function upgradeBeacon(
-  beaconAddress: string,
+  beacon: string | ContractInstance,
   Contract: ContractClass,
   opts?: {
     deployer?: Deployer,
@@ -142,9 +162,16 @@ async function upgradeBeacon(
 
 Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] at a specified address to a new implementation contract, and returns the beacon contract instance.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `beacon` - the beacon address or beacon contract instance.
+* `Contract` - a Truffle contract class to use as the new implementation.
+* `opts` - an object with options:
+** See <<common-options>>.
+
+*Returns:*
+
+* the beacon contract instance.
 
 *Since:*
 
@@ -156,7 +183,7 @@ Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBea
 [source,ts]
 ----
 async function deployBeaconProxy(
-  beaconAddress: string,
+  beaconAddress: string | ContractInstance,
   attachTo: ContractClass,
   args: unknown[] = [],
   opts?: {
@@ -168,9 +195,17 @@ async function deployBeaconProxy(
 
 Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beacon proxy] given an existing beacon contract address and a Truffle contract class corresponding to the beacon's current implementation contract, and returns a contract instance with the beacon proxy address and the implementation interface. If `args` is set, will call an initializer function `initialize` with the supplied args during proxy deployment.
 
-*Options:*
+*Parameters:*
 
-* `initializer`: set a different initializer function to call, or specify `false` to disable initialization
+* `beacon` - the beacon address or beacon contract instance.
+* `attachTo` - an ethers contract factory corresponding to the beacon's current implementation contract.
+* `args` - arguments for the initializer function.
+* `opts` - an object with options:
+** `initializer`: set a different initializer function to call, or specify `false` to disable initialization
+
+*Returns:*
+
+* a contract instance with the beacon proxy address and the implementation interface.
 
 *Since:*
 
@@ -196,10 +231,16 @@ CAUTION: When importing a proxy or beacon, the `deployedImpl` argument must be t
 
 Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons and implementation contracts.
 
-*Options:*
+*Parameters:*
 
-* `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
-* See <<common-options>>.
+* `address` - the address of an existing proxy, beacon or implementation.
+* `deployedImpl` - the ethers contract factory of the implementation contract that was deployed.
+* `opts` - an object with options:
+** `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
+
+*Returns:*
+
+* a contract instance representing the imported proxy, beacon or implementation.
 
 *Since:*
 
@@ -221,9 +262,11 @@ async function validateImplementation(
 
 Validates an implementation contract without deploying it.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `Contract` - the ethers contract factory of the implementation contract.
+* `opts` - an object with options:
+** See <<common-options>>.
 
 *Since:*
 
@@ -250,9 +293,15 @@ async function deployImplementation(
 
 Validates and deploys an implementation contract, and returns its address.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `Contract` - a Truffle contract class representing the implementation contract.
+* `opts` - an object with options:
+** See <<common-options>>.
+
+*Returns:*
+
+* the address or an ethers transaction response corresponding to the deployment of the new implementation contract.
 
 *Since:*
 
@@ -277,9 +326,12 @@ async function validateUpgrade(
 
 Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract (given a proxy or beacon address that uses the current implementation, or an address or Truffle contract class corresponding to the current implementation) to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `referenceAddressOrContract` - a proxy or beacon address that uses the current implementation, or an address or Truffle contract class corresponding to the current implementation.
+* `newContract` - the new implementation contract.
+* `opts` - an object with options:
+** See <<common-options>>.
 
 *Since:*
 
@@ -330,9 +382,16 @@ async function prepareUpgrade(
 
 Validates and deploys a new implementation contract, and returns its address. Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from Truffle. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `proxyOrBeaconAddress` - the proxy or beacon address or contract instance.
+* `Contract` - the new implementation contract.
+* `opts` - an object with options:
+** See <<common-options>>.
+
+*Returns:*
+
+* the address or an ethers transaction response corresponding to the deployment of the new implementation contract.
 
 [[deploy-proxy-admin]]
 == deployProxyAdmin
@@ -350,9 +409,14 @@ async function deployProxyAdmin(
 
 Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy admin] contract and returns its address if one was not already deployed on the current network, or just returns the address of the proxy admin if one was already deployed. Note that this plugin currently only supports using one proxy admin per network.
 
-*Options:*
+*Parameters:*
 
-* See <<common-options>>.
+* `opts` - an object with options:
+** See <<common-options>>.
+
+*Returns:*
+
+* the address of the proxy admin.
 
 *Since:*
 
@@ -371,6 +435,11 @@ async function changeProxyAdmin(
 
 Changes the admin for a specific proxy. Receives the address of the proxy to change, and the new admin address.
 
+*Parameters:*
+
+* `proxyAddress` - the address of the proxy to change.
+* `newAdmin` - the new admin address.
+
 [[admin-transfer-proxy-admin-ownership]]
 == admin.transferProxyAdminOwnership
 
@@ -382,6 +451,10 @@ async function transferProxyAdminOwnership(
 ----
 
 Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies. Receives the new admin address.
+
+*Parameters:*
+
+* `newAdmin` - the new admin address.
 
 [[erc1967]]
 == erc1967
@@ -395,6 +468,14 @@ async function erc1967.getAdminAddress(proxyAddress: string): Promise<string>;
 
 Functions in this module provide access to the https://eips.ethereum.org/EIPS/eip-1967[ERC1967] variables of a proxy contract.
 
+*Parameters:*
+
+* `proxyAddress` - the proxy address.
+
+*Returns:*
+
+* the implementation, beacon, or admin address depending on the function called.
+
 [[beacon]]
 == beacon
 
@@ -404,6 +485,14 @@ async function beacon.getImplementationAddress(beaconAddress: string): Promise<s
 ----
 
 This module provides a convenience function to get the implementation address from a beacon contract.
+
+*Parameters:*
+
+* `beaconAddress` - the beacon address.
+
+*Returns:*
+
+* the implementation address.
 
 *Since:*
 

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -74,7 +74,7 @@ If you call `deployProxy` several times for the same implementation contract, se
 [source,ts]
 ----
 async function upgradeProxy(
-  proxyAddress: string,
+  proxy: string | ContractInstance,
   Contract: ContractClass,
   opts?: {
     deployer?: Deployer,
@@ -183,7 +183,7 @@ Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBea
 [source,ts]
 ----
 async function deployBeaconProxy(
-  beaconAddress: string | ContractInstance,
+  beacon: string | ContractInstance,
   attachTo: ContractClass,
   args: unknown[] = [],
   opts?: {
@@ -301,7 +301,7 @@ Validates and deploys an implementation contract, and returns its address.
 
 *Returns:*
 
-* the address or an ethers transaction response corresponding to the deployment of the new implementation contract.
+* the address of the implementation contract.
 
 *Since:*
 
@@ -324,7 +324,7 @@ async function validateUpgrade(
 ): Promise<void>
 ----
 
-Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract (given a proxy or beacon address that uses the current implementation, or an address or Truffle contract class corresponding to the current implementation) to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required.
+Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required.
 
 *Parameters:*
 
@@ -364,7 +364,7 @@ await validateUpgrade(Box, BoxV2);
 [source,ts]
 ----
 async function prepareUpgrade(
-  proxyOrBeaconAddress: string,
+  proxyOrBeacon: string | ContractInstance,
   Contract: ContractClass,
   opts?: {
     deployer?: Deployer,
@@ -384,14 +384,14 @@ Validates and deploys a new implementation contract, and returns its address. Us
 
 *Parameters:*
 
-* `proxyOrBeaconAddress` - the proxy or beacon address or contract instance.
+* `proxyOrBeacon` - the proxy or beacon address or contract instance.
 * `Contract` - the new implementation contract.
 * `opts` - an object with options:
 ** See <<common-options>>.
 
 *Returns:*
 
-* the address or an ethers transaction response corresponding to the deployment of the new implementation contract.
+* the address of the new implementation contract.
 
 [[deploy-proxy-admin]]
 == deployProxyAdmin
@@ -433,7 +433,7 @@ async function changeProxyAdmin(
 ): Promise<void>
 ----
 
-Changes the admin for a specific proxy. Receives the address of the proxy to change, and the new admin address.
+Changes the admin for a specific proxy.
 
 *Parameters:*
 
@@ -450,7 +450,7 @@ async function transferProxyAdminOwnership(
 ): Promise<void>
 ----
 
-Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies. Receives the new admin address.
+Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies.
 
 *Parameters:*
 

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -58,7 +58,7 @@ If you call `deployProxy` several times for the same implementation contract, se
 
 *Parameters:*
 
-* `Contract` - an Truffle contract class to use as the implementation.
+* `Contract` - a Truffle contract class to use as the implementation.
 * `args` - arguments for the initializer function.
 * `opts` - an object with options:
 ** `initializer`: set a different initializer function to call, or specify `false` to disable initialization
@@ -198,7 +198,7 @@ Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beac
 *Parameters:*
 
 * `beacon` - the beacon address or beacon contract instance.
-* `attachTo` - an ethers contract factory corresponding to the beacon's current implementation contract.
+* `attachTo` - a Truffle contract class corresponding to the beacon's current implementation contract.
 * `args` - arguments for the initializer function.
 * `opts` - an object with options:
 ** `initializer`: set a different initializer function to call, or specify `false` to disable initialization
@@ -234,7 +234,7 @@ Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plug
 *Parameters:*
 
 * `address` - the address of an existing proxy, beacon or implementation.
-* `deployedImpl` - the ethers contract factory of the implementation contract that was deployed.
+* `deployedImpl` - the Truffle contract class of the implementation contract that was deployed.
 * `opts` - an object with options:
 ** `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
 
@@ -264,7 +264,7 @@ Validates an implementation contract without deploying it.
 
 *Parameters:*
 
-* `Contract` - the ethers contract factory of the implementation contract.
+* `Contract` - the Truffle contract class of the implementation contract.
 * `opts` - an object with options:
 ** See <<common-options>>.
 
@@ -295,7 +295,7 @@ Validates and deploys an implementation contract, and returns its address.
 
 *Parameters:*
 
-* `Contract` - a Truffle contract class representing the implementation contract.
+* `Contract` - a Truffle contract class to use as the implementation.
 * `opts` - an object with options:
 ** See <<common-options>>.
 

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -109,6 +109,8 @@ async function deployBeacon(
 ): Promise<ContractInstance>
 ----
 
+* Since: `@openzeppelin/truffle-upgrades@1.12.0`
+
 [[upgrade-beacon]]
 == upgradeBeacon
 
@@ -134,6 +136,8 @@ async function upgradeBeacon(
 ): Promise<ContractInstance>
 ----
 
+* Since: `@openzeppelin/truffle-upgrades@1.12.0`
+
 [[deploy-beacon-proxy]]
 == deployBeaconProxy
 
@@ -153,6 +157,8 @@ async function deployBeaconProxy(
   },
 ): Promise<ContractInstance>
 ----
+
+* Since: `@openzeppelin/truffle-upgrades@1.12.0`
 
 [[force-import]]
 == forceImport
@@ -177,6 +183,8 @@ async function forceImport(
 ): Promise<ContractInstance>
 ----
 
+* Since: `@openzeppelin/truffle-upgrades@1.13.0`
+
 [[validate-implementation]]
 == validateImplementation
 
@@ -194,6 +202,8 @@ async function validateImplementation(
   },
 ): Promise<void>
 ----
+
+* Since: `@openzeppelin/truffle-upgrades@1.16.0`
 
 [[deploy-implementation]]
 == deployImplementation
@@ -217,6 +227,8 @@ async function deployImplementation(
   },
 ): Promise<string>
 ----
+
+* Since: `@openzeppelin/truffle-upgrades@1.16.0`
 
 [[validate-upgrade]]
 == validateUpgrade
@@ -259,6 +271,8 @@ const Box = artifacts.require('Box');
 const BoxV2 = artifacts.require('BoxV2');
 await validateUpgrade(Box, BoxV2);
 ----
+
+* Since: `@openzeppelin/truffle-upgrades@1.16.0`
 
 [[prepare-upgrade]]
 == prepareUpgrade
@@ -303,6 +317,8 @@ async function deployProxyAdmin(
   },
 ): Promise<string>
 ----
+
+* Since: `@openzeppelin/truffle-upgrades@1.16.0`
 
 [[admin-change-proxy-admin]]
 == admin.changeProxyAdmin
@@ -350,6 +366,8 @@ This module provides a convenience function to get the implementation address fr
 ----
 async function beacon.getImplementationAddress(beaconAddress: string): Promise<string>;
 ----
+
+* Since: `@openzeppelin/truffle-upgrades@1.12.0`
 
 == silenceWarnings
 

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -32,15 +32,6 @@ The following options have been deprecated.
 [[deploy-proxy]]
 == deployProxy
 
-Creates a UUPS or Transparent proxy given a Truffle contract class to use as implementation, and returns a contract instance with the proxy address and the implementation interface. During a migration, the proxy address will be stored in the implementation contract's artifact, so you can use Truffle's https://www.trufflesuite.com/docs/truffle/reference/contract-abstractions#-code-mycontract-deployed-code-[`deployed()`] function to load it.
-
-If `args` is set, will call an initializer function `initialize` with the supplied `args` during proxy deployment.
-
-If you call `deployProxy` several times for the same implementation contract, several proxies will be deployed, but only one implementation contract will be used.
-
-* `initializer`: set a different initializer function to call, or specify `false` to disable initialization
-* See <<common-options>>.
-
 [source,ts]
 ----
 async function deployProxy(
@@ -59,13 +50,19 @@ async function deployProxy(
 ): Promise<ContractInstance>
 ----
 
+Creates a UUPS or Transparent proxy given a Truffle contract class to use as implementation, and returns a contract instance with the proxy address and the implementation interface. During a migration, the proxy address will be stored in the implementation contract's artifact, so you can use Truffle's https://www.trufflesuite.com/docs/truffle/reference/contract-abstractions#-code-mycontract-deployed-code-[`deployed()`] function to load it.
+
+If `args` is set, will call an initializer function `initialize` with the supplied `args` during proxy deployment.
+
+If you call `deployProxy` several times for the same implementation contract, several proxies will be deployed, but only one implementation contract will be used.
+
+*Options:*
+
+* `initializer`: set a different initializer function to call, or specify `false` to disable initialization
+* See <<common-options>>.
+
 [[upgrade-proxy]]
 == upgradeProxy
-
-Upgrades a UUPS or Transparent proxy at a specified address to a new implementation contract, and returns a contract instance with the proxy address and the new implementation interface.
-
-* `call`: enables the execution of an arbitrary function call during the upgrade process. This call is described using a function name or signature and optional arguments. It is batched into the upgrade transaction, making it safe to call migration initializing functions.
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -87,12 +84,15 @@ async function upgradeProxy(
 ): Promise<ContractInstance>
 ----
 
+Upgrades a UUPS or Transparent proxy at a specified address to a new implementation contract, and returns a contract instance with the proxy address and the new implementation interface.
+
+*Options:*
+
+* `call`: enables the execution of an arbitrary function call during the upgrade process. This call is described using a function name or signature and optional arguments. It is batched into the upgrade transaction, making it safe to call migration initializing functions.
+* See <<common-options>>.
+
 [[deploy-beacon]]
 == deployBeacon
-
-Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] given a Truffle contract class to use as implementation, and returns the beacon contract instance.
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -109,14 +109,18 @@ async function deployBeacon(
 ): Promise<ContractInstance>
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.12.0`
+Creates an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] given a Truffle contract class to use as implementation, and returns the beacon contract instance.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.12.0`
 
 [[upgrade-beacon]]
 == upgradeBeacon
-
-Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] at a specified address to a new implementation contract, and returns the beacon contract instance.
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -136,14 +140,18 @@ async function upgradeBeacon(
 ): Promise<ContractInstance>
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.12.0`
+Upgrades an https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon[upgradable beacon] at a specified address to a new implementation contract, and returns the beacon contract instance.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.12.0`
 
 [[deploy-beacon-proxy]]
 == deployBeaconProxy
-
-Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beacon proxy] given an existing beacon contract address and a Truffle contract class corresponding to the beacon's current implementation contract, and returns a contract instance with the beacon proxy address and the implementation interface. If `args` is set, will call an initializer function `initialize` with the supplied args during proxy deployment.
-
-* `initializer`: set a different initializer function to call, or specify `false` to disable initialization
 
 [source,ts]
 ----
@@ -158,19 +166,18 @@ async function deployBeaconProxy(
 ): Promise<ContractInstance>
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.12.0`
+Creates a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy[Beacon proxy] given an existing beacon contract address and a Truffle contract class corresponding to the beacon's current implementation contract, and returns a contract instance with the beacon proxy address and the implementation interface. If `args` is set, will call an initializer function `initialize` with the supplied args during proxy deployment.
+
+*Options:*
+
+* `initializer`: set a different initializer function to call, or specify `false` to disable initialization
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.12.0`
 
 [[force-import]]
 == forceImport
-
-Forces the import of an existing proxy, beacon, or implementation contract deployment to be used with this plugin. Provide the address of an existing proxy, beacon or implementation, along with the Truffle contract class of the implementation contract that was deployed.  
-
-CAUTION: When importing a proxy or beacon, the `deployedImpl` argument must be the contract class of the *current* implementation contract version that is being used, not the version that you are planning to upgrade to.  
-
-Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons and implementation contracts.
-
-* `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -183,14 +190,23 @@ async function forceImport(
 ): Promise<ContractInstance>
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.13.0`
+Forces the import of an existing proxy, beacon, or implementation contract deployment to be used with this plugin. Provide the address of an existing proxy, beacon or implementation, along with the Truffle contract class of the implementation contract that was deployed.
+
+CAUTION: When importing a proxy or beacon, the `deployedImpl` argument must be the contract class of the *current* implementation contract version that is being used, not the version that you are planning to upgrade to.
+
+Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons and implementation contracts.
+
+*Options:*
+
+* `kind`: (`"uups" | "transparent" | "beacon"`) forces a proxy to be treated as a UUPS, Transparent, or Beacon proxy. If not provided, the proxy kind will be automatically detected.
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.13.0`
 
 [[validate-implementation]]
 == validateImplementation
-
-Validates an implementation contract without deploying it.
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -203,14 +219,18 @@ async function validateImplementation(
 ): Promise<void>
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.16.0`
+Validates an implementation contract without deploying it.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.16.0`
 
 [[deploy-implementation]]
 == deployImplementation
-
-Validates and deploys an implementation contract, and returns its address.
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -228,14 +248,18 @@ async function deployImplementation(
 ): Promise<string>
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.16.0`
+Validates and deploys an implementation contract, and returns its address.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.16.0`
 
 [[validate-upgrade]]
 == validateUpgrade
-
-Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract (given a proxy or beacon address that uses the current implementation, or an address or Truffle contract class corresponding to the current implementation) to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required. 
-
-* See <<common-options>>.
 
 [source,ts]
 ----
@@ -251,7 +275,17 @@ async function validateUpgrade(
 ): Promise<void>
 ----
 
-*Examples*
+Validates a new implementation contract without deploying it and without actually upgrading to it. Compares the current implementation contract (given a proxy or beacon address that uses the current implementation, or an address or Truffle contract class corresponding to the current implementation) to the new implementation contract to check for storage layout compatibility errors. If `referenceAddressOrContract` is the current implementation address, the `kind` option is required.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.16.0`
+
+*Examples:*
 
 Validate upgrading an existing proxy to a new contract (replace `PROXY_ADDRESS` with the address of your proxy):
 [source,ts]
@@ -272,14 +306,8 @@ const BoxV2 = artifacts.require('BoxV2');
 await validateUpgrade(Box, BoxV2);
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.16.0`
-
 [[prepare-upgrade]]
 == prepareUpgrade
-
-Validates and deploys a new implementation contract, and returns its address. Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from Truffle. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons.
-
-See <<common-options>>.
 
 [source,ts]
 ----
@@ -300,12 +328,14 @@ async function prepareUpgrade(
 ): Promise<string>
 ----
 
-[[deploy-proxy-admin]]
-== deployProxyAdmin
+Validates and deploys a new implementation contract, and returns its address. Use this method to prepare an upgrade to be run from an admin address you do not control directly or cannot use from Truffle. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons.
 
-Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy admin] contract and returns its address if one was not already deployed on the current network, or just returns the address of the proxy admin if one was already deployed. Note that this plugin currently only supports using one proxy admin per network.
+*Options:*
 
 * See <<common-options>>.
+
+[[deploy-proxy-admin]]
+== deployProxyAdmin
 
 [source,ts]
 ----
@@ -318,12 +348,18 @@ async function deployProxyAdmin(
 ): Promise<string>
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.16.0`
+Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy admin] contract and returns its address if one was not already deployed on the current network, or just returns the address of the proxy admin if one was already deployed. Note that this plugin currently only supports using one proxy admin per network.
+
+*Options:*
+
+* See <<common-options>>.
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.16.0`
 
 [[admin-change-proxy-admin]]
 == admin.changeProxyAdmin
-
-Changes the admin for a specific proxy. Receives the address of the proxy to change, and the new admin address.
 
 [source,ts]
 ----
@@ -333,10 +369,10 @@ async function changeProxyAdmin(
 ): Promise<void>
 ----
 
+Changes the admin for a specific proxy. Receives the address of the proxy to change, and the new admin address.
+
 [[admin-transfer-proxy-admin-ownership]]
 == admin.transferProxyAdminOwnership
-
-Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies. Receives the new admin address.
 
 [source,ts]
 ----
@@ -345,10 +381,10 @@ async function transferProxyAdminOwnership(
 ): Promise<void>
 ----
 
+Changes the owner of the proxy admin contract, which is the default admin for upgrade rights over all proxies. Receives the new admin address.
+
 [[erc1967]]
 == erc1967
-
-Functions in this module provide access to the https://eips.ethereum.org/EIPS/eip-1967[ERC1967] variables of a proxy contract.
 
 [source,ts]
 ----
@@ -357,25 +393,29 @@ async function erc1967.getBeaconAddress(proxyAddress: string): Promise<string>;
 async function erc1967.getAdminAddress(proxyAddress: string): Promise<string>;
 ----
 
+Functions in this module provide access to the https://eips.ethereum.org/EIPS/eip-1967[ERC1967] variables of a proxy contract.
+
 [[beacon]]
 == beacon
-
-This module provides a convenience function to get the implementation address from a beacon contract.
 
 [source,ts]
 ----
 async function beacon.getImplementationAddress(beaconAddress: string): Promise<string>;
 ----
 
-* Since: `@openzeppelin/truffle-upgrades@1.12.0`
+This module provides a convenience function to get the implementation address from a beacon contract.
+
+*Since:*
+
+* `@openzeppelin/truffle-upgrades@1.12.0`
 
 == silenceWarnings
-
-Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.
-
-NOTE: This function is useful for tests, but its use in production deployment scripts is discouraged.
 
 [source,ts]
 ----
 function silenceWarnings()
 ----
+
+NOTE: This function is useful for tests, but its use in production deployment scripts is discouraged.
+
+Silences all subsequent warnings about the use of unsafe flags. Prints a last warning before doing so.


### PR DESCRIPTION
Document:
- Parameters (including options)
- Returns
- Since - the minimum package version required for each recent function, so that users know when they need to update their package.  This includes functions related to beacon proxy support, forceImport, granular functions, and Etherscan verification.