### PR TITLE
Use proxy transactionHash for implementation contract abstraction in Truffle

### DIFF
--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use proxy transaction hash for implementation contract abstraction. ([#737](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/737))
+
 ## 1.17.0 (2022-09-27)
 
 - Include solc version in storage layouts in manifest files. ([#662](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/662))

--- a/packages/plugin-truffle/src/deploy-beacon-proxy.ts
+++ b/packages/plugin-truffle/src/deploy-beacon-proxy.ts
@@ -82,6 +82,7 @@ export async function deployBeaconProxy(
   await manifest.addProxy(proxyDeployment);
 
   attachTo.address = proxyDeployment.address;
+  attachTo.transactionHash = proxyDeployment.txHash;
   const contract = new attachTo(proxyDeployment.address);
   contract.transactionHash = proxyDeployment.txHash;
   return contract;

--- a/packages/plugin-truffle/src/deploy-proxy.ts
+++ b/packages/plugin-truffle/src/deploy-proxy.ts
@@ -71,6 +71,7 @@ export async function deployProxy(
   await manifest.addProxy(proxyDeployment);
 
   Contract.address = proxyDeployment.address;
+  Contract.transactionHash = proxyDeployment.txHash;
   const contract = new Contract(proxyDeployment.address);
   contract.transactionHash = proxyDeployment.txHash;
   return contract;

--- a/packages/plugin-truffle/src/utils/truffle.ts
+++ b/packages/plugin-truffle/src/utils/truffle.ts
@@ -18,6 +18,7 @@ export interface ContractClass {
   class_defaults: ContractClassDefaults;
   contractName: string;
   address?: string;
+  transactionHash?: string;
   networks?: {
     [id: string]: NetworkObject;
   };

--- a/packages/plugin-truffle/test/migrations/2_1_deploy_greeter_transparent.js
+++ b/packages/plugin-truffle/test/migrations/2_1_deploy_greeter_transparent.js
@@ -10,8 +10,9 @@ module.exports = async function (deployer) {
   assert.equal(Greeter.address, g.address);
   assert.equal(Greeter.transactionHash, g.transactionHash);
 
-  await upgradeProxy(g, GreeterV2, { deployer });
+  const upgraded = await upgradeProxy(g, GreeterV2, { deployer });
 
-  assert.equal(GreeterV2.address, Greeter.address);
+  assert.equal(GreeterV2.address, upgraded.address);
+  assert.equal(GreeterV2.transactionHash, upgraded.transactionHash);
   assert.notEqual(GreeterV2.transactionHash, Greeter.transactionHash);
 };

--- a/packages/plugin-truffle/test/migrations/2_1_deploy_greeter_transparent.js
+++ b/packages/plugin-truffle/test/migrations/2_1_deploy_greeter_transparent.js
@@ -6,8 +6,12 @@ const assert = require('assert');
 
 module.exports = async function (deployer) {
   const g = await deployProxy(Greeter, ['Hello Truffle'], { deployer, kind: 'transparent' });
+
   assert.equal(Greeter.address, g.address);
   assert.equal(Greeter.transactionHash, g.transactionHash);
 
   await upgradeProxy(g, GreeterV2, { deployer });
+
+  assert.equal(GreeterV2.address, Greeter.address);
+  assert.notEqual(GreeterV2.transactionHash, Greeter.transactionHash);
 };

--- a/packages/plugin-truffle/test/migrations/2_1_deploy_greeter_transparent.js
+++ b/packages/plugin-truffle/test/migrations/2_1_deploy_greeter_transparent.js
@@ -2,8 +2,12 @@ const Greeter = artifacts.require('Greeter');
 const GreeterV2 = artifacts.require('GreeterV2');
 
 const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const assert = require('assert');
 
 module.exports = async function (deployer) {
   const g = await deployProxy(Greeter, ['Hello Truffle'], { deployer, kind: 'transparent' });
+  assert.equal(Greeter.address, g.address);
+  assert.equal(Greeter.transactionHash, g.transactionHash);
+
   await upgradeProxy(g, GreeterV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/2_2_deploy_greeter_uups.js
+++ b/packages/plugin-truffle/test/migrations/2_2_deploy_greeter_uups.js
@@ -6,8 +6,12 @@ const assert = require('assert');
 
 module.exports = async function (deployer) {
   const g = await deployProxy(Greeter, ['Hello Truffle'], { deployer, kind: 'uups' });
+
   assert.equal(Greeter.address, g.address);
   assert.equal(Greeter.transactionHash, g.transactionHash);
 
   await upgradeProxy(g, GreeterV2, { deployer });
+
+  assert.equal(GreeterV2.address, Greeter.address);
+  assert.notEqual(GreeterV2.transactionHash, Greeter.transactionHash);
 };

--- a/packages/plugin-truffle/test/migrations/2_2_deploy_greeter_uups.js
+++ b/packages/plugin-truffle/test/migrations/2_2_deploy_greeter_uups.js
@@ -2,8 +2,12 @@ const Greeter = artifacts.require('GreeterProxiable');
 const GreeterV2 = artifacts.require('GreeterV2Proxiable');
 
 const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const assert = require('assert');
 
 module.exports = async function (deployer) {
   const g = await deployProxy(Greeter, ['Hello Truffle'], { deployer, kind: 'uups' });
+  assert.equal(Greeter.address, g.address);
+  assert.equal(Greeter.transactionHash, g.transactionHash);
+
   await upgradeProxy(g, GreeterV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/2_2_deploy_greeter_uups.js
+++ b/packages/plugin-truffle/test/migrations/2_2_deploy_greeter_uups.js
@@ -10,8 +10,9 @@ module.exports = async function (deployer) {
   assert.equal(Greeter.address, g.address);
   assert.equal(Greeter.transactionHash, g.transactionHash);
 
-  await upgradeProxy(g, GreeterV2, { deployer });
+  const upgraded = await upgradeProxy(g, GreeterV2, { deployer });
 
-  assert.equal(GreeterV2.address, Greeter.address);
+  assert.equal(GreeterV2.address, upgraded.address);
+  assert.equal(GreeterV2.transactionHash, upgraded.transactionHash);
   assert.notEqual(GreeterV2.transactionHash, Greeter.transactionHash);
 };

--- a/packages/plugin-truffle/test/migrations/2_3_deploy_greeter_beacon.js
+++ b/packages/plugin-truffle/test/migrations/2_3_deploy_greeter_beacon.js
@@ -2,9 +2,14 @@ const GreeterBeaconImpl = artifacts.require('GreeterBeaconImpl');
 const GreeterV2 = artifacts.require('GreeterV2');
 
 const { deployBeacon, deployBeaconProxy, upgradeBeacon } = require('@openzeppelin/truffle-upgrades');
+const assert = require('assert');
 
 module.exports = async function (deployer) {
   const beacon = await deployBeacon(GreeterBeaconImpl, { deployer });
-  await deployBeaconProxy(beacon, GreeterBeaconImpl, ['Hello Truffle'], { deployer });
+
+  const proxy = await deployBeaconProxy(beacon, GreeterBeaconImpl, ['Hello Truffle'], { deployer });
+  assert.equal(GreeterBeaconImpl.address, proxy.address);
+  assert.equal(GreeterBeaconImpl.transactionHash, proxy.transactionHash);
+
   await upgradeBeacon(beacon, GreeterV2, { deployer });
 };

--- a/packages/plugin-truffle/test/migrations/2_3_deploy_greeter_beacon.js
+++ b/packages/plugin-truffle/test/migrations/2_3_deploy_greeter_beacon.js
@@ -8,6 +8,7 @@ module.exports = async function (deployer) {
   const beacon = await deployBeacon(GreeterBeaconImpl, { deployer });
 
   const proxy = await deployBeaconProxy(beacon, GreeterBeaconImpl, ['Hello Truffle'], { deployer });
+
   assert.equal(GreeterBeaconImpl.address, proxy.address);
   assert.equal(GreeterBeaconImpl.transactionHash, proxy.transactionHash);
 


### PR DESCRIPTION
The implementation contract transactionHash is not set to the proxy contract transactionHash in the build/contracts/\<ContractName\>.json file.

build:
```
"networks": {
    "5777": {
      "events": {},
      "links": {},
      "address": "0xd6Fd7B733e189109Ba0874B8c886Cc509a1b2C85",
      "transactionHash": "0xef8418e2bfea6f4175e86a707154ce63508d458c363074f3161fc92bdf4cd0ec"
    }
  },
```

.openzeppelin:
```
  "proxies": [
    {
      "address": "0xd6Fd7B733e189109Ba0874B8c886Cc509a1b2C85",
      "txHash": "0xea38585fa68592eec02faec61331e91d101be13bcdd54010bb8016a41d3ecde4",
      "kind": "transparent"
    }
  ],
  "impls": {
    "851eb7f66375439b9eb97824f366c9260c3472be98d739e29eccd0f291c5aaf9": {
      "address": "0xBb2100DeA2AfE3fc661e625E6F6673ca36bF0198",
      "txHash": "0xef8418e2bfea6f4175e86a707154ce63508d458c363074f3161fc92bdf4cd0ec",
      ...
    }
  }
```