### PR TITLE
Replacing the obsolete Solidity documentation link

### DIFF
--- a/docs/modules/ROOT/pages/proxies.adoc
+++ b/docs/modules/ROOT/pages/proxies.adoc
@@ -49,7 +49,7 @@ assembly {
 }
 ----
 
-This code can be put in the https://solidity.readthedocs.io/en/v0.6.12/contracts.html#fallback-function[fallback function] of a proxy, and will forward any call to any function with any set of parameters to the logic contract without it needing to know anything in particular of the logic contract's interface. In essence, (1) the `calldata` is copied to memory, (2) the call is forwarded to the logic contract, (3) the return data from the call to the logic contract is retrieved, and (4) the returned data is forwarded back to the caller.
+This code can be put in the https://docs.soliditylang.org/en/latest/contracts.html#fallback-function[fallback function] of a proxy, and will forward any call to any function with any set of parameters to the logic contract without it needing to know anything in particular of the logic contract's interface. In essence, (1) the `calldata` is copied to memory, (2) the call is forwarded to the logic contract, (3) the return data from the call to the logic contract is retrieved, and (4) the returned data is forwarded back to the caller.
 
 A very important thing to note is that the code makes use of the EVM's `delegatecall` opcode which executes the callee's code in the context of the caller's state. That is, the logic contract controls the proxy's state and the logic contract's state is meaningless. Thus, the proxy doesn't only forward transactions to and from the logic contract, but also represents the pair's state. The state is in the proxy and the logic is in the particular implementation that the proxy points to.
 


### PR DESCRIPTION
Replacing the obsolete link to the Solidity documentation (from version 0.6.12) with the **latest**.