### PR TITLE
Enable migrating from previous Hardhat manifest location to dev instance manifest

### DIFF
--- a/packages/core/src/manifest.test.ts
+++ b/packages/core/src/manifest.test.ts
@@ -104,6 +104,42 @@ test.serial('rename manifest', async t => {
   await deleteManifests(t, id);
 });
 
+test.serial('rename hardhat from unknown to dev manifest', async t => {
+  const id = 31337;
+
+  await deleteFile(t, `.openzeppelin/unknown-${id}.json`);
+  await writeTestManifest(`.openzeppelin/unknown-${id}.json`);
+
+  const instanceId = '0xaa0';
+  const devInstanceMetadata = { networkName: 'hardhat', instanceId: instanceId };
+
+  const manifest = new Manifest(id, devInstanceMetadata, os.tmpdir());
+
+  await fs.access(`.openzeppelin/unknown-${id}.json`);
+  await manifest.lockedRun(async () => {
+    await fs.access(`${os.tmpdir()}/openzeppelin-upgrades/chain-${id}-${instanceId}.lock`);
+    const data = await manifest.read();
+    data.proxies.push({
+      address: '0x456',
+      txHash: '0x0',
+      kind: 'uups',
+    });
+
+    await fs.access(`.openzeppelin/unknown-${id}.json`);
+    await manifest.write(data);
+  });
+  t.throwsAsync(fs.access(`.openzeppelin/unknown-${id}.json`));
+  await fs.access(`${os.tmpdir()}/openzeppelin-upgrades/hardhat-${id}-${instanceId}.json`);
+
+  const dev = await new Manifest(id, devInstanceMetadata, os.tmpdir()).read();
+  t.is(dev.proxies.length, 2);
+  t.is(dev.proxies[0].address, '0x123');
+  t.is(dev.proxies[1].address, '0x456');
+
+  await deleteFile(t, `.openzeppelin/unknown-${id}.json`);
+  await deleteFile(t, `${os.tmpdir()}/openzeppelin-upgrades/hardhat-${id}-${instanceId}.json`);
+});
+
 test.serial('forked chain from known network with fallback name', async t => {
   const forkedId = 80001;
   const devId = 55555;

--- a/packages/core/src/manifest.test.ts
+++ b/packages/core/src/manifest.test.ts
@@ -359,6 +359,18 @@ test('manifest name for an unknown network, development instance, non hardhat', 
   t.is(manifest.fallbackFile, expectedPath);
 });
 
+test('manifest name for an unknown network, development instance, hardhat', t => {
+  const chainId = 31337;
+  const instanceId = '0x22223';
+  const devInstanceMetadata = { networkName: 'dev', instanceId: instanceId };
+
+  const manifest = new Manifest(chainId, devInstanceMetadata, '/tmp');
+
+  const expectedPath = `/tmp/openzeppelin-upgrades/dev-${chainId}-${instanceId}.json`;
+  t.is(manifest.file, expectedPath);
+  t.is(manifest.fallbackFile, `.openzeppelin/unknown-${chainId}.json`);
+});
+
 test('manifest dev instance without tmp dir param', t => {
   const chainId = 1;
   const instanceId = '0x33333';

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -111,6 +111,8 @@ export class Manifest {
     this.chainId = chainId;
     this.chainIdSuffix = getSuffix(chainId, devInstanceMetadata);
 
+    const defaultFallbackName = `unknown-${chainId}`;
+
     if (devInstanceMetadata !== undefined) {
       assert(osTmpDir !== undefined);
       this.dir = path.join(osTmpDir, MANIFEST_TEMP_DIR);
@@ -118,10 +120,14 @@ export class Manifest {
 
       const devName = `${devInstanceMetadata.networkName}-${this.chainIdSuffix}`;
       const devFile = path.join(this.dir, `${devName}.json`);
-      debug('development manifest file:', devFile);
 
-      this.fallbackFile = devFile;
       this.file = devFile;
+      if (chainId === 31337) {
+        this.fallbackFile = path.join(MANIFEST_DEFAULT_DIR, `${defaultFallbackName}.json`);
+      } else {
+        this.fallbackFile = devFile;
+      }
+      debug('development manifest file:', this.file, 'fallback file:', this.fallbackFile);
 
       if (devInstanceMetadata.forkedNetwork !== undefined) {
         const forkedChainId = devInstanceMetadata.forkedNetwork.chainId;
@@ -131,10 +137,10 @@ export class Manifest {
       }
     } else {
       this.dir = MANIFEST_DEFAULT_DIR;
+
       const networkName = networkNames[chainId];
-      const fallbackName = `unknown-${chainId}`;
-      this.fallbackFile = path.join(MANIFEST_DEFAULT_DIR, `${fallbackName}.json`);
-      this.file = path.join(MANIFEST_DEFAULT_DIR, `${networkName ?? fallbackName}.json`);
+      this.file = path.join(MANIFEST_DEFAULT_DIR, `${networkName ?? defaultFallbackName}.json`);
+      this.fallbackFile = path.join(MANIFEST_DEFAULT_DIR, `${defaultFallbackName}.json`);
 
       debug('manifest file:', this.file, 'fallback file:', this.fallbackFile);
     }


### PR DESCRIPTION
If a Hardhat manifest file was found in the previous location as `unknown-31337.json`, allow migrating it to the new dev instance manifest location.

Related to https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/726