### PR TITLE
add Foundry's "anvil" as a "development network"

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support Hardhat tests in --parallel mode when using Hardhat version 2.12.3 or later. ([#726](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/726))
 - Support Hardhat forked networks when using Hardhat version 2.12.3 or later. ([#726](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/726))
+- Add Foundry's anvil as a development network. ([#744](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/744))
 
 ## 1.23.0 (2023-02-09)
 

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -142,7 +142,7 @@ export async function isDevelopmentNetwork(provider: EthereumProvider): Promise<
   } else {
     const clientVersion = await getClientVersion(provider);
     const [name] = clientVersion.split('/', 1);
-    return name === 'HardhatNetwork' || name === 'EthereumJS TestRPC';
+    return name === 'HardhatNetwork' || name === 'EthereumJS TestRPC' || name === 'anvil';
   }
 }
 


### PR DESCRIPTION
And so avoid spurious "clashes" when upgrading proxy implementation contracts. Pull less hair.  👍 
Tested. Works now so much better.  😃