### PR TITLE
Remove check for beacon in proposeUpgrade

### DIFF
--- a/packages/plugin-defender-hardhat/src/propose-upgrade.ts
+++ b/packages/plugin-defender-hardhat/src/propose-upgrade.ts
@@ -43,8 +43,6 @@ export function makeProposeUpgrade(hre: HardhatRuntimeEnvironment): ProposeUpgra
 
     if (await isBeaconProxy(hre.network.provider, proxyAddress)) {
       throw new Error(`Beacon proxy is not currently supported with defender.proposeUpgrade()`);
-    } else if (await isBeacon(hre.network.provider, proxyAddress)) {
-      throw new Error(`Beacon is not currently supported with defender.proposeUpgrade()`);
     } else if (
       !multisig &&
       (await isTransparentOrUUPSProxy(hre.network.provider, proxyAddress)) &&

--- a/packages/plugin-defender-hardhat/test/propose-upgrade-beacon.js
+++ b/packages/plugin-defender-hardhat/test/propose-upgrade-beacon.js
@@ -48,7 +48,7 @@ test('block proposing an upgrade on beacon', async t => {
   const title = 'My upgrade';
   const description = 'My contract upgrade';
   await t.throwsAsync(() => proposeUpgrade(greeterBeacon.address, GreeterV2, { title, description }), {
-    message: 'Beacon is not currently supported with defender.proposeUpgrade()',
+    message: /Contract at \S+ doesn't look like an ERC 1967 proxy with a logic contract address/,
   });
 });
 
@@ -81,6 +81,6 @@ test('block proposing an upgrade reusing prepared implementation on beacon', asy
 
   await upgrades.prepareUpgrade(greeterBeacon.address, GreeterV2);
   await t.throwsAsync(() => proposeUpgrade(greeterBeacon.address, GreeterV2), {
-    message: 'Beacon is not currently supported with defender.proposeUpgrade()',
+    message: /Contract at \S+ doesn't look like an ERC 1967 proxy with a logic contract address/,
   });
 });


### PR DESCRIPTION
`proposeUpgrade` checks if the given address is a beacon by looking for the `implementation()` function selector as per the [IBeacon](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5a00628ed3d6ce3154cee4d2cc93fad920e8ea30/contracts/proxy/beacon/IBeacon.sol) interface, and blocks the proposal since beacons are not currently supported through this function.

However, some alternative [proxy contracts](https://github.com/chugsplash/chugsplash/blob/develop/packages/contracts/contracts/libraries/Proxy.sol#L131) have an `implementation()` function, which causes the plugins to misinterpret this as a beacon.

We should remove this check, and `proposeUpgrade` would just fall back to giving a different error if the given address is not an ERC1967 proxy.