### PR TITLE
Remove test contracts from source code verification

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   env: {
     node: true,
-    es6: true,
+    es2022: true,
   },
   plugins: ['unicorn'],
   rules: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   env: {
     node: true,
+    es6: true,
   },
   plugins: ['unicorn'],
   rules: {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Remove test contracts from source code verification. ([#751](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/751))
+
 ## 1.24.0 (2023-02-14)
 
 - Support Hardhat tests in --parallel mode when using Hardhat version 2.12.3 or later. ([#726](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/726))

--- a/packages/core/hardhat.config.js
+++ b/packages/core/hardhat.config.js
@@ -1,7 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
 require('dotenv/config');
 
 require('@nomiclabs/hardhat-ethers');
 require('@nomiclabs/hardhat-etherscan');
+
+for (const f of fs.readdirSync(path.join(__dirname, 'hardhat'))) {
+  require(path.join(__dirname, 'hardhat', f));
+}
 
 const settings = {
   optimizer: {

--- a/packages/core/hardhat/separate-test-contracts.js
+++ b/packages/core/hardhat/separate-test-contracts.js
@@ -1,0 +1,28 @@
+// We have some test contracts that contain unsafe code and should not be included for source code verification.
+// Thus, we force Hardhat to compile them in a separate compilation job so that they would appear in a separate
+// compilation artifact file.
+
+const { task } = require('hardhat/config');
+const {
+  TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE,
+} = require('hardhat/builtin-tasks/task-names');
+
+const marker = Symbol('test');
+const markedCache = new WeakMap();
+
+task(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE, async (params, _, runSuper) => {
+  const job = await runSuper(params);
+  // If the file is not a proxy contract, we make a copy of the config and mark it, which will cause it to get
+  // compiled separately (along with the other marked files).
+  // Dependencies of proxy contracts would be automatically included in the proxy contracts compilation.
+  if (!params.file.sourceName.startsWith('@openzeppelin/contracts/proxy/')) {
+    const originalConfig = job.solidityConfig;
+    let markedConfig = markedCache.get(originalConfig);
+    if (markedConfig === undefined) {
+      markedConfig = { ...originalConfig, [marker]: true };
+      markedCache.set(originalConfig, markedConfig);
+    }
+    job.solidityConfig = markedConfig;
+  }
+  return job;
+});

--- a/packages/core/hardhat/separate-test-contracts.js
+++ b/packages/core/hardhat/separate-test-contracts.js
@@ -3,9 +3,7 @@
 // compilation artifact file.
 
 const { task } = require('hardhat/config');
-const {
-  TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE,
-} = require('hardhat/builtin-tasks/task-names');
+const { TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE } = require('hardhat/builtin-tasks/task-names');
 
 const marker = Symbol('test');
 const markedCache = new WeakMap();

--- a/packages/core/scripts/copy-build-info.js
+++ b/packages/core/scripts/copy-build-info.js
@@ -26,15 +26,40 @@ const buildInfoField = readJSON(
 ).buildInfo;
 const jsonRelativePath = `artifacts/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol/${buildInfoField}`;
 
+// Assert that all deployable proxy artifacts use the same build-info file
+assert(
+  buildInfoField ===
+    readJSON('artifacts/@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol/BeaconProxy.dbg.json').buildInfo,
+);
+assert(
+  buildInfoField ===
+    readJSON('artifacts/@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol/UpgradeableBeacon.dbg.json')
+      .buildInfo,
+);
+assert(
+  buildInfoField ===
+    readJSON(
+      'artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.dbg.json',
+    ).buildInfo,
+);
+assert(
+  buildInfoField ===
+    readJSON('artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.dbg.json').buildInfo,
+);
+
 const buildInfo = readJSON(jsonRelativePath);
 const reducedInfo = { solcLongVersion: buildInfo.solcLongVersion, input: buildInfo.input };
 
 const sources = reducedInfo.input.sources;
+
+// Assert that all deployable proxy artifacts exist in ERC1967's build-info file
 assert(hasProperty(sources, '@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol'));
 assert(hasProperty(sources, '@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol'));
 assert(hasProperty(sources, '@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol'));
 assert(hasProperty(sources, '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol'));
 assert(hasProperty(sources, '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol'));
+
+// Assert that the build-info file does NOT contain test contracts
 assert(!hasPropertyStartsWith(sources, 'contracts/test'));
 
 writeJSON('artifacts/build-info.json', reducedInfo);

--- a/packages/core/scripts/copy-build-info.js
+++ b/packages/core/scripts/copy-build-info.js
@@ -17,7 +17,7 @@ function hasProperty(obj, prop) {
 
 function hasPropertyStartsWith(obj, prefix) {
   return Object.keys(obj).some(item => {
-    return typeof item === "string" && item.startsWith(prefix);
+    return typeof item === 'string' && item.startsWith(prefix);
   });
 }
 

--- a/packages/core/scripts/copy-build-info.js
+++ b/packages/core/scripts/copy-build-info.js
@@ -15,6 +15,12 @@ function hasProperty(obj, prop) {
   return prop in obj;
 }
 
+function hasPropertyStartsWith(obj, prefix) {
+  return Object.keys(obj).some(item => {
+    return typeof item === "string" && item.startsWith(prefix);
+  });
+}
+
 const buildInfoField = readJSON(
   'artifacts/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol/ERC1967Proxy.dbg.json',
 ).buildInfo;
@@ -29,5 +35,6 @@ assert(hasProperty(sources, '@openzeppelin/contracts/proxy/beacon/BeaconProxy.so
 assert(hasProperty(sources, '@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol'));
 assert(hasProperty(sources, '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol'));
 assert(hasProperty(sources, '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol'));
+assert(!hasPropertyStartsWith(sources, 'contracts/test'));
 
 writeJSON('artifacts/build-info.json', reducedInfo);


### PR DESCRIPTION
Fixes #750

When compiling contracts in the `core` package, marks any contracts that are not part of `@openzeppelin/contracts/proxy` to be compiled separately.

Note that dependencies of `@openzeppelin/contracts/proxy` would still be compiled along with `@openzeppelin/contracts/proxy`

This results in the `build-info` file used for source code verification to only have the proxy contracts and their dependencies.