### PR TITLE
Update proxy fallback solidity code snippet for solc 0.8.0

### DIFF
--- a/docs/modules/ROOT/pages/proxies.adoc
+++ b/docs/modules/ROOT/pages/proxies.adoc
@@ -29,9 +29,9 @@ The most immediate problem that proxies need to solve is how the proxy exposes t
 
 [source,solidity]
 ----
-// this code is for "illustration" purposes. To implement a similar functionality,
-// you should use the `Proxy` contract from the `@openzeppelin/contracts` library.
-// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/Proxy.sol
+// This code is for "illustration" purposes. To implement this functionality in production it
+// is recommended to use the `Proxy` contract from the `@openzeppelin/contracts` library.
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.8.2/contracts/proxy/Proxy.sol
 
 assembly {
   // (1) copy incoming call data

--- a/docs/modules/ROOT/pages/proxies.adoc
+++ b/docs/modules/ROOT/pages/proxies.adoc
@@ -29,23 +29,28 @@ The most immediate problem that proxies need to solve is how the proxy exposes t
 
 [source,solidity]
 ----
-assembly {
-  let ptr := mload(0x40)
+// this code is for "illustration" purposes. To implement a similar functionality,
+// you should use the `Proxy` contract from the `@openzeppelin/contracts` library.
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/Proxy.sol
 
+assembly {
   // (1) copy incoming call data
-  calldatacopy(ptr, 0, calldatasize())
+  calldatacopy(0, 0, calldatasize())
 
   // (2) forward call to logic contract
-  let result := delegatecall(gas(), sload(_impl.slot), ptr, calldatasize(), 0, 0)
-  let size := returndatasize()
+  let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
 
   // (3) retrieve return data
-  returndatacopy(ptr, 0, size)
+  returndatacopy(0, 0, returndatasize())
 
   // (4) forward return data back to caller
   switch result
-  case 0 { revert(ptr, size) }
-  default { return(ptr, size) }
+  case 0 {
+      revert(0, returndatasize())
+  }
+  default {
+      return(0, returndatasize())
+  }
 }
 ----
 

--- a/docs/modules/ROOT/pages/proxies.adoc
+++ b/docs/modules/ROOT/pages/proxies.adoc
@@ -33,11 +33,11 @@ assembly {
   let ptr := mload(0x40)
 
   // (1) copy incoming call data
-  calldatacopy(ptr, 0, calldatasize)
+  calldatacopy(ptr, 0, calldatasize())
 
   // (2) forward call to logic contract
-  let result := delegatecall(gas, _impl, ptr, calldatasize, 0, 0)
-  let size := returndatasize
+  let result := delegatecall(gas(), _impl.slot, ptr, calldatasize(), 0, 0)
+  let size := returndatasize()
 
   // (3) retrieve return data
   returndatacopy(ptr, 0, size)

--- a/docs/modules/ROOT/pages/proxies.adoc
+++ b/docs/modules/ROOT/pages/proxies.adoc
@@ -36,7 +36,7 @@ assembly {
   calldatacopy(ptr, 0, calldatasize())
 
   // (2) forward call to logic contract
-  let result := delegatecall(gas(), _impl.slot, ptr, calldatasize(), 0, 0)
+  let result := delegatecall(gas(), sload(_impl.slot), ptr, calldatasize(), 0, 0)
   let size := returndatasize()
 
   // (3) retrieve return data


### PR DESCRIPTION
In the following page for the OpenZeppelin upgrade docs --> https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies

The Solidity code snippet for the proxy forwarding (delegatecall in fallback function) does not work with the new solc version 0.8.x

<img width="786" alt="image" src="https://user-images.githubusercontent.com/31145285/224957713-889b578f-6e0a-4c5d-8ec5-3bf2b0d7101d.png">

The assembly opcodes now use the syntax with parentheses like `calldatasize()` for instance.

I am making this PR to update the docs.
Only part where I am not sure is for retrieving the address of the implementation contract from the contract state.

I use in assembly `sload(_impl.slot)` but maybe this is probably not robust because we don't know what else in the storage slot packed alongside the `_impl` address.