### PR TITLE
optimize isConstructor gas usage

### DIFF
--- a/packages/core/contracts/Initializable.sol
+++ b/packages/core/contracts/Initializable.sol
@@ -51,14 +51,12 @@ contract Initializable {
 
   /// @dev Returns true if and only if the function is running in the constructor
   function isConstructor() private view returns (bool) {
-    // extcodesize checks the size of the code stored in an address, and
-    // address returns the current address. Since the code is still not
+    // codesize checks the size of the current code. Since the code is still not
     // deployed when running a constructor, any checks on its code size will
     // yield zero, making it an effective way to detect if a contract is
     // under construction or not.
-    address self = address(this);
     uint256 cs;
-    assembly { cs := extcodesize(self) }
+    assembly { cs := codesize() }
     return cs == 0;
   }
 


### PR DESCRIPTION
It seems no particular reason to use `extcodesize` .