### PR TITLE
Allow custom signer for admin functions

### DIFF
--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -442,7 +442,7 @@ Similar to `prepareUpgrade`. This method validates and deploys the new implement
 [source,ts]
 ----
 async function deployProxyAdmin(
-  Signer?: ethers.Signer,
+  signer?: ethers.Signer,
   opts?: {
     timeout?: number,
     pollingInterval?: number,
@@ -454,7 +454,7 @@ Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy
 
 *Parameters:*
 
-* `Signer` - the signer to use for deployment.
+* `signer` - the signer to use for deployment.
 * `opts` - an object with options:
 ** See <<common-options>>.
 
@@ -474,7 +474,7 @@ Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy
 async function changeProxyAdmin(
   proxyAddress: string,
   newAdmin: string,
-  Signer?: ethers.Signer,
+  signer?: ethers.Signer,
 ): Promise<void>
 ----
 
@@ -484,7 +484,7 @@ Changes the admin for a specific proxy.
 
 * `proxyAddress` - the address of the proxy to change.
 * `newAdmin` - the new admin address.
-* `Signer` - the signer to use for the transaction.
+* `signer` - the signer to use for the transaction.
 
 [[admin-transfer-proxy-admin-ownership]]
 == admin.transferProxyAdminOwnership
@@ -493,7 +493,7 @@ Changes the admin for a specific proxy.
 ----
 async function transferProxyAdminOwnership(
   newAdmin: string,
-  Signer?: ethers.Signer,
+  signer?: ethers.Signer,
 ): Promise<void>
 ----
 
@@ -502,7 +502,7 @@ Changes the owner of the proxy admin contract, which is the default admin for up
 *Parameters:*
 
 * `newAdmin` - the new admin address.
-* `Signer` - the signer to use for the transaction.
+* `signer` - the signer to use for the transaction.
 
 [[erc1967]]
 == erc1967

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -474,6 +474,7 @@ Deploys a https://docs.openzeppelin.com/contracts/4.x/api/proxy#ProxyAdmin[proxy
 async function changeProxyAdmin(
   proxyAddress: string,
   newAdmin: string,
+  Signer?: ethers.Signer,
 ): Promise<void>
 ----
 
@@ -483,6 +484,7 @@ Changes the admin for a specific proxy.
 
 * `proxyAddress` - the address of the proxy to change.
 * `newAdmin` - the new admin address.
+* `Signer` - the signer to use for the transaction.
 
 [[admin-transfer-proxy-admin-ownership]]
 == admin.transferProxyAdminOwnership
@@ -491,6 +493,7 @@ Changes the admin for a specific proxy.
 ----
 async function transferProxyAdminOwnership(
   newAdmin: string,
+  Signer?: ethers.Signer,
 ): Promise<void>
 ----
 
@@ -499,6 +502,7 @@ Changes the owner of the proxy admin contract, which is the default admin for up
 *Parameters:*
 
 * `newAdmin` - the new admin address.
+* `Signer` - the signer to use for the transaction.
 
 [[erc1967]]
 == erc1967

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support custom signer for `admin` functions. ([#784](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/784))
+
 ## 1.23.1 (2023-04-26)
 
 - Enable `verify` to fall back to hardhat-etherscan if proxy bytecode does not match. ([#752](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/752))

--- a/packages/plugin-hardhat/src/admin.ts
+++ b/packages/plugin-hardhat/src/admin.ts
@@ -1,19 +1,19 @@
 import chalk from 'chalk';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { Manifest, getAdminAddress } from '@openzeppelin/upgrades-core';
-import { Contract } from 'ethers';
+import { Contract, Signer } from 'ethers';
 import { getProxyAdminFactory } from './utils';
 
 const SUCCESS_CHECK = chalk.green('✔') + ' ';
 const FAILURE_CROSS = chalk.red('✘') + ' ';
 
-export type ChangeAdminFunction = (proxyAddress: string, newAdmin: string) => Promise<void>;
-export type TransferProxyAdminOwnershipFunction = (newOwner: string) => Promise<void>;
-export type GetInstanceFunction = () => Promise<Contract>;
+export type ChangeAdminFunction = (proxyAddress: string, newAdmin: string, signer?: Signer) => Promise<void>;
+export type TransferProxyAdminOwnershipFunction = (newOwner: string, signer?: Signer) => Promise<void>;
+export type GetInstanceFunction = (signer?: Signer) => Promise<Contract>;
 
 export function makeChangeProxyAdmin(hre: HardhatRuntimeEnvironment): ChangeAdminFunction {
-  return async function changeProxyAdmin(proxyAddress, newAdmin) {
-    const admin = await getManifestAdmin(hre);
+  return async function changeProxyAdmin(proxyAddress: string, newAdmin: string, signer?: Signer) {
+    const admin = await getManifestAdmin(hre, signer);
     const proxyAdminAddress = await getAdminAddress(hre.network.provider, proxyAddress);
 
     if (admin.address !== proxyAdminAddress) {
@@ -25,8 +25,8 @@ export function makeChangeProxyAdmin(hre: HardhatRuntimeEnvironment): ChangeAdmi
 }
 
 export function makeTransferProxyAdminOwnership(hre: HardhatRuntimeEnvironment): TransferProxyAdminOwnershipFunction {
-  return async function transferProxyAdminOwnership(newOwner) {
-    const admin = await getManifestAdmin(hre);
+  return async function transferProxyAdminOwnership(newOwner: string, signer?: Signer) {
+    const admin = await getManifestAdmin(hre, signer);
     await admin.transferOwnership(newOwner);
 
     const { provider } = hre.network;
@@ -43,12 +43,12 @@ export function makeTransferProxyAdminOwnership(hre: HardhatRuntimeEnvironment):
 }
 
 export function makeGetInstanceFunction(hre: HardhatRuntimeEnvironment): GetInstanceFunction {
-  return async function getInstance() {
-    return await getManifestAdmin(hre);
+  return async function getInstance(signer?: Signer) {
+    return await getManifestAdmin(hre, signer);
   };
 }
 
-export async function getManifestAdmin(hre: HardhatRuntimeEnvironment): Promise<Contract> {
+export async function getManifestAdmin(hre: HardhatRuntimeEnvironment, signer?: Signer): Promise<Contract> {
   const manifest = await Manifest.forNetwork(hre.network.provider);
   const manifestAdmin = await manifest.getAdmin();
   const proxyAdminAddress = manifestAdmin?.address;
@@ -57,6 +57,6 @@ export async function getManifestAdmin(hre: HardhatRuntimeEnvironment): Promise<
     throw new Error('No ProxyAdmin was found in the network manifest');
   }
 
-  const AdminFactory = await getProxyAdminFactory(hre);
+  const AdminFactory = await getProxyAdminFactory(hre, signer);
   return AdminFactory.attach(proxyAdminAddress);
 }

--- a/packages/plugin-hardhat/test/transparent-change-admin-signer.js
+++ b/packages/plugin-hardhat/test/transparent-change-admin-signer.js
@@ -1,0 +1,17 @@
+const test = require('ava');
+
+const { ethers, upgrades, network } = require('hardhat');
+const { getAdminAddress } = require('@openzeppelin/upgrades-core');
+
+const testAddress = '0x1E6876a6C2757de611c9F12B23211dBaBd1C9028';
+
+test('changeProxyAdmin - signer', async t => {
+  const signer = (await ethers.getSigners())[1];
+  const Greeter = await ethers.getContractFactory('Greeter', signer);
+
+  const greeter = await upgrades.deployProxy(Greeter, ['Hello, Hardhat!'], { kind: 'transparent' });
+  await upgrades.admin.changeProxyAdmin(greeter.address, testAddress, signer);
+  const newAdmin = await getAdminAddress(network.provider, greeter.address);
+
+  t.is(newAdmin, testAddress);
+});

--- a/packages/plugin-hardhat/test/transparent-change-admin-wrong-signer.js
+++ b/packages/plugin-hardhat/test/transparent-change-admin-wrong-signer.js
@@ -1,0 +1,20 @@
+const test = require('ava');
+
+const { ethers, upgrades } = require('hardhat');
+
+const testAddress = '0x1E6876a6C2757de611c9F12B23211dBaBd1C9028';
+
+test.before(async t => {
+  t.context.Greeter = await ethers.getContractFactory('Greeter');
+});
+
+test('changeProxyAdmin - wrong signer', async t => {
+  const { Greeter } = t.context;
+  const greeter = await upgrades.deployProxy(Greeter, ['Hello, Hardhat!'], { kind: 'transparent' });
+
+  const signer = (await ethers.getSigners())[1];
+
+  await t.throwsAsync(() => upgrades.admin.changeProxyAdmin(greeter.address, testAddress, signer), {
+    message: /(caller is not the owner)/,
+  });
+});

--- a/packages/plugin-hardhat/test/transparent-transfer-admin-ownership-signer.js
+++ b/packages/plugin-hardhat/test/transparent-transfer-admin-ownership-signer.js
@@ -1,0 +1,20 @@
+const test = require('ava');
+
+const hre = require('hardhat');
+const { getManifestAdmin } = require('@openzeppelin/hardhat-upgrades/dist/admin.js');
+const { ethers, upgrades } = hre;
+const testAddress = '0x1E6876a6C2757de611c9F12B23211dBaBd1C9028';
+
+test('transferProxyAdminOwnership - signer', async t => {
+  // we need to deploy a proxy so we have a Proxy Admin
+  const signer = (await ethers.getSigners())[1];
+  const Greeter = await ethers.getContractFactory('Greeter', signer);
+
+  await upgrades.deployProxy(Greeter, ['Hello, Hardhat!'], { kind: 'transparent' });
+
+  const admin = await getManifestAdmin(hre);
+  await upgrades.admin.transferProxyAdminOwnership(testAddress, signer);
+  const newOwner = await admin.owner();
+
+  t.is(newOwner, testAddress);
+});

--- a/packages/plugin-hardhat/test/transparent-transfer-admin-ownership-wrong-signer.js
+++ b/packages/plugin-hardhat/test/transparent-transfer-admin-ownership-wrong-signer.js
@@ -1,0 +1,21 @@
+const test = require('ava');
+
+const hre = require('hardhat');
+const { ethers, upgrades } = hre;
+const testAddress = '0x1E6876a6C2757de611c9F12B23211dBaBd1C9028';
+
+test.before(async t => {
+  t.context.Greeter = await ethers.getContractFactory('Greeter');
+});
+
+test('transferProxyAdminOwnership - wrong signer', async t => {
+  // we need to deploy a proxy so we have a Proxy Admin
+  const { Greeter } = t.context;
+  await upgrades.deployProxy(Greeter, ['Hello, Hardhat!'], { kind: 'transparent' });
+
+  const signer = (await ethers.getSigners())[1];
+
+  await t.throwsAsync(() => upgrades.admin.transferProxyAdminOwnership(testAddress, signer), {
+    message: /(caller is not the owner)/,
+  });
+});


### PR DESCRIPTION
Fixes #782 

Supports passing in an optional Signer parameter to `admin.changeProxyAdmin` and `admin.transferProxyAdminOwnership` 