### PR TITLE
Use proxies from OpenZeppelin Contracts 4.8.3

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Use proxies from Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
+- Use proxies from OpenZeppelin Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
 
 ## 1.26.0 (2023-05-08)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use proxies from Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
+
 ## 1.26.0 (2023-05-08)
 
 - Enable using OpenZeppelin Platform for deployments. ([#763](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/763))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "@ava/typescript": "^2.0.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-etherscan": "^3.0.0",
-    "@openzeppelin/contracts": "4.1.0",
+    "@openzeppelin/contracts": "4.8.3",
     "@openzeppelin/contracts-upgradeable": "4.1.0",
     "@types/cbor": "^5.0.0",
     "@types/debug": "^4.1.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/upgrades-core",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/core",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-etherscan": "^3.0.0",
     "@openzeppelin/contracts": "4.8.3",
-    "@openzeppelin/contracts-upgradeable": "4.1.0",
+    "@openzeppelin/contracts-upgradeable": "4.8.3",
     "@types/cbor": "^5.0.0",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^7.0.2",

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Use proxies from Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
+- Use proxies from OpenZeppelin Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
 
 ## 1.25.1 (2023-05-10)
 

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use proxies from Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
+
 ## 1.25.1 (2023-05-10)
 
 - Fix type error with `platform.deployContract`. ([#793](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/793))

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -33,7 +33,7 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@openzeppelin/upgrades-core": "^1.26.0",
+    "@openzeppelin/upgrades-core": "^1.26.1",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",
     "defender-admin-client": "^1.39.0",

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -24,7 +24,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@openzeppelin/contracts": "4.8.3",
-    "@openzeppelin/contracts-upgradeable": "4.1.0",
+    "@openzeppelin/contracts-upgradeable": "4.8.3",
     "@types/mocha": "^7.0.2",
     "ava": "^5.0.0",
     "fgbg": "^0.1.4",

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
-    "@openzeppelin/contracts": "4.1.0",
+    "@openzeppelin/contracts": "4.8.3",
     "@openzeppelin/contracts-upgradeable": "4.1.0",
     "@types/mocha": "^7.0.2",
     "ava": "^5.0.0",

--- a/packages/plugin-hardhat/src/upgrade-proxy.ts
+++ b/packages/plugin-hardhat/src/upgrade-proxy.ts
@@ -6,7 +6,7 @@ import { Manifest, getAdminAddress, getCode, isEmptySlot } from '@openzeppelin/u
 import {
   UpgradeProxyOptions,
   deployProxyImpl,
-  getTransparentUpgradeableProxyFactory,
+  getITransparentUpgradeableProxyFactory,
   getProxyAdminFactory,
   getContractAddress,
   ContractAddressOrInstance,
@@ -46,9 +46,9 @@ export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment, platformModule:
     const adminBytecode = await getCode(provider, adminAddress);
 
     if (isEmptySlot(adminAddress) || adminBytecode === '0x') {
-      // No admin contract: use TransparentUpgradeableProxyFactory to get proxiable interface
-      const TransparentUpgradeableProxyFactory = await getTransparentUpgradeableProxyFactory(hre, signer);
-      const proxy = TransparentUpgradeableProxyFactory.attach(proxyAddress);
+      // No admin contract: use ITransparentUpgradeableProxyFactory to get proxiable interface
+      const ITransparentUpgradeableProxyFactory = await getITransparentUpgradeableProxyFactory(hre, signer);
+      const proxy = ITransparentUpgradeableProxyFactory.attach(proxyAddress);
 
       return (nextImpl, call) => (call ? proxy.upgradeToAndCall(nextImpl, call) : proxy.upgradeTo(nextImpl));
     } else {

--- a/packages/plugin-hardhat/src/utils/factories.ts
+++ b/packages/plugin-hardhat/src/utils/factories.ts
@@ -4,6 +4,7 @@ import ERC1967Proxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/co
 import BeaconProxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol/BeaconProxy.json';
 import UpgradeableBeacon from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol/UpgradeableBeacon.json';
 import TransparentUpgradeableProxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json';
+import ITransparentUpgradeableProxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/ITransparentUpgradeableProxy.json';
 import ProxyAdmin from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json';
 
 export async function getProxyFactory(hre: HardhatRuntimeEnvironment, signer?: Signer): Promise<ContractFactory> {
@@ -15,6 +16,13 @@ export async function getTransparentUpgradeableProxyFactory(
   signer?: Signer,
 ): Promise<ContractFactory> {
   return hre.ethers.getContractFactory(TransparentUpgradeableProxy.abi, TransparentUpgradeableProxy.bytecode, signer);
+}
+
+export async function getITransparentUpgradeableProxyFactory(
+  hre: HardhatRuntimeEnvironment,
+  signer?: Signer,
+): Promise<ContractFactory> {
+  return hre.ethers.getContractFactory(ITransparentUpgradeableProxy.abi, ITransparentUpgradeableProxy.bytecode, signer);
 }
 
 export async function getProxyAdminFactory(hre: HardhatRuntimeEnvironment, signer?: Signer): Promise<ContractFactory> {

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Use proxies from Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
+- Use proxies from OpenZeppelin Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
 
 ## 1.18.0 (2023-04-26)
 

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use proxies from Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))
+
 ## 1.18.0 (2023-04-26)
 
 - Support `prepareUpgrade` from an implementation address. ([#777](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/777))

--- a/packages/plugin-truffle/package.json
+++ b/packages/plugin-truffle/package.json
@@ -24,7 +24,7 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@openzeppelin/upgrades-core": "^1.25.0",
+    "@openzeppelin/upgrades-core": "^1.26.1",
     "@truffle/contract": "^4.3.26",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",

--- a/packages/plugin-truffle/src/upgrade-proxy.ts
+++ b/packages/plugin-truffle/src/upgrade-proxy.ts
@@ -5,7 +5,7 @@ import {
   ContractInstance,
   wrapProvider,
   deployProxyImpl,
-  getTransparentUpgradeableProxyFactory,
+  getITransparentUpgradeableProxyFactory,
   getProxyAdminFactory,
   UpgradeProxyOptions,
   withDefaults,
@@ -46,9 +46,9 @@ async function getUpgrader(
   const adminBytecode = await getCode(provider, adminAddress);
 
   if (isEmptySlot(adminAddress) || adminBytecode === '0x') {
-    // No admin contract: use TransparentUpgradeableProxyFactory to get proxiable interface
-    const TransparentUpgradeableProxyFactory = getTransparentUpgradeableProxyFactory(contractTemplate);
-    const proxy = new TransparentUpgradeableProxyFactory(proxyAddress);
+    // No admin contract: use ITransparentUpgradeableProxyFactory to get proxiable interface
+    const ITransparentUpgradeableProxyFactory = getITransparentUpgradeableProxyFactory(contractTemplate);
+    const proxy = new ITransparentUpgradeableProxyFactory(proxyAddress);
 
     return (nextImpl, call) => {
       return call ? proxy.upgradeToAndCall(nextImpl, call) : proxy.upgradeTo(nextImpl);

--- a/packages/plugin-truffle/src/utils/factories.ts
+++ b/packages/plugin-truffle/src/utils/factories.ts
@@ -2,6 +2,7 @@ import { TruffleContract, ContractClass, getTruffleDefaults, getTruffleProvider 
 
 import ERC1967ProxyArtifact from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol/ERC1967Proxy.json';
 import TransparentUpgradeableProxyArtifact from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json';
+import ITransparentUpgradeableProxyArtifact from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/ITransparentUpgradeableProxy.json';
 import ProxyAdminArtifact from '@openzeppelin/upgrades-core/artifacts//@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json';
 import BeaconProxyArtifact from '@openzeppelin/upgrades-core/artifacts//@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol/BeaconProxy.json';
 import UpgradeableBeaconArtifact from '@openzeppelin/upgrades-core/artifacts//@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol/UpgradeableBeacon.json';
@@ -17,6 +18,7 @@ function makeFactoryGetter(artifacts: unknown): (template?: ContractClass) => Co
 
 export const getProxyFactory = makeFactoryGetter(ERC1967ProxyArtifact);
 export const getTransparentUpgradeableProxyFactory = makeFactoryGetter(TransparentUpgradeableProxyArtifact);
+export const getITransparentUpgradeableProxyFactory = makeFactoryGetter(ITransparentUpgradeableProxyArtifact);
 export const getProxyAdminFactory = makeFactoryGetter(ProxyAdminArtifact);
 export const getBeaconProxyFactory = makeFactoryGetter(BeaconProxyArtifact);
 export const getUpgradeableBeaconFactory = makeFactoryGetter(UpgradeableBeaconArtifact);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2182,10 +2182,10 @@
   dependencies:
     "@octokit/openapi-types" "^14.0.0"
 
-"@openzeppelin/contracts-upgradeable@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.1.0.tgz#36a6113ceeda278ae14f740280e5388161dfd383"
-  integrity sha512-QZSvbYqNpU/x60vARhq/jghh97VWjml3NAlKfu4u1XehvpEBbHVXJyKTBSZtZY7jviG305jOczEisnN8VeOMcw==
+"@openzeppelin/contracts-upgradeable@4.8.3":
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.3.tgz#6b076a7b751811b90fe3a172a7faeaa603e13a3f"
+  integrity sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg==
 
 "@openzeppelin/contracts@4.8.3":
   version "4.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,10 +2187,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.1.0.tgz#36a6113ceeda278ae14f740280e5388161dfd383"
   integrity sha512-QZSvbYqNpU/x60vARhq/jghh97VWjml3NAlKfu4u1XehvpEBbHVXJyKTBSZtZY7jviG305jOczEisnN8VeOMcw==
 
-"@openzeppelin/contracts@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.1.0.tgz#baec89a7f5f73e3d8ea582a78f1980134b605375"
-  integrity sha512-TihZitscnaHNcZgXGj9zDLDyCqjziytB4tMCwXq0XimfWkAjBYyk5/pOsDbbwcavhlc79HhpTEpQcrMnPVa1mw==
+"@openzeppelin/contracts@4.8.3":
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.3.tgz#cbef3146bfc570849405f59cba18235da95a252a"
+  integrity sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==
 
 "@openzeppelin/docs-utils@^0.1.0":
   version "0.1.3"


### PR DESCRIPTION
Closes #774
Closes #773
Closes #772
Closes #771

Updates proxies in order to use updated [TransparentUpgradeableProxy](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4154) from [Contracts 4.8.3](https://github.com/OpenZeppelin/openzeppelin-contracts/releases/tag/v4.8.3).

Note: Using this version of the plugin to verify a proxy that was deployed by a previous version of the plugin will fail.  See https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/674 for details.  Users who are affected should downgrade the plugins to the previous version, run the verify task, then upgrade the plugins back to the latest version.