### PR TITLE
Fix ITransparentUpgradeableProxy.json not found.

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add missing file in package. ([#797](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/797))
+
 ## 1.26.1 (2023-05-12)
 
 - Use proxies from OpenZeppelin Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/upgrades-core",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/core",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "/artifacts/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol",
     "/artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json",
     "/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json",
+    "/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/ITransparentUpgradeableProxy.json",
     "/artifacts/build-info.json"
   ],
   "scripts": {

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add missing file in package. ([#797](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/797))
+
 ## 1.25.2 (2023-05-12)
 
 - Use proxies from OpenZeppelin Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -33,7 +33,7 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@openzeppelin/upgrades-core": "^1.26.1",
+    "@openzeppelin/upgrades-core": "^1.26.2",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",
     "defender-admin-client": "^1.39.0",

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add missing file in package. ([#797](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/797))
+
 ## 1.18.1 (2023-05-12)
 
 - Use proxies from OpenZeppelin Contracts 4.8.3. ([#795](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795))

--- a/packages/plugin-truffle/package.json
+++ b/packages/plugin-truffle/package.json
@@ -24,7 +24,7 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@openzeppelin/upgrades-core": "^1.26.1",
+    "@openzeppelin/upgrades-core": "^1.26.2",
     "@truffle/contract": "^4.3.26",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/795 missing this interface file and cause compile error.

```
Error: Cannot find module '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/ITransparentUpgradeableProxy.json'
```