### PR TITLE
Support `salt` option for deployments on OpenZeppelin Platform

### DIFF
--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -25,6 +25,7 @@ The following options are common to some functions.
 * `usePlatformDeploy`: (`boolean`) Deploy contracts using the OpenZeppelin Platform instead of ethers.js. See xref:platform-deploy.adoc[Using with OpenZeppelin Platform]. **Note**: OpenZeppelin Platform is in beta and functionality related to Platform is subject to change.
 * `verifySourceCode`: (`boolean`) When using Platform, whether to verify source code on block explorers. Defaults to `true`.
 * `walletId`: (`string`) When using Platform, the ID of the wallet to use for the deployment. Defaults to the wallet configured for your deployment environment on Platform.
+* `salt`: (`string`) When using Platform, deployments are performed using the CREATE2 opcode. Use this option to provide the salt for the deployment. Defaults to a random salt.
 
 Note that the options `unsafeAllow` can also be specified in a more granular way directly in the source code if using Solidity >=0.8.2. See xref:faq.adoc#how-can-i-disable-checks[How can I disable some of the checks?]
 

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Support `salt` option for deployments on OpenZeppelin Platform. ([#799](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/799))
+
+**Note**: OpenZeppelin Platform is currently in beta and functionality related to it is subject to change.
+
 ## 1.26.0 (2023-05-15)
 
 - Improve OpenZeppelin Platform functions. ([#791](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/791))

--- a/packages/plugin-hardhat/src/platform/deploy.ts
+++ b/packages/plugin-hardhat/src/platform/deploy.ts
@@ -76,6 +76,10 @@ export async function platformDeploy(
     debug(`License type: ${license}`);
   }
 
+  if (opts.salt !== undefined) {
+    debug(`Salt: ${opts.salt}`);
+  }
+
   let deploymentResponse: DeploymentResponse;
   try {
     deploymentResponse = await client.Deployment.deploy({
@@ -87,6 +91,7 @@ export async function platformDeploy(
       constructorInputs: constructorArgs,
       verifySourceCode: verifySourceCode,
       walletId: opts.walletId,
+      salt: opts.salt,
     });
   } catch (e: any) {
     if (e.response?.data?.message?.includes('licenseType should be equal to one of the allowed values')) {

--- a/packages/plugin-hardhat/src/utils/options.ts
+++ b/packages/plugin-hardhat/src/utils/options.ts
@@ -54,6 +54,7 @@ export type Platform = {
 export type PlatformDeployOptions = Platform & {
   verifySourceCode?: boolean;
   walletId?: string;
+  salt?: string;
 };
 
 export type DeployBeaconProxyOptions = DeployOpts & ProxyKindOption & Initializer & PlatformDeployOptions;

--- a/packages/plugin-hardhat/test/platform-deploy.js
+++ b/packages/plugin-hardhat/test/platform-deploy.js
@@ -18,6 +18,7 @@ const ADDRESS = '0x2';
 const TX_RESPONSE = 'mocked response';
 const ETHERSCAN_API_KEY = 'fakeKey';
 const WALLET_ID = '123-abc';
+const SALT = 'customsalt';
 
 const LOGIC_ADDRESS = '0x0000000000000000000000000000000000000003';
 const ADMIN_ADDRESS = '0x0000000000000000000000000000000000000004';
@@ -109,6 +110,7 @@ test('calls platform deploy', async t => {
     constructorInputs: [],
     verifySourceCode: true,
     walletId: undefined,
+    salt: undefined,
   });
 
   assertResult(t, result);
@@ -133,6 +135,32 @@ test('calls platform deploy with walletId', async t => {
     constructorInputs: [],
     verifySourceCode: true,
     walletId: WALLET_ID,
+    salt: undefined,
+  });
+
+  assertResult(t, result);
+});
+
+test('calls platform deploy with salt', async t => {
+  const { spy, deploy, fakeHre, fakeChainId } = t.context;
+
+  const contractPath = 'contracts/Greeter.sol';
+  const contractName = 'Greeter';
+
+  const factory = await ethers.getContractFactory(contractName);
+  const result = await deploy.platformDeploy(fakeHre, factory, { salt: SALT });
+
+  const buildInfo = await hre.artifacts.getBuildInfo(`${contractPath}:${contractName}`);
+  sinon.assert.calledWithExactly(spy, {
+    contractName: contractName,
+    contractPath: contractPath,
+    network: fakeChainId,
+    artifactPayload: JSON.stringify(buildInfo),
+    licenseType: 'None',
+    constructorInputs: [],
+    verifySourceCode: true,
+    walletId: undefined,
+    salt: SALT,
   });
 
   assertResult(t, result);
@@ -157,6 +185,7 @@ test('calls platform deploy with license', async t => {
     constructorInputs: [],
     verifySourceCode: true,
     walletId: undefined,
+    salt: undefined,
   });
 
   assertResult(t, result);
@@ -181,6 +210,7 @@ test('calls platform deploy with constructor args', async t => {
     constructorInputs: [10],
     verifySourceCode: true,
     walletId: undefined,
+    salt: undefined,
   });
 
   assertResult(t, result);
@@ -205,6 +235,7 @@ test('calls platform deploy with verify false', async t => {
     constructorInputs: [],
     verifySourceCode: false,
     walletId: undefined,
+    salt: undefined,
   });
 
   assertResult(t, result);
@@ -229,6 +260,7 @@ test('calls platform deploy with ERC1967Proxy', async t => {
     constructorInputs: [LOGIC_ADDRESS, DATA],
     verifySourceCode: true,
     walletId: undefined,
+    salt: undefined,
   });
 });
 
@@ -251,6 +283,7 @@ test('calls platform deploy with BeaconProxy', async t => {
     constructorInputs: [LOGIC_ADDRESS, DATA],
     verifySourceCode: true,
     walletId: undefined,
+    salt: undefined,
   });
 });
 
@@ -273,5 +306,6 @@ test('calls platform deploy with TransparentUpgradeableProxy', async t => {
     constructorInputs: [LOGIC_ADDRESS, ADMIN_ADDRESS, DATA],
     verifySourceCode: true,
     walletId: undefined,
+    salt: undefined,
   });
 });


### PR DESCRIPTION
When using Platform, deployments are performed using the CREATE2 opcode. This option allows users to provide the salt for the deployment. If not provided, Platform defaults to using a random salt.