### PR TITLE
Add forceDeployImplementation option

### DIFF
--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -21,7 +21,8 @@ The following options are common to some functions.
 * `constructorArgs`: (`unknown[]`) Provide arguments for the constructor of the implementation contract. Note that these are different from initializer arguments, and will be used in the deployment of the implementation contract itself. Can be used to initialize immutable variables.
 * `timeout`: (`number`) Timeout in milliseconds to wait for the transaction confirmation when deploying an implementation contract or proxy admin contract. Defaults to `60000`. Use `0` to wait indefinitely. 
 * `pollingInterval`: (`number`) Polling interval in milliseconds between checks for the transaction confirmation when deploying an implementation contract or proxy admin contract. Defaults to `5000`.
-* `useDeployedImplementation`: (`boolean`) Require the use of an existing deployed implementation. If this is set to `true` and the implementation contract was not previously deployed or is not found in the network file, an error will be thrown instead of deploying the implementation.
+* `useDeployedImplementation`: (`boolean`) Require the use of an existing deployed implementation. If this is set to `true` and the implementation contract was not previously deployed or is not found in the network file, an error will be thrown instead of deploying the implementation. Defaults to `false`.
+* `forceDeployImplementation`: (`boolean`) Force the deployment of the implementation contract even if it was previously deployed. This can be used with the `salt` option when deploying a proxy through OpenZeppelin Platform to ensure that the new proxy has a matching implementation deployed with the same salt. Cannot be used together with `useDeployedImplementation`. Defaults to `false`.
 * `usePlatformDeploy`: (`boolean`) Deploy contracts using the OpenZeppelin Platform instead of ethers.js. See xref:platform-deploy.adoc[Using with OpenZeppelin Platform]. **Note**: OpenZeppelin Platform is in beta and functionality related to Platform is subject to change.
 * `verifySourceCode`: (`boolean`) When using Platform, whether to verify source code on block explorers. Defaults to `true`.
 * `walletId`: (`string`) When using Platform, the ID of the wallet to use for the deployment. Defaults to the wallet configured for your deployment environment on Platform.
@@ -49,6 +50,7 @@ async function deployProxy(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     kind?: 'uups' | 'transparent',
     usePlatformDeploy?: boolean,
   },
@@ -88,6 +90,7 @@ async function upgradeProxy(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     kind?: 'uups' | 'transparent',
   },
 ): Promise<ethers.Contract>
@@ -120,6 +123,7 @@ async function deployBeacon(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
   },
 ): Promise<ethers.Contract>
 ----
@@ -156,6 +160,7 @@ async function upgradeBeacon(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
   },
 ): Promise<ethers.Contract>
 ----
@@ -286,6 +291,7 @@ async function deployImplementation(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     getTxResponse?: boolean,
     kind?: 'uups' | 'transparent' | 'beacon',
     usePlatformDeploy?: boolean,
@@ -377,6 +383,7 @@ async function prepareUpgrade(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     getTxResponse?: boolean,
     kind?: 'uups' | 'transparent' | 'beacon',
     usePlatformDeploy?: boolean,
@@ -450,6 +457,7 @@ async function proposeUpgrade(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     kind?: 'uups' | 'transparent' | 'beacon',
     usePlatformDeploy?: boolean,
     approvalProcessId?: string,
@@ -521,6 +529,7 @@ async function proposeUpgrade(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     kind?: 'uups' | 'transparent' | 'beacon',
     title?: string,
     description?: string,

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -21,6 +21,7 @@ The following options are common to some functions.
 * `unsafeSkipStorageCheck`: (`boolean`) upgrades the proxy or beacon without first checking for storage layout compatibility errors. This is a dangerous option meant to be used as a last resort.
 * `constructorArgs`: (`unknown[]`) Provide arguments for the constructor of the implementation contract. Note that these are different from initializer arguments, and will be used in the deployment of the implementation contract itself. Can be used to initialize immutable variables.
 * `useDeployedImplementation`: (`boolean`) Require the use of an existing deployed implementation. If this is set to `true` and the implementation contract was not previously deployed or is not found in the network file, an error will be thrown instead of deploying the implementation.
+* `forceDeployImplementation`: (`boolean`) Force the deployment of the implementation contract even if it was previously deployed. Cannot be used together with `useDeployedImplementation`. Defaults to `false`.
 
 Note that the options `unsafeAllow` can also be specified in a more granular way directly in the source code if using Solidity >=0.8.2. See xref:faq.adoc#how-can-i-disable-checks[How can I disable some of the checks?]
 
@@ -45,6 +46,7 @@ async function deployProxy(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     kind?: 'uups' | 'transparent',
   },
 ): Promise<ContractInstance>
@@ -86,6 +88,7 @@ async function upgradeProxy(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     kind?: 'uups' | 'transparent',
   },
 ): Promise<ContractInstance>
@@ -119,6 +122,7 @@ async function deployBeacon(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
   },
 ): Promise<ContractInstance>
 ----
@@ -156,6 +160,7 @@ async function upgradeBeacon(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
   },
 ): Promise<ContractInstance>
 ----
@@ -286,6 +291,7 @@ async function deployImplementation(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     kind?: 'uups' | 'transparent' | 'beacon',
   },
 ): Promise<string>
@@ -375,6 +381,7 @@ async function prepareUpgrade(
     timeout?: number,
     pollingInterval?: number,
     useDeployedImplementation?: boolean,
+    forceDeployImplementation?: boolean,
     kind?: 'uups' | 'transparent' | 'beacon',
   },
 ): Promise<string>

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support `salt` option for deployments on OpenZeppelin Platform. ([#799](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/799))
+- Support `forceDeployImplementation` option. ([#800](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/800))
 
 **Note**: OpenZeppelin Platform is currently in beta and functionality related to it is subject to change.
 

--- a/packages/plugin-hardhat/src/utils/deploy-impl.ts
+++ b/packages/plugin-hardhat/src/utils/deploy-impl.ts
@@ -99,6 +99,14 @@ async function deployImpl(
 ): Promise<DeployedImpl> {
   const layout = deployData.layout;
 
+  if (opts.useDeployedImplementation && opts.forceDeployImplementation) {
+    throw new UpgradesError(
+      'The useDeployedImplementation and forceDeployImplementation options cannot both be set to true at the same time',
+    );
+  }
+
+  const merge = opts.forceDeployImplementation;
+
   const deployment = await fetchOrDeployGetDeployment(
     deployData.version,
     deployData.provider,
@@ -119,7 +127,7 @@ async function deployImpl(
       return { ...deployment, layout };
     },
     opts,
-    undefined,
+    merge,
     remoteDeploymentId => getRemoteDeployment(hre, remoteDeploymentId),
   );
 

--- a/packages/plugin-hardhat/src/utils/options.ts
+++ b/packages/plugin-hardhat/src/utils/options.ts
@@ -13,6 +13,7 @@ export type StandaloneOptions = StandaloneValidationOptions &
   DeployOpts & {
     constructorArgs?: unknown[];
     useDeployedImplementation?: boolean;
+    forceDeployImplementation?: boolean;
   };
 
 /**
@@ -25,7 +26,8 @@ export function withDefaults(opts: UpgradeOptions = {}): Required<UpgradeOptions
     constructorArgs: opts.constructorArgs ?? [],
     timeout: opts.timeout ?? 60e3,
     pollingInterval: opts.pollingInterval ?? 5e3,
-    useDeployedImplementation: opts.useDeployedImplementation ?? true,
+    useDeployedImplementation: opts.useDeployedImplementation ?? false,
+    forceDeployImplementation: opts.forceDeployImplementation ?? false,
     ...withValidationDefaults(opts),
   };
 }

--- a/packages/plugin-hardhat/test/force-deploy-implementation.js
+++ b/packages/plugin-hardhat/test/force-deploy-implementation.js
@@ -5,7 +5,6 @@ const { ethers, upgrades } = require('hardhat');
 test.before(async t => {
   t.context.Greeter = await ethers.getContractFactory('Greeter');
   t.context.GreeterV2 = await ethers.getContractFactory('GreeterV2');
-  t.context.GreeterV3 = await ethers.getContractFactory('GreeterV3');
 });
 
 test('deployImplementation - both use and force options enabled', async t => {

--- a/packages/plugin-hardhat/test/force-deploy-implementation.js
+++ b/packages/plugin-hardhat/test/force-deploy-implementation.js
@@ -1,0 +1,86 @@
+const test = require('ava');
+
+const { ethers, upgrades } = require('hardhat');
+
+test.before(async t => {
+  t.context.Greeter = await ethers.getContractFactory('Greeter');
+  t.context.GreeterV2 = await ethers.getContractFactory('GreeterV2');
+  t.context.GreeterV3 = await ethers.getContractFactory('GreeterV3');
+});
+
+test('deployImplementation - both use and force options enabled', async t => {
+  const { Greeter } = t.context;
+
+  await t.throwsAsync(
+    () => upgrades.deployImplementation(Greeter, { useDeployedImplementation: true, forceDeployImplementation: true }),
+    {
+      message:
+        /(The useDeployedImplementation and forceDeployImplementation options cannot both be set to true at the same time)/,
+    },
+  );
+});
+
+test('deployImplementation - force', async t => {
+  const { Greeter } = t.context;
+
+  const impl1 = await upgrades.deployImplementation(Greeter);
+  const impl2 = await upgrades.deployImplementation(Greeter, { forceDeployImplementation: true });
+  t.not(impl2, impl1);
+});
+
+test('deployProxy - force', async t => {
+  const { Greeter } = t.context;
+
+  const greeterImplAddr = await upgrades.deployImplementation(Greeter);
+  const greeter = await upgrades.deployProxy(Greeter, ['Hola mundo!'], {
+    kind: 'transparent',
+    forceDeployImplementation: true,
+  });
+  t.is(await greeter.greet(), 'Hola mundo!');
+  t.not(greeterImplAddr, await upgrades.erc1967.getImplementationAddress(greeter.address));
+});
+
+test('deployBeacon - force', async t => {
+  const { Greeter } = t.context;
+
+  const greeterImplAddr = await upgrades.deployImplementation(Greeter);
+  const beacon = await upgrades.deployBeacon(Greeter, { forceDeployImplementation: true });
+  t.not(greeterImplAddr, await upgrades.beacon.getImplementationAddress(beacon.address));
+});
+
+test('prepareUpgrade - force', async t => {
+  const { Greeter, GreeterV2 } = t.context;
+
+  const greeter = await upgrades.deployProxy(Greeter, ['Hello, Hardhat!'], { kind: 'transparent' });
+  const deployedImplAddress = await upgrades.deployImplementation(GreeterV2);
+  const preparedImplAddress = await upgrades.prepareUpgrade(greeter, GreeterV2, { forceDeployImplementation: true });
+  t.not(preparedImplAddress, deployedImplAddress);
+});
+
+test('upgradeProxy - force', async t => {
+  const { Greeter, GreeterV2 } = t.context;
+
+  const greeter = await upgrades.deployProxy(Greeter, ['Hello, Hardhat!'], { kind: 'transparent' });
+  const origImplAddress = await upgrades.erc1967.getImplementationAddress(greeter.address);
+
+  const deployedImplAddress = await upgrades.deployImplementation(GreeterV2);
+  await upgrades.upgradeProxy(greeter, GreeterV2, { forceDeployImplementation: true });
+
+  const newImplAddress = await upgrades.erc1967.getImplementationAddress(greeter.address);
+  t.not(newImplAddress, origImplAddress);
+  t.not(newImplAddress, deployedImplAddress);
+});
+
+test('upgradeBeacon - force', async t => {
+  const { Greeter, GreeterV2 } = t.context;
+
+  const greeterBeacon = await upgrades.deployBeacon(Greeter);
+  const origImplAddress = await upgrades.beacon.getImplementationAddress(greeterBeacon.address);
+
+  const deployedImplAddress = await upgrades.deployImplementation(GreeterV2);
+
+  await upgrades.upgradeBeacon(greeterBeacon, GreeterV2, { forceDeployImplementation: true });
+  const newImplAddress = await upgrades.beacon.getImplementationAddress(greeterBeacon.address);
+  t.not(newImplAddress, origImplAddress);
+  t.not(newImplAddress, deployedImplAddress);
+});

--- a/packages/plugin-hardhat/test/force-deploy-implementation.js
+++ b/packages/plugin-hardhat/test/force-deploy-implementation.js
@@ -27,8 +27,8 @@ test('deployImplementation - force', async t => {
   t.not(impl2, impl1);
 });
 
-test('deployProxy - force', async t => {
-  const { Greeter } = t.context;
+test('deployProxy - force, then upgrade', async t => {
+  const { Greeter, GreeterV2 } = t.context;
 
   const greeterImplAddr = await upgrades.deployImplementation(Greeter);
   const greeter = await upgrades.deployProxy(Greeter, ['Hola mundo!'], {
@@ -37,6 +37,9 @@ test('deployProxy - force', async t => {
   });
   t.is(await greeter.greet(), 'Hola mundo!');
   t.not(greeterImplAddr, await upgrades.erc1967.getImplementationAddress(greeter.address));
+
+  // upgrade proxy that had a force deployed implementation
+  await upgrades.upgradeProxy(greeter, GreeterV2);
 });
 
 test('deployBeacon - force', async t => {

--- a/packages/plugin-truffle/CHANGELOG.md
+++ b/packages/plugin-truffle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support `forceDeployImplementation` option. ([#800](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/800))
+
 ## 1.18.2 (2023-05-12)
 
 - Add missing file in package. ([#797](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/797))

--- a/packages/plugin-truffle/src/utils/options.ts
+++ b/packages/plugin-truffle/src/utils/options.ts
@@ -16,6 +16,7 @@ export type StandaloneOptions = StandaloneValidationOptions &
   TruffleDeployer & {
     constructorArgs?: unknown[];
     useDeployedImplementation?: boolean;
+    forceDeployImplementation?: boolean;
   };
 
 export type UpgradeOptions = ValidationOptions & StandaloneOptions;
@@ -26,7 +27,8 @@ export function withDefaults(opts: UpgradeOptions = {}): Required<UpgradeOptions
     timeout: opts.timeout ?? 60e3, // not used for Truffle, but include these anyways
     pollingInterval: opts.pollingInterval ?? 5e3, // not used for Truffle, but include these anyways
     constructorArgs: opts.constructorArgs ?? [],
-    useDeployedImplementation: opts.useDeployedImplementation ?? true,
+    useDeployedImplementation: opts.useDeployedImplementation ?? false,
+    forceDeployImplementation: opts.forceDeployImplementation ?? false,
     ...withValidationDefaults(opts),
   };
 }

--- a/packages/plugin-truffle/test/test/force-deploy-implementation.js
+++ b/packages/plugin-truffle/test/test/force-deploy-implementation.js
@@ -32,7 +32,7 @@ contract('Greeter', function () {
     assert.notEqual(impl2, impl1);
   });
 
-  it('deployProxy - force', async function () {
+  it('deployProxy - force, then upgrade', async function () {
     const greeterImplAddr = await deployImplementation(GreeterDeployImpl);
     const greeter = await deployProxy(GreeterDeployImpl, ['Hola mundo!'], {
       kind: 'transparent',
@@ -40,6 +40,9 @@ contract('Greeter', function () {
     });
     assert.equal(await greeter.greet(), 'Hola mundo!');
     assert.notEqual(greeterImplAddr, await erc1967.getImplementationAddress(greeter.address));
+
+    // upgrade proxy that had a force deployed implementation
+    await upgradeProxy(greeter, GreeterV2DeployImpl);
   });
 
   it('deployBeacon - force', async function () {

--- a/packages/plugin-truffle/test/test/force-deployed-implementation.js
+++ b/packages/plugin-truffle/test/test/force-deployed-implementation.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+
+const {
+  deployProxy,
+  deployBeacon,
+  deployImplementation,
+  upgradeProxy,
+  upgradeBeacon,
+  erc1967,
+  prepareUpgrade,
+  beacon,
+} = require('@openzeppelin/truffle-upgrades');
+
+const GreeterDeployImpl = artifacts.require('GreeterDeployImpl');
+const GreeterV2DeployImpl = artifacts.require('GreeterV2DeployImpl');
+
+contract('Greeter', function () {
+  it('deployImplementation - both use and force options enabled', async function () {
+    // this isn't a realistic scenario but we should still handle it
+    await assert.rejects(
+      deployImplementation(GreeterDeployImpl, { useDeployedImplementation: true, forceDeployImplementation: true }),
+      error =>
+        error.message.includes(
+          'The useDeployedImplementation and forceDeployImplementation options cannot both be set to true at the same time',
+        ),
+    );
+  });
+
+  it('deployImplementation - force', async function () {
+    const impl1 = await deployImplementation(GreeterDeployImpl);
+    const impl2 = await deployImplementation(GreeterDeployImpl, { forceDeployImplementation: true });
+    assert.notEqual(impl2, impl1);
+  });
+
+  it('deployProxy - force', async function () {
+    const greeterImplAddr = await deployImplementation(GreeterDeployImpl);
+    const greeter = await deployProxy(GreeterDeployImpl, ['Hola mundo!'], {
+      kind: 'transparent',
+      forceDeployImplementation: true,
+    });
+    assert.equal(await greeter.greet(), 'Hola mundo!');
+    assert.notEqual(greeterImplAddr, await erc1967.getImplementationAddress(greeter.address));
+  });
+
+  it('deployBeacon - force', async function () {
+    const greeterImplAddr = await deployImplementation(GreeterDeployImpl);
+    const deployedBeacon = await deployBeacon(GreeterDeployImpl, { forceDeployImplementation: true });
+    assert.notEqual(greeterImplAddr, await beacon.getImplementationAddress(deployedBeacon.address));
+  });
+
+  it('prepareUpgrade - force', async function () {
+    const greeter = await deployProxy(GreeterDeployImpl, ['Hola mundo!'], { kind: 'transparent' });
+    const deployedImplAddress = await deployImplementation(GreeterV2DeployImpl);
+    const preparedImplAddress = await prepareUpgrade(greeter, GreeterV2DeployImpl, { forceDeployImplementation: true });
+    assert.notEqual(preparedImplAddress, deployedImplAddress);
+  });
+
+  it('upgradeProxy - force', async function () {
+    const greeter = await deployProxy(GreeterDeployImpl, ['Hola mundo!'], { kind: 'transparent' });
+    const origImplAddress = await erc1967.getImplementationAddress(greeter.address);
+
+    const deployedImplAddress = await deployImplementation(GreeterV2DeployImpl);
+    await upgradeProxy(greeter, GreeterV2DeployImpl, { forceDeployImplementation: true });
+
+    const newImplAddress = await erc1967.getImplementationAddress(greeter.address);
+    assert.notEqual(newImplAddress, origImplAddress);
+    assert.notEqual(newImplAddress, deployedImplAddress);
+  });
+
+  it('upgradeBeacon - force', async function () {
+    const greeterBeacon = await deployBeacon(GreeterDeployImpl);
+    const origImplAddress = await beacon.getImplementationAddress(greeterBeacon.address);
+
+    const deployedImplAddress = await deployImplementation(GreeterV2DeployImpl);
+
+    await upgradeBeacon(greeterBeacon, GreeterV2DeployImpl, { forceDeployImplementation: true });
+    const newImplAddress = await beacon.getImplementationAddress(greeterBeacon.address);
+    assert.notEqual(newImplAddress, origImplAddress);
+    assert.notEqual(newImplAddress, deployedImplAddress);
+  });
+});


### PR DESCRIPTION
Adds an option to force the deployment of the implementation contract even if it was previously deployed with the same bytecode. This can be used with the `salt` option when deploying a proxy through OpenZeppelin Platform to ensure that the new proxy has a matching implementation deployed with the same salt.