### PR TITLE
Pin versioning for peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ```
 npm install --save-dev @openzeppelin/hardhat-upgrades
-npm install --save-dev @nomiclabs/hardhat-ethers@^2.0.0 ethers@^5.0.0 # peer dependencies
+npm install --save-dev '@nomiclabs/hardhat-ethers@^2.0.0' 'ethers@^5.0.0' # peer dependencies
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ```
 npm install --save-dev @openzeppelin/hardhat-upgrades
-npm install --save-dev @nomiclabs/hardhat-ethers ethers # peer dependencies
+npm install --save-dev @nomiclabs/hardhat-ethers@^2.0.0 ethers@^5.0.0 # peer dependencies
 ```
 
 ```js


### PR DESCRIPTION
As title. `ethers` defaults to the breaking v6 and `@nomiclabs/hardhat-ethers` already has released a RC version for `3.0.0`, so this is a preemptive measure. You should consider adding the peer deps also in the `package.json`.