### PR TITLE
Fix typo and link in docs

### DIFF
--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -217,7 +217,7 @@ Truffle sometimes partially recompiles only the contracts that have changed. We 
 [[how-to-rename]]
 == How can I rename a variable, or change its type?
 
-Renaming a variable is disallowed by default because there is a change that a renaming is actually an accidental reordering. For example, if variables `uint a; uint b;` are upgraded to `uint b; uint a;`, if renaming was simply allowed this would not be seen as a mistake, but it could have been an accident, especially when multiple inheritance is involved.
+Renaming a variable is disallowed by default because there is a chance that a renaming is actually an accidental reordering. For example, if variables `uint a; uint b;` are upgraded to `uint b; uint a;`, if renaming was simply allowed this would not be seen as a mistake, but it could have been an accident, especially when multiple inheritance is involved.
 
 It is possible to disable this check by passing the option `unsafeAllowRenames: true`. A more granular approach is to use a docstring comment `/// @custom:oz-renamed-from <previous name>` right above the variable that is being renamed, for example:
 

--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -210,7 +210,7 @@ Some users who have already deployed proxies with structs and/or enums and who n
 [[why-do-i-have-to-recompile-all-contracts-for-truffle]]
 == Why do I have to recompile all contracts for Truffle?
 
-Truffle artifacts (the JSON files in `build/contracts`) contain the AST (abstract syntax tree) for each of your contracts. Our plugin uses this information to validate that your contracts are [upgrade safe](#what-does-it-mean-for-a-contract-to-be-upgrade-safe).
+Truffle artifacts (the JSON files in `build/contracts`) contain the AST (abstract syntax tree) for each of your contracts. Our plugin uses this information to validate that your contracts are <<what-does-it-mean-for-a-contract-to-be-upgrade-safe, upgrade safe>>.
 
 Truffle sometimes partially recompiles only the contracts that have changed. We will ask you to trigger a full recompilation either using `truffle compile --all` or deleting the `build/contracts` directory when this happens. The technical reason is that since Solidity does not produce deterministic ASTs, the plugins are unable to resolve references correctly if they are not from the same compiler run.
 


### PR DESCRIPTION
there's also a broken link in 

`this information to validate that your contracts are [upgrade safe](#what-does-it-mean-for-a-contract-to-be-upgrade-safe).` 

but I couldn't figure out why easily.