### PR TITLE
Remove address override

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Use `hardhat-verify` for proxy verification. ([#829](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/829))
+- Remove address override for deployments. ([#832](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/832))
 
 ## 2.0.0-alpha.0 (2023-06-20)
 

--- a/packages/plugin-hardhat/src/utils/deploy.ts
+++ b/packages/plugin-hardhat/src/utils/deploy.ts
@@ -1,11 +1,8 @@
 import type { Deployment, RemoteDeploymentId } from '@openzeppelin/upgrades-core';
-import debug from './debug';
 import type { ethers, ContractFactory } from 'ethers';
-import { getCreateAddress } from 'ethers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { platformDeploy } from '../platform/deploy';
 import { PlatformDeployOptions, UpgradeOptions } from './options';
-import { getSigner } from './ethers';
 
 export interface DeployTransaction {
   deployTransaction?: ethers.TransactionResponse;
@@ -30,31 +27,14 @@ async function ethersDeploy(
   ...args: unknown[]
 ): Promise<Required<Deployment & DeployTransaction> & RemoteDeploymentId> {
   const contractInstance = await factory.deploy(...args);
-  const deployTransaction = contractInstance.deploymentTransaction();
 
+  const deployTransaction = contractInstance.deploymentTransaction();
   if (deployTransaction === null) {
     throw new Error('Broken invariant: deploymentTransaction is null');
   }
 
-  const signer = getSigner(factory.runner);
-  const contractAddress = await contractInstance.getAddress();
-
-  let address = contractAddress;
-
-  if (signer !== undefined) {
-    const from = await signer.getAddress();
-
-    // Some RPC endpoints can return an incorrect address. See https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/487
-    // As a workaround, calculate the correct address using the address and nonce.
-    address = getCreateAddress({
-      from: from,
-      nonce: deployTransaction.nonce,
-    });
-    if (address !== contractAddress) {
-      debug(`overriding contract address from ${contractAddress} to ${address} for nonce ${deployTransaction.nonce}`);
-    }
-  }
-
+  const address = await contractInstance.getAddress();
   const txHash = deployTransaction.hash;
+
   return { address, txHash, deployTransaction };
 }


### PR DESCRIPTION
Closes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/767

Remove overriding the contract address on deployments, since ethers.js's `deploy` function already calculates the address for the create operation.