### PR TITLE
Trim bytecode whitespace when hashing

### DIFF
--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -21,6 +21,7 @@ export function getVersion(bytecode: string, linkedBytecode?: string, constructo
 
 export function hashBytecode(bytecode: string, constructorArgs = ''): string {
   bytecode = bytecode
+    .trim()
     .replace(/__\$([0-9a-fA-F]{34})\$__/g, (_, placeholder) => `000${placeholder}000`)
     .replace(/__\w{36}__/g, placeholder => keccak256(Buffer.from(placeholder)).toString('hex', 0, 20));
 


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/823

Note: This is backwards compatible because any whitespace that is present would cause the hex check to fail, rather than change the resulting hash.