### PR TITLE
Support user-defined value types in mappings

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Support user-defined value types in mappings. ([#844](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/844))
+
 ## 1.27.2 (2023-07-10)
 
-- Allow assignment of immutable variables if the `state-variable-immutable` override is present.
+- Allow assignment of immutable variables if the `state-variable-immutable` override is present. ([#838](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/838))
 
 ## 1.27.1 (2023-06-15)
 

--- a/packages/core/contracts/test/Storage089.sol
+++ b/packages/core/contracts/test/Storage089.sol
@@ -19,3 +19,27 @@ contract Storage089_V3 {
 
   uint x;
 }
+
+contract Storage089_MappingUVDTKey_V1 {
+  type MyUserValueType is bool;
+
+  mapping (MyUserValueType => uint) m1;
+  mapping (MyUserValueType => uint) m2;
+  mapping (uint8 => uint) m3;
+}
+
+contract Storage089_MappingUVDTKey_V2_Ok {
+  type MyUserValueType is uint8;
+
+  mapping (MyUserValueType => uint) m1;
+  mapping (MyUserValueType => uint) m2;
+  mapping (uint8 => uint) m3;
+}
+
+contract Storage089_MappingUVDTKey_V2_Bad {
+  type MyUserValueType is uint16;
+
+  mapping (MyUserValueType => uint) m1;
+  mapping (MyUserValueType => uint) m2;
+  mapping (uint8 => uint) m3;
+}

--- a/packages/core/src/storage-0.8.test.ts
+++ b/packages/core/src/storage-0.8.test.ts
@@ -112,3 +112,35 @@ test('renamed retyped - extraction', async t => {
   const layout = await t.context.extractStorageLayout('StorageRenamedRetyped');
   t.snapshot(stabilizeStorageLayout(layout));
 });
+
+test('mapping with user defined value type key - ok', async t => {
+  const v1 = await t.context.extractStorageLayout('Storage089_MappingUVDTKey_V1');
+  const v2 = await t.context.extractStorageLayout('Storage089_MappingUVDTKey_V2_Ok');
+  const comparison = getStorageUpgradeErrors(v1, v2);
+  t.deepEqual(comparison, []);
+});
+
+test('mapping with user defined value type key - bad', async t => {
+  const v1 = await t.context.extractStorageLayout('Storage089_MappingUVDTKey_V1');
+  const v2 = await t.context.extractStorageLayout('Storage089_MappingUVDTKey_V2_Bad');
+  const comparison = getStorageUpgradeErrors(v1, v2);
+  t.like(comparison, {
+    length: 2,
+    0: {
+      kind: 'typechange',
+      change: {
+        kind: 'mapping key',
+      },
+      original: { label: 'm1' },
+      updated: { label: 'm1' },
+    },
+    1: {
+      kind: 'typechange',
+      change: {
+        kind: 'mapping key',
+      },
+      original: { label: 'm2' },
+      updated: { label: 'm2' },
+    },
+  });
+});

--- a/packages/core/src/utils/is-value-type.ts
+++ b/packages/core/src/utils/is-value-type.ts
@@ -1,5 +1,5 @@
 import { ParsedTypeDetailed } from '../storage/layout';
 
 export function isValueType(type: ParsedTypeDetailed): boolean {
-  return type.args === undefined || ['t_contract', 't_enum'].includes(type.head);
+  return type.args === undefined || ['t_contract', 't_enum', 't_userDefinedValueType'].includes(type.head);
 }


### PR DESCRIPTION
This fixes the upgraded contract storage check failure when using a custom value types in mappings, e.g.
```
mapping(UserDefinedValueType => ...) mappingThatFails;
```

See https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/779#issuecomment-1527902368

I can confirm that this fixes the upgrade for a contract that uses such mapping (I'm using `upgradeProxy` from hardhat-upgrades).

cc @frangio who suggested the fix