### PR TITLE
Add Truffle deprecation notices

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,13 +1,13 @@
 * xref:index.adoc[Overview]
-* xref:truffle-upgrades.adoc[Using with Truffle]
 * xref:hardhat-upgrades.adoc[Using with Hardhat]
 ** xref:defender-deploy.adoc[OpenZeppelin Defender integration]
+* xref:truffle-upgrades.adoc[Using with Truffle]
 * xref:writing-upgradeable.adoc[Writing Upgradeable Contracts]
 * xref:proxies.adoc[Proxy Upgrade Pattern]
 * xref:network-files.adoc[Network Files]
 * xref:faq.adoc[Frequently Asked Questions]
 
 .API Reference
-* xref:api-truffle-upgrades.adoc[Truffle Upgrades]
 * xref:api-hardhat-upgrades.adoc[Hardhat Upgrades]
+* xref:api-truffle-upgrades.adoc[Truffle Upgrades]
 * xref:api-core.adoc[Upgrades Core & CLI]

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -1,6 +1,6 @@
 = OpenZeppelin Truffle Upgrades API
 
-NOTE: This package is deprecated. The recommended alternative is to use https://hardhat.org/[Hardhat] along with the xref:hardhat-upgrades.adoc[Hardhat Upgrades] plugin.
+WARNING: This package is deprecated. The recommended alternative is to use https://hardhat.org/[Hardhat] along with the xref:hardhat-upgrades.adoc[Hardhat Upgrades] plugin.
 
 Both `deployProxy` and `upgradeProxy` functions will return instances of https://www.trufflesuite.com/docs/truffle/reference/contract-abstractions[Truffle contracts], and require Truffle contract classes (retrieved via `artifacts.require`) as arguments. For https://docs.openzeppelin.com/contracts/4.x/api/proxy#beacon[beacons], `deployBeacon` and `upgradeBeacon` will both return an upgradable beacon instance that can be used with a beacon proxy. All deploy and upgrade functions validate that the implementation contract is upgrade-safe, and will fail otherwise.
 

--- a/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-truffle-upgrades.adoc
@@ -1,5 +1,7 @@
 = OpenZeppelin Truffle Upgrades API
 
+NOTE: This package is deprecated. The recommended alternative is to use https://hardhat.org/[Hardhat] along with the xref:hardhat-upgrades.adoc[Hardhat Upgrades] plugin.
+
 Both `deployProxy` and `upgradeProxy` functions will return instances of https://www.trufflesuite.com/docs/truffle/reference/contract-abstractions[Truffle contracts], and require Truffle contract classes (retrieved via `artifacts.require`) as arguments. For https://docs.openzeppelin.com/contracts/4.x/api/proxy#beacon[beacons], `deployBeacon` and `upgradeBeacon` will both return an upgradable beacon instance that can be used with a beacon proxy. All deploy and upgrade functions validate that the implementation contract is upgrade-safe, and will fail otherwise.
 
 [[common-options]]

--- a/docs/modules/ROOT/pages/truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/truffle-upgrades.adoc
@@ -1,6 +1,6 @@
 = Using with Truffle
 
-NOTE: This package is deprecated. The recommended alternative is to use https://hardhat.org/[Hardhat] along with the xref:hardhat-upgrades.adoc[Hardhat Upgrades] plugin.
+WARNING: This package is deprecated. The recommended alternative is to use https://hardhat.org/[Hardhat] along with the xref:hardhat-upgrades.adoc[Hardhat Upgrades] plugin.
 
 This package adds functions to your Truffle migrations and tests so you can deploy and upgrade proxies for your contracts.
 

--- a/docs/modules/ROOT/pages/truffle-upgrades.adoc
+++ b/docs/modules/ROOT/pages/truffle-upgrades.adoc
@@ -1,5 +1,7 @@
 = Using with Truffle
 
+NOTE: This package is deprecated. The recommended alternative is to use https://hardhat.org/[Hardhat] along with the xref:hardhat-upgrades.adoc[Hardhat Upgrades] plugin.
+
 This package adds functions to your Truffle migrations and tests so you can deploy and upgrade proxies for your contracts.
 
 NOTE: Usage from https://www.trufflesuite.com/docs/truffle/getting-started/writing-external-scripts[Truffle external scripts] is not yet supported.

--- a/packages/plugin-truffle/README.md
+++ b/packages/plugin-truffle/README.md
@@ -1,6 +1,6 @@
 # OpenZeppelin Truffle Upgrades
 
-> **Note**
+> **Warning**
 > This package is deprecated. The recommended alternative is to use [Hardhat](https://hardhat.org/) along with the [Hardhat Upgrades](https://docs.openzeppelin.com/upgrades-plugins/hardhat-upgrades) plugin.
 
 [![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.openzeppelin.com/upgrades-plugins/truffle-upgrades)

--- a/packages/plugin-truffle/README.md
+++ b/packages/plugin-truffle/README.md
@@ -1,5 +1,8 @@
 # OpenZeppelin Truffle Upgrades
 
+> **Note**
+> This package is deprecated. The recommended alternative is to use [Hardhat](https://hardhat.org/) along with the [Hardhat Upgrades](https://docs.openzeppelin.com/upgrades-plugins/hardhat-upgrades) plugin.
+
 [![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.openzeppelin.com/upgrades-plugins/truffle-upgrades)
 [![NPM Package](https://img.shields.io/npm/v/@openzeppelin/truffle-upgrades.svg)](https://www.npmjs.org/package/@openzeppelin/truffle-upgrades)
 


### PR DESCRIPTION
Deprecate Truffle Upgrades due to https://consensys.io/blog/consensys-announces-the-sunset-of-truffle-and-ganache-and-new-hardhat