### PR TITLE
Check for non-zero admin address when importing transparent proxy

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Check for non-zero admin address when importing transparent proxy. ([#887](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/887))
+
 ## 2.3.0 (2023-09-27)
 
 - Support new upgrade interface in OpenZeppelin Contracts 5.0. ([#883](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/883))

--- a/packages/plugin-hardhat/src/force-import.ts
+++ b/packages/plugin-hardhat/src/force-import.ts
@@ -116,6 +116,7 @@ async function addAdminToManifest(
     throw new UpgradesError(
       `Proxy at ${proxyAddress} doesn't look like a transparent proxy`,
       () =>
+        `The proxy doesn't look like a transparent proxy because its admin address slot is empty. ` +
         `Set the \`kind\` option to the kind of proxy that was deployed at ${proxyAddress} (either 'uups' or 'beacon')`,
     );
   }

--- a/packages/plugin-hardhat/src/force-import.ts
+++ b/packages/plugin-hardhat/src/force-import.ts
@@ -111,7 +111,7 @@ async function addAdminToManifest(
 ) {
   const adminAddress = await getAdminAddress(provider, proxyAddress);
   if (isEmptySlot(adminAddress)) {
-    // Asser that the admin slot of a transparent proxy is not zero, otherwise the simulation below would fail due to no code at the address.
+    // Assert that the admin slot of a transparent proxy is not zero, otherwise the simulation below would fail due to no code at the address.
     // Note: Transparent proxies should not have the zero address as the admin, according to TransparentUpgradeableProxy's _setAdmin function.
     throw new UpgradesError(
       `Proxy at ${proxyAddress} doesn't look like a transparent proxy`,

--- a/packages/plugin-hardhat/src/force-import.ts
+++ b/packages/plugin-hardhat/src/force-import.ts
@@ -13,6 +13,8 @@ import {
   ProxyDeployment,
   hasCode,
   NoContractImportError,
+  isEmptySlot,
+  UpgradesError,
 } from '@openzeppelin/upgrades-core';
 
 import {
@@ -108,5 +110,14 @@ async function addAdminToManifest(
   opts: ForceImportOptions,
 ) {
   const adminAddress = await getAdminAddress(provider, proxyAddress);
+  if (isEmptySlot(adminAddress)) {
+    // Asser that the admin slot of a transparent proxy is not zero, otherwise the simulation below would fail due to no code at the address.
+    // Note: Transparent proxies should not have the zero address as the admin, according to TransparentUpgradeableProxy's _setAdmin function.
+    throw new UpgradesError(
+      `Proxy at ${proxyAddress} doesn't look like a transparent proxy`,
+      () =>
+        `Set the \`kind\` option to the kind of proxy that was deployed at ${proxyAddress} (either 'uups' or 'beacon')`,
+    );
+  }
   await simulateDeployAdmin(hre, ImplFactory, opts, adminAddress);
 }

--- a/packages/plugin-hardhat/test/import-50.js
+++ b/packages/plugin-hardhat/test/import-50.js
@@ -38,7 +38,7 @@ function getInitializerData(contractInterface, args) {
   return contractInterface.encodeFunctionData(fragment, args);
 }
 
-const REQUESTED_UPGRADE_WRONG_KIND = 'Requested an upgrade of kind uups but proxy is transparent';
+const NOT_TRANSPARENT_PROXY = `doesn't look like a transparent proxy`;
 
 test('implementation happy path', async t => {
   const { GreeterProxiable } = t.context;
@@ -186,13 +186,16 @@ test('wrong kind', async t => {
   );
   await proxy.waitForDeployment();
 
-  // specify wrong kind
-  const greeter = await upgrades.forceImport(await proxy.getAddress(), GreeterProxiable, { kind: 'transparent' });
-  t.is(await greeter.greet(), 'Hello, Hardhat!');
+  // specify wrong kind.
+  // an error is expected since the admin adress is zero
+  const e = await t.throwsAsync(async () =>
+    upgrades.forceImport(await proxy.getAddress(), GreeterProxiable, { kind: 'transparent' }),
+  );
+  t.true(e.message.includes(NOT_TRANSPARENT_PROXY), e.message);
 
-  // an error is expected since the user force imported the wrong kind
-  const e = await t.throwsAsync(() => upgrades.upgradeProxy(greeter, GreeterV2Proxiable));
-  t.true(e.message.startsWith(REQUESTED_UPGRADE_WRONG_KIND), e.message);
+  // import with correct kind
+  const greeter = await upgrades.forceImport(await proxy.getAddress(), GreeterProxiable, { kind: 'uups' });
+  await upgrades.upgradeProxy(greeter, GreeterV2Proxiable);
 });
 
 test('import custom UUPS proxy', async t => {


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/882

When importing a proxy, the proxy kind can be inferred based on the presence of upgrade function signatures in the implementation.

For transparent proxies, we import the admin address using the admin address slot.  During this import, we check whether the admin address has code.

If the proxy kind was inferred incorrectly, or if the user provided the wrong `kind` option (e.g. passed in 'transparent' but the proxy is actually UUPS), the admin address is the zero address.  This causes the error when we check for code at the admin address:
```
No contract at address 0x0000000000000000000000000000000000000000 (Removed from manifest)
```

Instead, we should throw an error if the admin address is zero, and tell the user to set the correct proxy kind.

NOTE: This assumes that a zero admin address is never a valid scenario for a transparent proxy. 