### PR TITLE
Fix tests when running coverage

### DIFF
--- a/packages/core/ava.config.js
+++ b/packages/core/ava.config.js
@@ -8,4 +8,5 @@ module.exports = {
   environmentVariables: {
     FORCE_COLOR: '0',
   },
+  timeout: '30s',
 };

--- a/packages/plugin-hardhat/ava.config.js
+++ b/packages/plugin-hardhat/ava.config.js
@@ -5,4 +5,7 @@ module.exports = {
   serial: true,
   failWithoutAssertions: false,
   snapshotDir: '.',
+  environmentVariables: {
+    FORCE_COLOR: '0',
+  },
 };


### PR DESCRIPTION
Tests when running coverage currently fails for two reasons:
- CLI tests in core may take longer than the default timeout of 10 seconds -> increase timeout
- Console output has color, so does not match snapshots -> remove color