### PR TITLE
chore: bump contracts version to 4.9.3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,8 +38,8 @@
   "devDependencies": {
     "@ava/typescript": "^4.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.0",
-    "@openzeppelin/contracts": "4.8.3",
-    "@openzeppelin/contracts-upgradeable": "4.8.3",
+    "@openzeppelin/contracts": "4.9.3",
+    "@openzeppelin/contracts-upgradeable": "4.9.3",
     "@types/cbor": "^5.0.0",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^7.0.2",

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -23,9 +23,9 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.0",
     "@nomicfoundation/hardhat-verify": "^1.1.0",
-    "@openzeppelin/contracts": "4.8.3",
+    "@openzeppelin/contracts": "4.9.3",
     "@openzeppelin/contracts-5.0": "npm:@openzeppelin/contracts@^5.0.0-rc.0",
-    "@openzeppelin/contracts-upgradeable": "4.8.3",
+    "@openzeppelin/contracts-upgradeable": "4.9.3",
     "@types/mocha": "^7.0.2",
     "ava": "^5.0.0",
     "fgbg": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,15 +2383,15 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.0-rc.0.tgz#801345b25e27c8a27e6075b508fd9e17cc303e8d"
   integrity sha512-OvYXXB1EshHue8IBakqkYCglk3Yh/NaP9HUDeoONXBmTCBD/4Oo/dU84ZJ19CG6M+lEy55I7N30xNGTT69396Q==
 
-"@openzeppelin/contracts-upgradeable@4.8.3":
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.3.tgz#6b076a7b751811b90fe3a172a7faeaa603e13a3f"
-  integrity sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg==
+"@openzeppelin/contracts-upgradeable@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz#ff17a80fb945f5102571f8efecb5ce5915cc4811"
+  integrity sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==
 
-"@openzeppelin/contracts@4.8.3":
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.3.tgz#cbef3146bfc570849405f59cba18235da95a252a"
-  integrity sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==
+"@openzeppelin/contracts@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.3.tgz#00d7a8cf35a475b160b3f0293a6403c511099364"
+  integrity sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg==
 
 "@openzeppelin/defender-admin-client@^1.48.0":
   version "1.48.0"


### PR DESCRIPTION
I suggest to bump contracts versions to 4.9.3
No changes in JS code required.

Related PRs:
#861
#862
#864
#865
#866
#867
#868
#869

Tests:

* one skipped: - [skip] manifest › rename hardhat from unknown to dev manifest
* all rest pass


```
$ yarn test
yarn run v1.22.19
$ tsc -b && wsrun -ms test
plugin-truffle-test has no test script, skipping missing
@openzeppelin/upgrades-core
$ tsc -b && hardhat compile --force && node scripts/copy-build-info.js && ava
...
 |   - [skip] manifest › rename hardhat from unknown to dev manifest
...
 |   399 tests passed
 |   1 test skipped
@openzeppelin/hardhat-upgrades
$ tsc -b && bash scripts/test.sh
 | 
 |   307 tests passed
@openzeppelin/truffle-upgrades
$ yarn compile && bash test.sh
$ tsc -b
$ /openzeppelin-upgrades/node_modules/.bin/truffle test
 | This version of µWS is not compatible with your Node.js build:
 | 
 | Error: Cannot find module '../binaries/uws_linux_x64_115.node'
 | Require stack:
 | - /openzeppelin-upgrades/node_modules/@trufflesuite/uws-js-unofficial/src/uws.js
 | - /openzeppelin-upgrades/node_modules/ganache/dist/node/core.js
 | - /openzeppelin-upgrades/node_modules/truffle/build/test.bundled.js
 | - /openzeppelin-upgrades/node_modules/original-require/index.js
 | - /openzeppelin-upgrades/node_modules/truffle/build/cli.bundled.js
 | Falling back to a NodeJS implementation; performance may be degraded.
 | 
....
 | 
 |   181 passing (53s)
 | 
Done in 411.15s.
```