### PR TITLE
Prepare hardhat-upgrades v3 for release

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.32.0-alpha.0 (2023-11-30)
+## Unreleased
 
 - Support deploying proxies from OpenZeppelin Contracts 5.0.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/upgrades-core",
-  "version": "1.32.0-alpha.0",
+  "version": "1.32.0",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/core",
   "license": "MIT",

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Changelog
 
-## 2.5.0 (2023-12-04)
-
-- Add `defender.getDeployApprovalProcess` and `defender.getUpgradeApprovalProcess` functions. ([#934](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/934))
-- Deprecate `defender.getDefaultApprovalProcess` function. This function is equivalent to `defender.getUpgradeApprovalProcess`.
-
-**Note**: OpenZeppelin Defender deployments is in beta and its functionality is subject to change.
-
-## 3.0.0-alpha.0 (2023-11-30)
+## Unreleased
 
 - Deploy proxies from OpenZeppelin Contracts 5.0.
 - Support `initialOwner` option when deploying a transparent proxy or beacon. If not set, the externally owned account used during deployment will be the default owner for the transparent proxy's admin or the beacon, respectively.
+- Update optional peer dependency on `@nomicfoundation/hardhat-verify` to v2.0.0 or higher.
+  - **Note**: [Fully verifying proxies](https://docs.openzeppelin.com/upgrades-plugins/1.x/api-hardhat-upgrades#verify) is only supported with Etherscan at the moment. The Hardhat Upgrades plugin does not currently assist with Sourcify verification for proxies.
 
 ### Breaking changes
 - `deployProxy`, `deployBeacon`, `deployBeaconProxy`: Deploys proxy contracts from [OpenZeppelin Contracts 5.0](https://docs.openzeppelin.com/contracts/5.x/api/proxy).
@@ -21,6 +16,14 @@
 - `deployProxyAdmin`: Removed, since proxy admins are deployed automatically by transparent proxies.
 - `admin.changeProxyAdmin`: Not supported with admins or proxies from OpenZeppelin Contracts 5.0. Only supported for previously deployed admins and proxies from OpenZeppelin Contracts 4.x or below.
 - `admin.transferProxyAdminOwnership`: This function no longer uses the proxy admin from the network file. It now requires a `proxyAddress` argument to be passed in.
+- `@nomicfoundation/hardhat-verify` v1.x and `@nomicfoundation/hardhat-toolbox` v3.x are no longer supported with this plugin. If you are using these packages, update them to `@nomicfoundation/hardhat-verify` v2.x and `@nomicfoundation/hardhat-toolbox` v4.x.
+
+## 2.5.0 (2023-12-04)
+
+- Add `defender.getDeployApprovalProcess` and `defender.getUpgradeApprovalProcess` functions. ([#934](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/934))
+- Deprecate `defender.getDefaultApprovalProcess` function. This function is equivalent to `defender.getUpgradeApprovalProcess`.
+
+**Note**: OpenZeppelin Defender deployments is in beta and its functionality is subject to change.
 
 ## 2.4.3 (2023-11-28)
 

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -39,7 +39,7 @@
     "@openzeppelin/defender-base-client": "^1.52.0",
     "@openzeppelin/defender-sdk-base-client": "^1.5.0",
     "@openzeppelin/defender-sdk-deploy-client": "^1.5.0",
-    "@openzeppelin/upgrades-core": "^1.32.0-alpha.0",
+    "@openzeppelin/upgrades-core": "^1.32.0",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",
     "ethereumjs-util": "^7.1.5",

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
-    "@nomicfoundation/hardhat-verify": "^1.1.0",
+    "@nomicfoundation/hardhat-verify": "^2.0.0",
     "@openzeppelin/contracts": "5.0.0",
     "@openzeppelin/contracts-upgradeable": "5.0.0",
     "@types/mocha": "^7.0.2",
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.0",
-    "@nomicfoundation/hardhat-verify": "^1.1.0",
+    "@nomicfoundation/hardhat-verify": "^2.0.0",
     "ethers": "^6.6.0",
     "hardhat": "^2.0.2"
   },

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/hardhat-upgrades",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/plugin-hardhat",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,10 +1977,10 @@
     debug "^4.1.1"
     lodash.isequal "^4.5.0"
 
-"@nomicfoundation/hardhat-verify@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.1.0.tgz#36c7f78adebd641d641ab5dd4660111520bb3055"
-  integrity sha512-mXHP17gz4wDsWiXIz8fBRE/8T2KJglWE/QGk5A6nwsubyeqWgjqimfbwTLyaPESphKvis3hX6G75QP5a9Cd8cQ==
+"@nomicfoundation/hardhat-verify@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.2.tgz#085f8509a335db44ea3bf39a8561f1ce0462fea2"
+  integrity sha512-SXmLPHrfh801m0Dj/8v4stAM6OI0tFktDlWe1pn3k43bCCjn5TGqcVy7hCtauG8/AlQWNZhR+01qTovSSVTvXQ==
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@ethersproject/address" "^5.0.2"
@@ -2451,6 +2451,7 @@
     minimist "^1.2.0"
 
 "@openzeppelin/upgrades-core-legacy@npm:@openzeppelin/upgrades-core@1.31.3", "@openzeppelin/upgrades-core@^1.30.0":
+  name "@openzeppelin/upgrades-core-legacy"
   version "1.31.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.31.3.tgz#ff268a498fcd23106c33149e01dd3e7dfcae79fe"
   integrity sha512-i7q0IuItKS4uO0clJwm4CARmt98aA9dLfKh38HFRbX+aFLGXwF0sOvB2iwr6f87ShH7d3DNuLrVgnnXUrYb7CA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,8 +2450,7 @@
     lodash.startcase "^4.4.0"
     minimist "^1.2.0"
 
-"@openzeppelin/upgrades-core-legacy@npm:@openzeppelin/upgrades-core@1.31.3", "@openzeppelin/upgrades-core@^1.30.0":
-  name "@openzeppelin/upgrades-core-legacy"
+"@openzeppelin/upgrades-core-legacy@npm:@openzeppelin/upgrades-core@1.31.3":
   version "1.31.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.31.3.tgz#ff268a498fcd23106c33149e01dd3e7dfcae79fe"
   integrity sha512-i7q0IuItKS4uO0clJwm4CARmt98aA9dLfKh38HFRbX+aFLGXwF0sOvB2iwr6f87ShH7d3DNuLrVgnnXUrYb7CA==


### PR DESCRIPTION
- Update peer dependency on `@nomicfoundation/hardhat-verify` to ^2.0.0
  - hardhat-verify v2 supports Sourcify.  We don't support Sourcify yet, but we override `verify:etherscan` so there is no impact since Sourcify is part of a different code path. 
- Merge from master
- Remove alpha version tags
- Update changelogs