### PR TITLE
Avoid address clash when redeploying implementation

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix address clash when redeploying implementation. ([#939](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/939))
+
 ## 1.31.3 (2023-11-28)
 
 - Fix Hardhat compile errors when contracts have overloaded functions or standalone NatSpec documentation. ([#918](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/918))

--- a/packages/core/src/impl-store.test.ts
+++ b/packages/core/src/impl-store.test.ts
@@ -10,6 +10,7 @@ import { fetchOrDeploy, fetchOrDeployGetDeployment, mergeAddresses } from './imp
 import { getVersion } from './version';
 import { stubProvider } from './stub-provider';
 import { ImplDeployment } from './manifest';
+import { RemoteDeploymentId } from './deployment';
 
 test.before(async () => {
   process.chdir(await fs.mkdtemp(path.join(os.tmpdir(), 'upgrades-core-test-')));
@@ -61,7 +62,7 @@ test('merge addresses', async t => {
   const depl1 = { address: '0x1' } as ImplDeployment;
   const depl2 = { address: '0x2' } as ImplDeployment;
 
-  const { address, allAddresses } = await mergeAddresses(depl1, depl2);
+  const { address, allAddresses } = mergeAddresses(depl1, depl2);
   t.is(address, '0x1');
   t.true(unorderedEqual(allAddresses, ['0x1', '0x2']), allAddresses.toString());
 });
@@ -70,7 +71,7 @@ test('merge multiple existing addresses', async t => {
   const depl1 = { address: '0x1', allAddresses: ['0x1a', '0x1b'] } as ImplDeployment;
   const depl2 = { address: '0x2' } as ImplDeployment;
 
-  const { address, allAddresses } = await mergeAddresses(depl1, depl2);
+  const { address, allAddresses } = mergeAddresses(depl1, depl2);
   t.is(address, '0x1');
   t.true(unorderedEqual(allAddresses, ['0x1', '0x1a', '0x1b', '0x2']), allAddresses.toString());
 });
@@ -79,7 +80,7 @@ test('merge all addresses', async t => {
   const depl1 = { address: '0x1', allAddresses: ['0x1a', '0x1b'] } as ImplDeployment;
   const depl2 = { address: '0x2', allAddresses: ['0x2a', '0x2b'] } as ImplDeployment;
 
-  const { address, allAddresses } = await mergeAddresses(depl1, depl2);
+  const { address, allAddresses } = mergeAddresses(depl1, depl2);
   t.is(address, '0x1');
   t.true(unorderedEqual(allAddresses, ['0x1', '0x1a', '0x1b', '0x2', '0x2a', '0x2b']), allAddresses.toString());
 });
@@ -88,7 +89,7 @@ function unorderedEqual(arr1: string[], arr2: string[]) {
   return arr1.every(i => arr2.includes(i)) && arr2.every(i => arr1.includes(i));
 }
 
-test('platform - replace tx hash for deployment', async t => {
+test('defender - replace tx hash for deployment', async t => {
   const provider = stubProvider();
 
   // create a pending deployment with id
@@ -136,4 +137,127 @@ test('platform - replace tx hash for deployment', async t => {
   );
   t.is(deployment.address, fakeDeploy.address);
   t.is(deployment.txHash, '0x2');
+});
+
+test('defender - address clash', async t => {
+  const provider = stubProvider();
+
+  // create a pending deployment with id
+  const fakeDeploy = await provider.deployPending();
+  provider.removeContract(fakeDeploy.address);
+
+  async function deployment1() {
+    return {
+      ...fakeDeploy,
+      txHash: '0x1',
+      remoteDeploymentId: 'abc',
+    };
+  }
+
+  const mockPendingDeployment = sinon.stub().returns({
+    status: 'submitted',
+    txHash: '0x1',
+  });
+  // let it timeout
+  await t.throwsAsync(
+    fetchOrDeployGetDeployment(
+      version1,
+      provider,
+      deployment1,
+      { timeout: 1, pollingInterval: 0 },
+      undefined,
+      mockPendingDeployment,
+    ),
+  );
+
+  // simulate a new deployment with the same address, but different tx hash and deployment id
+  async function deployment2() {
+    return {
+      ...fakeDeploy,
+      txHash: '0x2',
+      remoteDeploymentId: 'def',
+    };
+  }
+
+  // deploy with a different version hash
+  const error = await t.throwsAsync(
+    fetchOrDeployGetDeployment(
+      version2,
+      provider,
+      deployment2,
+      { timeout: 1, pollingInterval: 0 },
+      undefined,
+      mockPendingDeployment,
+    ),
+  );
+
+  t.true(
+    error?.message.startsWith(`The deployment clashes with an existing one at ${fakeDeploy.address}`),
+    error?.message,
+  );
+});
+
+test('defender - merge avoids address clash, replaces deployment id', async t => {
+  const provider = stubProvider();
+
+  const MERGE = true;
+
+  // create a pending deployment with id
+  const fakeDeploy = await provider.deployPending();
+  provider.removeContract(fakeDeploy.address);
+
+  async function deployment1() {
+    return {
+      ...fakeDeploy,
+      txHash: '0x1',
+      remoteDeploymentId: 'abc',
+    };
+  }
+
+  const getDeploymentResponse1 = sinon.stub().returns({
+    status: 'submitted',
+    txHash: '0x1',
+  });
+  // let it timeout
+  await t.throwsAsync(
+    fetchOrDeployGetDeployment(
+      version1,
+      provider,
+      deployment1,
+      { timeout: 1, pollingInterval: 0 },
+      MERGE,
+      getDeploymentResponse1,
+    ),
+  );
+
+  // simulate a failed previous deployment
+  const getDeploymentResponse2 = sinon.stub().returns({
+    status: 'failed',
+    txHash: '0x1',
+  });
+
+  // redeploy with a new deployment id
+  async function deployment2() {
+    return {
+      ...fakeDeploy,
+      txHash: '0x2',
+      remoteDeploymentId: 'def',
+    };
+  }
+
+  // make the contract code exist
+  provider.addContract(fakeDeploy.address);
+
+  const deployment = await fetchOrDeployGetDeployment(
+    version1,
+    provider,
+    deployment2,
+    { timeout: 1, pollingInterval: 0 },
+    MERGE,
+    getDeploymentResponse2,
+  );
+
+  t.is(deployment.address, fakeDeploy.address);
+  t.is(deployment.txHash, '0x2');
+  t.is((deployment as RemoteDeploymentId).remoteDeploymentId, 'def');
 });

--- a/packages/core/src/impl-store.ts
+++ b/packages/core/src/impl-store.ts
@@ -229,17 +229,19 @@ async function checkForAddressClash(
   merge: boolean,
 ): Promise<void> {
   let clash;
+  let findClash = () => lookupDeployment(data, updated.address, !merge);
+
   if (await isDevelopmentNetwork(provider)) {
     // Look for clashes so that we can delete deployments from older runs.
     // `merge` only checks primary addresses for clashes, since the address could already exist in an allAddresses field
     // but the updated and stored objects are different instances representing the same entry.
-    clash = lookupDeployment(data, updated.address, !merge);
+    clash = findClash();
     if (clash !== undefined) {
       debug('deleting a previous deployment at address', updated.address);
       clash.set(undefined);
     }
   } else if (!merge) {
-    clash = lookupDeployment(data, updated.address, true);
+    clash = findClash();
     if (clash !== undefined) {
       const existing = clash.get();
       // it's a clash if there is no deployment id or if deployment ids don't match

--- a/packages/core/src/impl-store.ts
+++ b/packages/core/src/impl-store.ts
@@ -251,8 +251,7 @@ async function checkForAddressClash(
       ) {
         throw new Error(
           `The deployment clashes with an existing one at ${updated.address}.\n\n` +
-            `Existing deployment: ${JSON.stringify(existing, null, 2)}\n\n` +
-            `New deployment: ${JSON.stringify(updated, null, 2)}\n\n`,
+            `Deployments: ${JSON.stringify({ existing, updated }, null, 2)}\n\n`,
         );
       }
     }

--- a/packages/core/src/impl-store.ts
+++ b/packages/core/src/impl-store.ts
@@ -72,9 +72,9 @@ async function fetchOrDeployGeneric<T extends Deployment, U extends T = T>(
       );
       if (updated !== stored) {
         if (merge && deployment.merge) {
-          // only check primary addresses for clashes, since the address could already exist in an allAddresses field
-          // but the above updated and stored objects are different instances representing the same entry
-          await checkForAddressClash(provider, data, updated, false);
+          // `merge` indicates that the user is force-importing or redeploying an implementation,
+          // so we don't need to check for address clashes because this is an assertion from the user.
+          // The bytecode version hash is already known to be identical, due to `stored` coming from the deployment.
           deployment.merge(updated);
         } else {
           await checkForAddressClash(provider, data, updated, true);
@@ -172,12 +172,17 @@ export async function fetchOrDeployGetDeployment<T extends ImplDeployment>(
 const implLens = (versionWithoutMetadata: string) =>
   lens(`implementation ${versionWithoutMetadata}`, 'implementation', data => ({
     get: () => data.impls[versionWithoutMetadata],
-    set: (value?: ImplDeployment) => (data.impls[versionWithoutMetadata] = value),
-    merge: (value?: ImplDeployment) => {
+    set: (value?: ImplDeployment & RemoteDeploymentId) => (data.impls[versionWithoutMetadata] = value),
+    merge: (value?: ImplDeployment & RemoteDeploymentId) => {
       const existing = data.impls[versionWithoutMetadata];
       if (existing !== undefined && value !== undefined) {
         const { address, allAddresses } = mergeAddresses(existing, value);
-        data.impls[versionWithoutMetadata] = { ...existing, address, allAddresses };
+        data.impls[versionWithoutMetadata] = {
+          ...existing,
+          address,
+          allAddresses,
+          remoteDeploymentId: value.remoteDeploymentId,
+        };
       } else {
         data.impls[versionWithoutMetadata] = value;
       }
@@ -238,9 +243,9 @@ async function checkForAddressClash(
         (existing.remoteDeploymentId === undefined || existing.remoteDeploymentId !== updated.remoteDeploymentId)
       ) {
         throw new Error(
-          `The following deployment clashes with an existing one at ${updated.address}\n\n` +
-            JSON.stringify(updated, null, 2) +
-            `\n\n`,
+          `The deployment clashes with an existing one at ${updated.address}.\n\n` +
+            `Existing deployment: ${JSON.stringify(existing, null, 2)}\n\n` +
+            `New deployment: ${JSON.stringify(updated, null, 2)}\n\n`,
         );
       }
     }

--- a/packages/core/src/impl-store.ts
+++ b/packages/core/src/impl-store.ts
@@ -229,7 +229,7 @@ async function checkForAddressClash(
   merge: boolean,
 ): Promise<void> {
   let clash;
-  let findClash = () => lookupDeployment(data, updated.address, !merge);
+  const findClash = () => lookupDeployment(data, updated.address, !merge);
 
   if (await isDevelopmentNetwork(provider)) {
     // Look for clashes so that we can delete deployments from older runs.


### PR DESCRIPTION
Avoids checking for address clash when using `forceImport` or `redeployImplementation: 'always'`.

Address clashes should not occur in general, because it indicates a deployment is being attempted to an address which was already in the manifest, and such deployment should not occur if the bytecode version hash was the same before (unless using `forceImport` or `redeployImplementation: 'always'`, which triggers a deployment regardless of an existing bytecode version hash).  

Fixes #938 