### PR TITLE
Fix manifest error when connecting to an Anvil dev network

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix manifest error when connecting to an Anvil dev network.
+- Fix manifest error when connecting to an Anvil dev network. ([#950](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/950))
 
 ## 1.32.1 (2023-12-14)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix manifest error when connecting to an Anvil dev network.
+
 ## 1.32.1 (2023-12-14)
 
 - CLI: Fix ambiguous name error when passing in fully qualified contract names. ([#944](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/944))

--- a/packages/core/src/manifest.test.ts
+++ b/packages/core/src/manifest.test.ts
@@ -399,11 +399,23 @@ test('manifest name for an unknown network, development instance, non hardhat', 
 test('manifest name for an unknown network, development instance, hardhat', t => {
   const chainId = 31337;
   const instanceId = '0x22223';
-  const devInstanceMetadata = { networkName: 'dev', instanceId: instanceId };
+  const devInstanceMetadata = { networkName: 'hardhat', instanceId: instanceId };
 
   const manifest = new Manifest(chainId, devInstanceMetadata, '/tmp');
 
-  const expectedPath = `/tmp/openzeppelin-upgrades/dev-${chainId}-${instanceId}.json`;
+  const expectedPath = `/tmp/openzeppelin-upgrades/hardhat-${chainId}-${instanceId}.json`;
+  t.is(manifest.file, expectedPath);
+  t.is(manifest.fallbackFile, `.openzeppelin/unknown-${chainId}.json`);
+});
+
+test('manifest name for an unknown network, development instance, anvil - forkedNetwork null', t => {
+  const chainId = 31337;
+  const instanceId = '0x22224';
+  const devInstanceMetadata = { networkName: 'anvil', instanceId: instanceId, forkedNetwork: null };
+
+  const manifest = new Manifest(chainId, devInstanceMetadata, '/tmp');
+
+  const expectedPath = `/tmp/openzeppelin-upgrades/anvil-${chainId}-${instanceId}.json`;
   t.is(manifest.file, expectedPath);
   t.is(manifest.fallbackFile, `.openzeppelin/unknown-${chainId}.json`);
 });

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -58,7 +58,6 @@ async function getDevInstanceMetadata(
   chainId: number,
 ): Promise<DevInstanceMetadata | undefined> {
   let networkMetadata: HardhatMetadata;
-
   let networkType: DevNetworkType;
   try {
     networkMetadata = await getAnvilMetadata(provider);

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1,7 +1,14 @@
 import os from 'os';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { EthereumProvider, HardhatMetadata, getChainId, getHardhatMetadata, networkNames } from './provider';
+import {
+  EthereumProvider,
+  HardhatMetadata,
+  getAnvilMetadata,
+  getChainId,
+  getHardhatMetadata,
+  networkNames,
+} from './provider';
 import lockfile from 'proper-lockfile';
 import { compare as compareVersions } from 'compare-versions';
 
@@ -44,28 +51,37 @@ function defaultManifest(): ManifestData {
 const MANIFEST_DEFAULT_DIR = '.openzeppelin';
 const MANIFEST_TEMP_DIR = 'openzeppelin-upgrades';
 
+type DevNetworkType = 'hardhat' | 'anvil';
+
 async function getDevInstanceMetadata(
   provider: EthereumProvider,
   chainId: number,
 ): Promise<DevInstanceMetadata | undefined> {
-  let hardhatMetadata: HardhatMetadata;
+  let networkMetadata: HardhatMetadata;
 
+  let networkType: DevNetworkType;
   try {
-    hardhatMetadata = await getHardhatMetadata(provider);
+    networkMetadata = await getAnvilMetadata(provider);
+    networkType = 'anvil';
   } catch (e: unknown) {
-    return undefined;
+    try {
+      networkMetadata = await getHardhatMetadata(provider);
+      networkType = 'hardhat';
+    } catch (e: unknown) {
+      return undefined;
+    }
   }
 
-  if (hardhatMetadata.chainId !== chainId) {
+  if (networkMetadata.chainId !== chainId) {
     throw new Error(
-      `Broken invariant: Hardhat metadata's chainId ${hardhatMetadata.chainId} does not match eth_chainId ${chainId}`,
+      `Broken invariant: Hardhat or Anvil metadata's chainId ${networkMetadata.chainId} does not match eth_chainId ${chainId}`,
     );
   }
 
   return {
-    networkName: hardhatMetadata.clientVersion.startsWith('anvil') ? 'anvil' : 'hardhat',
-    instanceId: hardhatMetadata.instanceId,
-    forkedNetwork: hardhatMetadata.forkedNetwork,
+    networkName: networkType,
+    instanceId: networkMetadata.instanceId,
+    forkedNetwork: networkMetadata.forkedNetwork,
   };
 }
 

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { EthereumProvider, getChainId, getHardhatMetadata, networkNames } from './provider';
+import { EthereumProvider, HardhatMetadata, getChainId, getHardhatMetadata, networkNames } from './provider';
 import lockfile from 'proper-lockfile';
 import { compare as compareVersions } from 'compare-versions';
 
@@ -48,23 +48,25 @@ async function getDevInstanceMetadata(
   provider: EthereumProvider,
   chainId: number,
 ): Promise<DevInstanceMetadata | undefined> {
+  let hardhatMetadata: HardhatMetadata;
+
   try {
-    const hardhatMetadata = await getHardhatMetadata(provider);
-
-    if (hardhatMetadata.chainId !== chainId) {
-      throw new Error(
-        `Broken invariant: Hardhat metadata's chainId ${hardhatMetadata.chainId} does not match eth_chainId ${chainId}`,
-      );
-    }
-
-    return {
-      networkName: hardhatMetadata.clientVersion.startsWith('anvil') ? 'anvil' : 'hardhat',
-      instanceId: hardhatMetadata.instanceId,
-      forkedNetwork: hardhatMetadata.forkedNetwork,
-    };
+    hardhatMetadata = await getHardhatMetadata(provider);
   } catch (e: unknown) {
     return undefined;
   }
+
+  if (hardhatMetadata.chainId !== chainId) {
+    throw new Error(
+      `Broken invariant: Hardhat metadata's chainId ${hardhatMetadata.chainId} does not match eth_chainId ${chainId}`,
+    );
+  }
+
+  return {
+    networkName: hardhatMetadata.clientVersion.startsWith('anvil') ? 'anvil' : 'hardhat',
+    instanceId: hardhatMetadata.instanceId,
+    forkedNetwork: hardhatMetadata.forkedNetwork,
+  };
 }
 
 function getSuffix(chainId: number, devInstanceMetadata?: DevInstanceMetadata) {

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -1,4 +1,5 @@
 export interface EthereumProvider {
+  send(method: 'anvil_metadata', params: []): Promise<HardhatMetadata>;
   send(method: 'hardhat_metadata', params: []): Promise<HardhatMetadata>;
   send(method: 'web3_clientVersion', params: []): Promise<string>;
   send(method: 'net_version', params: []): Promise<string>;
@@ -56,6 +57,13 @@ export async function getClientVersion(provider: EthereumProvider): Promise<stri
  */
 export async function getHardhatMetadata(provider: EthereumProvider): Promise<HardhatMetadata> {
   return provider.send('hardhat_metadata', []);
+}
+
+/**
+ * Anvil could have anvil_metadata, for which hardhat_metadata is an alias.
+ */
+export async function getAnvilMetadata(provider: EthereumProvider): Promise<HardhatMetadata> {
+  return provider.send('anvil_metadata', []);
 }
 
 export async function getStorageAt(

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -12,7 +12,7 @@ export interface EthereumProvider {
   send(method: string, params: unknown[]): Promise<unknown>;
 }
 
-interface HardhatMetadata {
+export interface HardhatMetadata {
   clientVersion: string;
   chainId: number;
   instanceId: string;

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -13,12 +13,13 @@ export interface EthereumProvider {
 }
 
 interface HardhatMetadata {
+  clientVersion: string;
   chainId: number;
   instanceId: string;
   forkedNetwork?: {
     // The chainId of the network that is being forked
     chainId: number;
-  };
+  } | null;
 }
 
 interface EthereumTransaction {


### PR DESCRIPTION
When handling network manifest files, we use the [RPC method `hardhat_metadata`](https://hardhat.org/hardhat-network/docs/reference#hardhat_metadata) to determine if the connected network is a Hardhat development network, in which case we write the manifest to the temp dir instead of `.openzeppelin`.

Furthermore, if this method has a `forkedNetwork` field in its response, we treat this as a network fork and make a copy of the origin networks's manifest file, so that we can write to it for the fork without affecting the original version.

In recent versions of Anvil, Anvil also supports the `hardhat_metadata` RPC method, but has `"forkedNetwork": null` in its response as seen [here](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/943#issuecomment-1864052578).

This PR does two things:
1. Try calling `anvil_metadata` to determine if Anvil, and if so, use `anvil` for the manifest file prefix to more accurately reflect the network type.
2. Check if `forkedNetwork` is null or undefined, in which case we determine that it is not a network fork.

Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/943