### PR TITLE
Use query instead of body for Etherscan API

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support proxy verification on Snowtrace. ([#954](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/954))
+
 ## 3.0.1 (2023-12-20)
 
 - Update dependency on undici. ([#948](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/948))

--- a/packages/plugin-hardhat/src/utils/etherscan-api.ts
+++ b/packages/plugin-hardhat/src/utils/etherscan-api.ts
@@ -14,9 +14,10 @@ import { Etherscan } from '@nomicfoundation/hardhat-verify/etherscan';
  * @returns The Etherscan API response
  */
 export async function callEtherscanApi(etherscan: Etherscan, params: any): Promise<EtherscanResponseBody> {
+  const parameters = { ...params, apikey: etherscan.apiKey };
   const response = await request(etherscan.apiUrl, {
     method: 'POST',
-    query: params
+    query: parameters
   });
 
   if (!(response.statusCode >= 200 && response.statusCode <= 299)) {

--- a/packages/plugin-hardhat/src/utils/etherscan-api.ts
+++ b/packages/plugin-hardhat/src/utils/etherscan-api.ts
@@ -17,7 +17,7 @@ export async function callEtherscanApi(etherscan: Etherscan, params: any): Promi
   const parameters = { ...params, apikey: etherscan.apiKey };
   const response = await request(etherscan.apiUrl, {
     method: 'POST',
-    query: parameters
+    query: parameters,
   });
 
   if (!(response.statusCode >= 200 && response.statusCode <= 299)) {

--- a/packages/plugin-hardhat/src/utils/etherscan-api.ts
+++ b/packages/plugin-hardhat/src/utils/etherscan-api.ts
@@ -14,12 +14,9 @@ import { Etherscan } from '@nomicfoundation/hardhat-verify/etherscan';
  * @returns The Etherscan API response
  */
 export async function callEtherscanApi(etherscan: Etherscan, params: any): Promise<EtherscanResponseBody> {
-  const parameters = new URLSearchParams({ ...params, apikey: etherscan.apiKey });
-
   const response = await request(etherscan.apiUrl, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: parameters.toString(),
+    query: params
   });
 
   if (!(response.statusCode >= 200 && response.statusCode <= 299)) {


### PR DESCRIPTION
When attempting to verify contracts on Snowtrace, I received the following error:
`Etherscan returned with message: NOTOK, reason: Invalid querystring request`

Looking at the Etherscan API I noticed that all endpoints used query parameters instead of a form-encoded body like in the code. With this change my verification calls are now working.

It's not clear to me why the original implementation was created or how it's working on Etherscan - I assume that Snowtrace conforms closer to the API spec and that is why the change is required.