### PR TITLE
CLI: Improve checks for build info file settings

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- CLI: Improve checks for build info file settings. ([#958](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/958))
+
 ## 1.32.2 (2023-12-21)
 
 - Fix manifest error when connecting to an Anvil dev network. ([#950](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/950))

--- a/packages/core/src/cli/validate/build-info-file.test.ts
+++ b/packages/core/src/cli/validate/build-info-file.test.ts
@@ -134,7 +134,7 @@ const BUILD_INFO_INDIVIDUAL_NO_LAYOUT = {
   },
 };
 
-const BUILD_INFO_PARTIALLY_NO_LAYOUT = {
+const BUILD_INFO_PARTIAL_NO_LAYOUT = {
   solcVersion: '0.8.9',
   input: {
     language: 'Solidity',
@@ -173,7 +173,7 @@ const BUILD_INFO_PARTIALLY_NO_LAYOUT = {
   },
 };
 
-const BUILD_INFO_PARTIAL_COMPILE_LAYOUT_OK = {
+const BUILD_INFO_PARTIAL_COMPILE = {
   solcVersion: '0.8.9',
   input: {
     language: 'Solidity',
@@ -212,7 +212,7 @@ const BUILD_INFO_PARTIAL_COMPILE_LAYOUT_OK = {
   },
 };
 
-const BUILD_INFO_NO_OUTPUT_SELECTION_OK = {
+const BUILD_INFO_NO_OUTPUT_SELECTION = {
   solcVersion: '0.8.9',
   input: {
     language: 'Solidity',
@@ -365,30 +365,30 @@ test.serial('individual output selections - partially no layout', async t => {
   const dir = 'partial-no-layout';
 
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIALLY_NO_LAYOUT));
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIAL_NO_LAYOUT));
 
   const error = await t.throwsAsync(getBuildInfoFiles(dir));
   t.true(error?.message.includes('does not contain storage layout'));
 });
 
-test.serial('individual output selections - partially compiled with layout - ok', async t => {
+test.serial('individual output selections - partially compiled', async t => {
   const dir = 'partial-compile-layout';
 
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIAL_COMPILE_LAYOUT_OK));
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIAL_COMPILE));
 
-  // only some contracts were compiled, but those do have storage layout
-  t.assert((await getBuildInfoFiles(dir)).length > 0);
+  const error = await t.throwsAsync(getBuildInfoFiles(dir));
+  t.true(error?.message.includes('does not contain a full compilation'));
 });
 
-test.serial('no output selection - ok', async t => {
+test.serial('no output selection', async t => {
   const dir = 'no-output';
 
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_NO_OUTPUT_SELECTION_OK));
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_NO_OUTPUT_SELECTION));
 
-  // should not give a storage layout error since there are no outputs
-  t.assert((await getBuildInfoFiles(dir)).length > 0);
+  const error = await t.throwsAsync(getBuildInfoFiles(dir));
+  t.true(error?.message.includes('does not contain a full compilation'));
 });
 
 function assertBuildInfoFiles(t: ExecutionContext, buildInfoFiles: BuildInfoFile[]) {

--- a/packages/core/src/cli/validate/build-info-file.test.ts
+++ b/packages/core/src/cli/validate/build-info-file.test.ts
@@ -134,7 +134,46 @@ const BUILD_INFO_INDIVIDUAL_NO_LAYOUT = {
   },
 };
 
-const BUILD_INFO_PARTIAL_NO_LAYOUT = {
+const BUILD_INFO_INDIVIDUAL_HAS_LAYOUT = {
+  solcVersion: '0.8.9',
+  input: {
+    language: 'Solidity',
+    sources: {
+      'mypath/MyContract.sol': {
+        content: 'contract MyContract {}',
+      },
+      'mypath/MyContractV2.sol': {
+        content: 'contract MyContractV2 {}',
+      },
+    },
+    settings: {
+      outputSelection: {
+        'mypath/MyContract.sol': {
+          '': ['ast'],
+          '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode', 'evm.methodIdentifiers', 'metadata', 'storageLayout'],
+        },
+        'mypath/MyContractV2.sol': {
+          '': ['ast'],
+          '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode', 'evm.methodIdentifiers', 'metadata', 'storageLayout'],
+        },
+      },
+    },
+  },
+  output: {
+    sources: {
+      'mypath/MyContract.sol': {
+        ast: {},
+        id: 123,
+      },
+      'mypath/MyContractV2.sol': {
+        ast: {},
+        id: 456,
+      },
+    },
+  },
+};
+
+const BUILD_INFO_PARTIAL_LAYOUT = {
   solcVersion: '0.8.9',
   input: {
     language: 'Solidity',
@@ -361,18 +400,27 @@ test.serial('individual output selections - no layout', async t => {
   t.true(error?.message.includes('does not contain storage layout'));
 });
 
-test.serial('individual output selections - partially no layout', async t => {
-  const dir = 'partial-no-layout';
+test.serial('individual output selections - has layout', async t => {
+  const dir = 'individual-has-layout';
 
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIAL_NO_LAYOUT));
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_INDIVIDUAL_HAS_LAYOUT));
+
+  t.assert((await getBuildInfoFiles(dir)).length === 1);
+});
+
+test.serial('individual output selections - partial layout', async t => {
+  const dir = 'partial-layout';
+
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIAL_LAYOUT));
 
   const error = await t.throwsAsync(getBuildInfoFiles(dir));
   t.true(error?.message.includes('does not contain storage layout'));
 });
 
-test.serial('individual output selections - partially compiled', async t => {
-  const dir = 'partial-compile-layout';
+test.serial('individual output selections - partial compile', async t => {
+  const dir = 'partial-compile';
 
   await fs.mkdir(dir, { recursive: true });
   await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIAL_COMPILE));

--- a/packages/core/src/cli/validate/build-info-file.test.ts
+++ b/packages/core/src/cli/validate/build-info-file.test.ts
@@ -95,6 +95,161 @@ const BUILD_INFO_NO_LAYOUT = {
   },
 };
 
+const BUILD_INFO_INDIVIDUAL_NO_LAYOUT = {
+  solcVersion: '0.8.9',
+  input: {
+    language: 'Solidity',
+    sources: {
+      'mypath/MyContract.sol': {
+        content: 'contract MyContract {}',
+      },
+      'mypath/MyContractV2.sol': {
+        content: 'contract MyContractV2 {}',
+      },
+    },
+    settings: {
+      outputSelection: {
+        'mypath/MyContract.sol': {
+          '': ['ast'],
+          '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode', 'evm.methodIdentifiers', 'metadata'],
+        },
+        'mypath/MyContractV2.sol': {
+          '': ['ast'],
+          '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode', 'evm.methodIdentifiers', 'metadata'],
+        },
+      },
+    },
+  },
+  output: {
+    sources: {
+      'mypath/MyContract.sol': {
+        ast: {},
+        id: 123,
+      },
+      'mypath/MyContractV2.sol': {
+        ast: {},
+        id: 456,
+      },
+    },
+  },
+};
+
+const BUILD_INFO_PARTIALLY_NO_LAYOUT = {
+  solcVersion: '0.8.9',
+  input: {
+    language: 'Solidity',
+    sources: {
+      'mypath/MyContract.sol': {
+        content: 'contract MyContract {}',
+      },
+      'mypath/MyContractV2.sol': {
+        content: 'contract MyContractV2 {}',
+      },
+    },
+    settings: {
+      outputSelection: {
+        'mypath/MyContract.sol': {
+          '': ['ast'],
+          '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode', 'evm.methodIdentifiers', 'metadata', 'storageLayout'],
+        },
+        'mypath/MyContractV2.sol': {
+          '': ['ast'],
+          '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode', 'evm.methodIdentifiers', 'metadata'],
+        },
+      },
+    },
+  },
+  output: {
+    sources: {
+      'mypath/MyContract.sol': {
+        ast: {},
+        id: 123,
+      },
+      'mypath/MyContractV2.sol': {
+        ast: {},
+        id: 456,
+      },
+    },
+  },
+};
+
+const BUILD_INFO_PARTIAL_COMPILE_LAYOUT_OK = {
+  solcVersion: '0.8.9',
+  input: {
+    language: 'Solidity',
+    sources: {
+      'mypath/MyContract.sol': {
+        content: 'contract MyContract {}',
+      },
+      'mypath/MyContractV2.sol': {
+        content: 'contract MyContractV2 {}',
+      },
+    },
+    settings: {
+      outputSelection: {
+        'mypath/MyContract.sol': {
+          '': ['ast'],
+          '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode', 'evm.methodIdentifiers', 'metadata', 'storageLayout'],
+        },
+        'mypath/MyContractV2.sol': {
+          '': [],
+          '*': [],
+        },
+      },
+    },
+  },
+  output: {
+    sources: {
+      'mypath/MyContract.sol': {
+        ast: {},
+        id: 123,
+      },
+      'mypath/MyContractV2.sol': {
+        ast: {},
+        id: 456,
+      },
+    },
+  },
+};
+
+const BUILD_INFO_NO_OUTPUT_SELECTION_OK = {
+  solcVersion: '0.8.9',
+  input: {
+    language: 'Solidity',
+    sources: {
+      'mypath/MyContract.sol': {
+        content: 'contract MyContract {}',
+      },
+      'mypath/MyContractV2.sol': {
+        content: 'contract MyContractV2 {}',
+      },
+    },
+    settings: {
+      outputSelection: {
+        'mypath/MyContract.sol': {
+          '*': [],
+        },
+        'mypath/MyContractV2.sol': {
+          '': [],
+          '*': [],
+        },
+      },
+    },
+  },
+  output: {
+    sources: {
+      'mypath/MyContract.sol': {
+        ast: {},
+        id: 123,
+      },
+      'mypath/MyContractV2.sol': {
+        ast: {},
+        id: 456,
+      },
+    },
+  },
+};
+
 test.serial('get build info files - default hardhat', async t => {
   await fs.mkdir('artifacts/build-info', { recursive: true });
   await fs.mkdir('out/build-info', { recursive: true }); // should be ignored since it's empty
@@ -177,19 +332,63 @@ test.serial('dir does not exist', async t => {
 });
 
 test.serial('no build info files', async t => {
-  await fs.mkdir('empty-dir', { recursive: true });
-  await fs.writeFile('empty-dir/notjson.txt', 'abc');
+  const dir = 'empty-dir';
 
-  const error = await t.throwsAsync(getBuildInfoFiles('empty-dir'));
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(`${dir}/notjson.txt`, 'abc');
+
+  const error = await t.throwsAsync(getBuildInfoFiles(dir));
   t.true(error?.message.includes('does not contain any build info files'));
 });
 
 test.serial('no storage layout', async t => {
-  await fs.mkdir('no-storage-layout', { recursive: true });
-  await fs.writeFile('no-storage-layout/build-info.json', JSON.stringify(BUILD_INFO_NO_LAYOUT));
+  const dir = 'no-storage-layout';
 
-  const error = await t.throwsAsync(getBuildInfoFiles('no-storage-layout'));
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_NO_LAYOUT));
+
+  const error = await t.throwsAsync(getBuildInfoFiles(dir));
   t.true(error?.message.includes('does not contain storage layout'));
+});
+
+test.serial('individual output selections - no layout', async t => {
+  const dir = 'individual-no-layout';
+
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_INDIVIDUAL_NO_LAYOUT));
+
+  const error = await t.throwsAsync(getBuildInfoFiles(dir));
+  t.true(error?.message.includes('does not contain storage layout'));
+});
+
+test.serial('individual output selections - partially no layout', async t => {
+  const dir = 'partial-no-layout';
+
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIALLY_NO_LAYOUT));
+
+  const error = await t.throwsAsync(getBuildInfoFiles(dir));
+  t.true(error?.message.includes('does not contain storage layout'));
+});
+
+test.serial('individual output selections - partially compiled with layout - ok', async t => {
+  const dir = 'partial-compile-layout';
+
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIAL_COMPILE_LAYOUT_OK));
+
+  // only some contracts were compiled, but those do have storage layout
+  t.assert((await getBuildInfoFiles(dir)).length > 0);
+});
+
+test.serial('no output selection - ok', async t => {
+  const dir = 'no-output';
+
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_NO_OUTPUT_SELECTION_OK));
+
+  // should not give a storage layout error since there are no outputs
+  t.assert((await getBuildInfoFiles(dir)).length > 0);
 });
 
 function assertBuildInfoFiles(t: ExecutionContext, buildInfoFiles: BuildInfoFile[]) {

--- a/packages/core/src/cli/validate/build-info-file.test.ts
+++ b/packages/core/src/cli/validate/build-info-file.test.ts
@@ -426,7 +426,7 @@ test.serial('individual output selections - partial compile', async t => {
   await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_PARTIAL_COMPILE));
 
   const error = await t.throwsAsync(getBuildInfoFiles(dir));
-  t.true(error?.message.includes('does not contain a full compilation'));
+  t.true(error?.message.includes('is not from a full compilation'));
 });
 
 test.serial('no output selection', async t => {
@@ -436,7 +436,7 @@ test.serial('no output selection', async t => {
   await fs.writeFile(`${dir}/build-info.json`, JSON.stringify(BUILD_INFO_NO_OUTPUT_SELECTION));
 
   const error = await t.throwsAsync(getBuildInfoFiles(dir));
-  t.true(error?.message.includes('does not contain a full compilation'));
+  t.true(error?.message.includes('is not from a full compilation'));
 });
 
 function assertBuildInfoFiles(t: ExecutionContext, buildInfoFiles: BuildInfoFile[]) {

--- a/packages/core/src/cli/validate/build-info-file.ts
+++ b/packages/core/src/cli/validate/build-info-file.ts
@@ -150,8 +150,7 @@ async function readBuildInfo(buildInfoFilePaths: string[]) {
 }
 
 /**
- * Checks if the build info file's output selection contains storage layout for all contracts,
- * and that there are no empty output selections for any contracts.
+ * Gives an error if there is empty output selection for any contract, or a contract does not have storage layout.
  */
 function checkOutputSelection(buildInfoJson: any, buildInfoFilePath: string) {
   const o = buildInfoJson.input.settings?.outputSelection;

--- a/packages/core/src/cli/validate/build-info-file.ts
+++ b/packages/core/src/cli/validate/build-info-file.ts
@@ -150,9 +150,20 @@ async function readBuildInfo(buildInfoFilePaths: string[]) {
   return buildInfoFiles;
 }
 
-function hasStorageLayoutSetting(buildInfoJson: any) {
+function hasStorageLayoutSetting(buildInfoJson: any): boolean {
   const o = buildInfoJson.input.settings?.outputSelection;
-  return o?.['*']?.['*'] && (o['*']['*'].includes('storageLayout') || o['*']['*'].includes('*'));
+
+  return Object.keys(o).every((item: any) => {
+    if (o[item][''].length === 0 && o[item]['*'].length === 0) {
+      // No outputs at all for this contract e.g. if there were no changes since the last compile in Foundry.
+      // This is fine, we can skip this contract since it should exist (and have storageLayout) in an earlier build info file.
+      return true;
+    } else if (o[item]['*'].length > 0 && o[item]['*'].includes('storageLayout')) {
+      return true;
+    } else {
+      return false;
+    }
+  });
 }
 
 async function readJSON(path: string) {

--- a/packages/core/src/cli/validate/build-info-file.ts
+++ b/packages/core/src/cli/validate/build-info-file.ts
@@ -164,9 +164,7 @@ function checkOutputSelection(buildInfoJson: any, buildInfoFilePath: string) {
         `Build info file ${buildInfoFilePath} does not contain a full compilation.`,
         () => PARTIAL_COMPILE_HELP,
       );
-    } else if (o[item]['*'].length > 0 && o[item]['*'].includes('storageLayout')) {
-      return true;
-    } else {
+    } else if (!o[item]['*'].includes('storageLayout')) {
       throw new ValidateCommandError(
         `Build info file ${buildInfoFilePath} does not contain storage layout for all contracts.`,
         () => STORAGE_LAYOUT_HELP,

--- a/packages/core/src/cli/validate/build-info-file.ts
+++ b/packages/core/src/cli/validate/build-info-file.ts
@@ -133,7 +133,7 @@ async function readBuildInfo(buildInfoFilePaths: string[]) {
         `Build info file ${buildInfoFilePath} must contain Solidity compiler input, output, and solcVersion.`,
       );
     } else {
-      if (!hasStorageLayoutSetting(buildInfoJson)) {
+      if (!hasStorageLayoutSettings(buildInfoJson)) {
         throw new ValidateCommandError(
           `Build info file ${buildInfoFilePath} does not contain storage layout.`,
           () => STORAGE_LAYOUT_HELP,
@@ -150,11 +150,18 @@ async function readBuildInfo(buildInfoFilePaths: string[]) {
   return buildInfoFiles;
 }
 
-function hasStorageLayoutSetting(buildInfoJson: any): boolean {
+/**
+ * Checks if the build info file contains storage layout settings for all contracts that have outputs.
+ *
+ * @param buildInfoJson Build info JSON object.
+ * @returns True if the build info file contains storage layout settings for all contracts that have outputs
+ *  (note this is vacuously true even if there are no outputs), false otherwise.
+ */
+function hasStorageLayoutSettings(buildInfoJson: any): boolean {
   const o = buildInfoJson.input.settings?.outputSelection;
 
   return Object.keys(o).every((item: any) => {
-    if (o[item][''].length === 0 && o[item]['*'].length === 0) {
+    if ((o[item][''] === undefined || o[item][''].length === 0) && o[item]['*'].length === 0) {
       // No outputs at all for this contract e.g. if there were no changes since the last compile in Foundry.
       // This is fine, we can skip this contract since it should exist (and have storageLayout) in an earlier build info file.
       return true;

--- a/packages/core/src/cli/validate/build-info-file.ts
+++ b/packages/core/src/cli/validate/build-info-file.ts
@@ -160,7 +160,7 @@ function checkOutputSelection(buildInfoJson: any, buildInfoFilePath: string) {
       // No outputs at all for this contract e.g. if there were no changes since the last compile in Foundry.
       // This is not supported for now, since it leads to AST nodes that reference node ids in other build-info files.
       throw new ValidateCommandError(
-        `Build info file ${buildInfoFilePath} does not contain a full compilation.`,
+        `Build info file ${buildInfoFilePath} is not from a full compilation.`,
         () => PARTIAL_COMPILE_HELP,
       );
     } else if (!o[item]['*'].includes('storageLayout')) {

--- a/packages/core/src/cli/validate/build-info-file.ts
+++ b/packages/core/src/cli/validate/build-info-file.ts
@@ -168,7 +168,7 @@ function checkOutputSelection(buildInfoJson: any, buildInfoFilePath: string) {
       return true;
     } else {
       throw new ValidateCommandError(
-        `Build info file ${buildInfoFilePath} does not contain storage layout.`,
+        `Build info file ${buildInfoFilePath} does not contain storage layout for all contracts.`,
         () => STORAGE_LAYOUT_HELP,
       );
     }


### PR DESCRIPTION
This PR addresses 2 issues:

1. When running validations from CLI, we previously looked for the following `outputSelection` from the build info file, and gave an error if that was missing:
```
      outputSelection: {
        '*': {
          '*': ['storageLayout']
        }
      }
```

However, in recent versions of Foundry (reported in https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/issues/4), running `forge script` no longer uses the above format.  Instead, it has settings enabled for each individual contract, like:
```
      outputSelection: {
        'mypath/MyContract.sol': {
          '': ['ast'],
          '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode', 'evm.methodIdentifiers', 'metadata', 'storageLayout']
        }
     }
```

This PR checks each contract's settings and gives an error if any of them do not have `storageLayout`.

2. Additionally, if users modify a Solidity file and run Foundry compilation, Foundry does a partial compilation by default.  This causes the updated build info file to contain AST nodes that reference node IDs from older build-info files, and we currently do not support this. Therefore, we throw an error telling users to do a full recompilation.