### PR TITLE
Enable moving network file across filesystems

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix error when renaming network file and using a separate filesystem. ([#964](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/964))
+
 ## 1.32.3 (2024-01-16)
 
 - CLI: Improve checks for build info file settings. ([#958](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/958))

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -229,16 +229,18 @@ export class Manifest {
   }
 
   private async writeFile(content: string): Promise<void> {
-    await this.renameFileIfRequired();
+    await this.moveFileIfRequired();
     await fs.writeFile(this.file, content);
   }
 
-  private async renameFileIfRequired() {
+  private async moveFileIfRequired() {
     if (this.file !== this.fallbackFile && (await this.exists(this.fallbackFile))) {
       try {
-        await fs.rename(this.fallbackFile, this.file);
+        // copy and delete instead of rename to work across filesystems
+        await fs.copyFile(this.fallbackFile, this.file);
+        await fs.unlink(this.fallbackFile);
       } catch (e: any) {
-        throw new Error(`Failed to rename network file from ${this.fallbackFile} to ${this.file}: ${e.message}`);
+        throw new Error(`Failed to move network file from ${this.fallbackFile} to ${this.file}: ${e.message}`);
       }
     }
   }


### PR DESCRIPTION
Fixes #962 

Network files can be in several locations:
1. The fallback location if the network is not known: `.openzeppelin/unknown-<chain id>.json`
2. A named location based on the network name (for live networks) such as `.openzeppelin/<network name>.json`
3. Within the temp directory (e.g. `/tmp/openzeppelin-upgrades/hardhat-31337-<hardhat instance id>.json`) if using a dev network such as Hardhat or Anvil.

If the file exists in (1) the fallback location (from a previous run of the Upgrades plugins), and a newer version of the plugin is aware of and wants to use (2) or (3), it tries to move it from (1) to (2) or (3).

To allow this move to occur across filesystems, we should copy and delete it instead of directly renaming it.