### PR TITLE
Remove console logging for transferProxyAdminOwnership

### DIFF
--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -637,6 +637,7 @@ async function transferProxyAdminOwnership(
   newOwner: string,
   signer?: ethers.Signer,
   opts?: {
+    silent?: boolean,
     txOverrides?: ethers.Overrides,
   }
 ): Promise<void>
@@ -652,6 +653,7 @@ NOTE: The `proxyAddress` parameter is required since `@openzeppelin/hardhat-upgr
 * `newOwner` - the new owner address for the proxy admin contract.
 * `signer` - the signer to use for the transaction.
 * `opts` - an object with options:
+** `silent`: if set to `true`, silences console logging about each proxy affected by the admin ownership transfer.
 ** additional options as described in <<common-options>>.
 
 *Since:*

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.5 (2024-03-01)
+## 3.0.5 (2024-03-04)
 
 - Simplify console logging for `admin.transferProxyAdminOwnership`. ([#978](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/978))
 

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Remove console logging when transferring proxy admin ownership.
+
 ## 3.0.4 (2024-02-27)
 
 - Support externally linked libraries for Defender deployments. ([#960](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/960))

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 3.0.5 (2024-02-28)
+## 3.0.5 (2024-03-01)
 
-- Remove console logging when transferring proxy admin ownership.
+- Simplify console logging for `admin.transferProxyAdminOwnership`. ([#978](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/978))
 
 ## 3.0.4 (2024-02-27)
 

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.0.5 (2024-02-28)
 
 - Remove console logging when transferring proxy admin ownership.
 

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.5 (2024-03-04)
+## Unreleased
 
 - Simplify console logging for `admin.transferProxyAdminOwnership`. ([#978](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/978))
 

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/hardhat-upgrades",
-  "version": "3.0.5",
+  "version": "3.0.4",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/plugin-hardhat",
   "license": "MIT",

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/hardhat-upgrades",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/plugin-hardhat",
   "license": "MIT",

--- a/packages/plugin-hardhat/src/admin.ts
+++ b/packages/plugin-hardhat/src/admin.ts
@@ -68,7 +68,14 @@ export function makeTransferProxyAdminOwnership(
       const { proxies } = await manifest.read();
       const adminAddress = await admin.getAddress();
 
-      const affected = proxies.filter(async proxy => (await getAdminAddress(provider, proxy.address)) === adminAddress);
+      const affected = [];
+      for (const proxy of proxies) {
+        const controller = await getAdminAddress(provider, proxy.address);
+        if (controller === adminAddress) {
+          affected.push(proxy);
+        }
+      }
+
       if (affected.length > 0) {
         console.log(SUCCESS_CHECK + `${affected.length} proxies ownership transferred through proxy admin`);
         affected.forEach(proxy => console.log(`    - ${proxy.address} (${proxy.kind})`));

--- a/packages/plugin-hardhat/src/admin.ts
+++ b/packages/plugin-hardhat/src/admin.ts
@@ -1,12 +1,8 @@
-import chalk from 'chalk';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { Manifest, getAdminAddress } from '@openzeppelin/upgrades-core';
+import { getAdminAddress } from '@openzeppelin/upgrades-core';
 import { Contract, Signer } from 'ethers';
 import { EthersDeployOptions, attachProxyAdminV4 } from './utils';
 import { disableDefender } from './defender/utils';
-
-const SUCCESS_CHECK = chalk.green('✔') + ' ';
-const FAILURE_CROSS = chalk.red('✘') + ' ';
 
 export type ChangeAdminFunction = (
   proxyAddress: string,
@@ -58,16 +54,5 @@ export function makeTransferProxyAdminOwnership(
 
     const overrides = opts.txOverrides ? [opts.txOverrides] : [];
     await admin.transferOwnership(newOwner, ...overrides);
-
-    const { provider } = hre.network;
-    const manifest = await Manifest.forNetwork(provider);
-    const { proxies } = await manifest.read();
-    for (const { address, kind } of proxies) {
-      if ((await admin.getAddress()) == (await getAdminAddress(provider, address))) {
-        console.log(SUCCESS_CHECK + `${address} (${kind}) proxy ownership transferred through proxy admin`);
-      } else {
-        console.log(FAILURE_CROSS + `${address} (${kind}) proxy ownership not affected by proxy admin`);
-      }
-    }
   };
 }

--- a/packages/plugin-hardhat/test/transparent-v4-transfer-admin-ownership-multiple.js
+++ b/packages/plugin-hardhat/test/transparent-v4-transfer-admin-ownership-multiple.js
@@ -39,6 +39,10 @@ test('transferProxyAdminOwnership v4 multiple proxies', async t => {
   );
   await upgrades.forceImport(await proxy2.getAddress(), Greeter);
 
+  // Deploy an unrelated UUPS proxy
+  const GreeterProxiable = await ethers.getContractFactory('GreeterProxiable');
+  await upgrades.deployProxy(GreeterProxiable, ['Hello, Hardhat!'], { kind: 'uups' });
+
   await upgrades.admin.transferProxyAdminOwnership(await greeter.getAddress(), testAddress);
   t.is(await admin.owner(), testAddress);
 });

--- a/packages/plugin-hardhat/test/transparent-v4-transfer-admin-ownership-multiple.js
+++ b/packages/plugin-hardhat/test/transparent-v4-transfer-admin-ownership-multiple.js
@@ -1,0 +1,44 @@
+const test = require('ava');
+
+const { ethers, upgrades } = require('hardhat');
+
+const ProxyAdmin = require('@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json');
+const TransparentUpgradableProxy = require('@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json');
+
+const testAddress = '0x1E6876a6C2757de611c9F12B23211dBaBd1C9028';
+
+test.before(async t => {
+  t.context.Greeter = await ethers.getContractFactory('Greeter');
+  t.context.ProxyAdmin = await ethers.getContractFactory(ProxyAdmin.abi, ProxyAdmin.bytecode);
+  t.context.TransparentUpgradableProxy = await ethers.getContractFactory(
+    TransparentUpgradableProxy.abi,
+    TransparentUpgradableProxy.bytecode,
+  );
+});
+
+test('transferProxyAdminOwnership v4 multiple proxies', async t => {
+  const { Greeter, ProxyAdmin, TransparentUpgradableProxy } = t.context;
+
+  // Deploy a v4 proxy and admin, and import them
+  const impl = await Greeter.deploy();
+  await impl.waitForDeployment();
+  const admin = await ProxyAdmin.deploy();
+  await admin.waitForDeployment();
+  const proxy = await TransparentUpgradableProxy.deploy(
+    await impl.getAddress(),
+    await admin.getAddress(),
+    Greeter.interface.encodeFunctionData('initialize', ['Hello, Hardhat!']),
+  );
+  const greeter = await upgrades.forceImport(await proxy.getAddress(), Greeter);
+
+  // Deploy a second proxy with same admin, and import it
+  const proxy2 = await TransparentUpgradableProxy.deploy(
+    await impl.getAddress(),
+    await admin.getAddress(),
+    Greeter.interface.encodeFunctionData('initialize', ['Hello, Hardhat!']),
+  );
+  await upgrades.forceImport(await proxy2.getAddress(), Greeter);
+
+  await upgrades.admin.transferProxyAdminOwnership(await greeter.getAddress(), testAddress);
+  t.is(await admin.owner(), testAddress);
+});


### PR DESCRIPTION
Fixes issue reported in https://forum.openzeppelin.com/t/openzeppelin-hardhat-upgrades-s-admin-transferproxyadminownership-always-logs-success/39686

transferProxyAdminOwnership previously iterated through all proxies from the manifest file, and displayed either:
```
console.log(SUCCESS_CHECK + `${address} (${kind}) proxy ownership transferred through proxy admin`);
```
or
```
console.log(FAILURE_CROSS + `${address} (${kind}) proxy ownership not affected by proxy admin`);
```
to help the user see which proxies were using that proxy admin.  This was useful with proxies from OpenZeppelin Contracts 4.x because the plugin only tracked 1 proxy admin and all transparent proxies were using the same admin.

But with OpenZeppelin Contracts 5.x where each proxy deploys its own proxy admin, this is less relevant.  The proxy address is a parameter of the `transferProxyAdminOwnership` function, and this function affects its proxy admin which is typically for only that specific proxy.

Therefore, this PR just removes this logging altogether.