### PR TITLE
Update devDependencies for OpenZeppelin Contracts 5.0.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@ava/typescript": "^4.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
-    "@openzeppelin/contracts": "5.0.1",
+    "@openzeppelin/contracts": "5.0.2",
     "@openzeppelin/upgrades-core-legacy": "npm:@openzeppelin/upgrades-core@1.31.3",
     "@types/cbor": "^5.0.0",
     "@types/debug": "^4.1.5",

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -23,8 +23,8 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-verify": "^2.0.0",
-    "@openzeppelin/contracts": "5.0.1",
-    "@openzeppelin/contracts-upgradeable": "5.0.1",
+    "@openzeppelin/contracts": "5.0.2",
+    "@openzeppelin/contracts-upgradeable": "5.0.2",
     "@types/mocha": "^7.0.2",
     "ava": "^6.0.0",
     "fgbg": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,15 +1006,15 @@
     "@nomicfoundation/solidity-analyzer-win32-ia32-msvc" "0.1.1"
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.1.1"
 
-"@openzeppelin/contracts-upgradeable@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.0.1.tgz#ebc163cbed2de6b8b69bff628261d18deb912a81"
-  integrity sha512-MvaLoPnVcoZr/qqZP+4cl9piuR4gg0iIGgxVSZ/AL1iId3M6IdEHzz9Naw5Lirl4KKBI6ciTVnX07yL4dOMIJg==
+"@openzeppelin/contracts-upgradeable@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.0.2.tgz#3e5321a2ecdd0b206064356798c21225b6ec7105"
+  integrity sha512-0MmkHSHiW2NRFiT9/r5Lu4eJq5UJ4/tzlOgYXNAIj/ONkQTVnz22pLxDvp4C4uZ9he7ZFvGn3Driptn1/iU7tQ==
 
-"@openzeppelin/contracts@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.1.tgz#93da90fc209a0a4ff09c1deb037fbb35e4020890"
-  integrity sha512-yQJaT5HDp9hYOOp4jTYxMsR02gdFZFXhewX5HW9Jo4fsqSVqqyIO/xTHdWDaKX5a3pv1txmf076Lziz+sO7L1w==
+"@openzeppelin/contracts@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.2.tgz#b1d03075e49290d06570b2fd42154d76c2a5d210"
+  integrity sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA==
 
 "@openzeppelin/defender-admin-client@^1.52.0":
   version "1.54.1"


### PR DESCRIPTION
Updating devDependencies for OpenZeppelin Contracts 5.0.2 as a best practice, as these are used for compilation and testing.  This does not impact users as there are no changes to proxy-related contracts, so source code and bytecode of the proxies remain the same and a release is not necessary at this point.

Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/985
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/984
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/983
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/981
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/980
Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/979