### PR TITLE
Update Foundry Upgrades submodule to v0.2.1

### DIFF
--- a/docs/modules/ROOT/pages/foundry/pages/foundry-defender.adoc
+++ b/docs/modules/ROOT/pages/foundry/pages/foundry-defender.adoc
@@ -12,19 +12,20 @@ See xref:foundry-upgrades#installion[Using with Foundry - Installation].
 == Prerequisites
 1. Install https://nodejs.org/[Node.js].
 
-2. Configure your `foundry.toml` to include build info and storage layout:
+2. Configure your `foundry.toml` to enable ffi, ast, build info and storage layout:
 [source,toml]
 ----
 [profile.default]
+ffi = true
+ast = true
 build_info = true
 extra_output = ["storageLayout"]
 ----
 
 NOTE: Metadata must also be included in the compiler output, which it is by default.  
 
-3. Include `--ffi` in your `forge script` or `forge test` command.  
-
-4. Set the following environment variables in your `.env` file at your project root, using your Team API key and secret from OpenZeppelin Defender:
+[start=3]
+3. Set the following environment variables in your `.env` file at your project root, using your Team API key and secret from OpenZeppelin Defender:
 [source]
 ----
 DEFENDER_KEY=<Your API key>

--- a/docs/modules/ROOT/pages/foundry/pages/foundry-upgrades.adoc
+++ b/docs/modules/ROOT/pages/foundry/pages/foundry-upgrades.adoc
@@ -41,19 +41,20 @@ If you want to be able to run upgrade safety checks, the following are needed:
 
 1. Install https://nodejs.org/[Node.js].
 
-2. Configure your `foundry.toml` to include build info and storage layout:
+2. Configure your `foundry.toml` to enable ffi, ast, build info and storage layout:
 [source,toml]
 ----
 [profile.default]
+ffi = true
+ast = true
 build_info = true
 extra_output = ["storageLayout"]
 ----
 
+[start=3]
 3. If you are upgrading your contract from a previous version, add the `@custom:oz-upgrades-from <reference>` annotation to the new version of your contract according to https://docs.openzeppelin.com/upgrades-plugins/1.x/api-core#define-reference-contracts[Define Reference Contracts] or specify the `referenceContract` option when calling the library's functions.
 
-4. Run `forge clean` before running your Foundry script or tests.
-
-5. Include `--ffi` in your `forge script` or `forge test` command.
+4. Run `forge clean` before running your Foundry script or tests, or include the `--force` option when running `forge script` or `forge test`.
 
 If you do not want to run upgrade safety checks, you can skip the above steps and use the `unsafeSkipAllChecks` option when calling the library's functions. Note that this is a dangerous option meant to be used as a last resort.
 


### PR DESCRIPTION
Update Foundry Upgrades submodule to https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/releases/tag/v0.2.1