### PR TITLE
Defender: Fix proxy deployments when using `constructorArgs`

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.1 (2024-05-29)
 
-- Defender: Fix proxy deployments when using `constructorArgs` option.
+- Defender: Fix proxy deployments when using `constructorArgs` option. ([#1029](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1029))
 
 ## 3.1.0 (2024-04-22)
 

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.1.1 (2024-05-29)
+## 3.1.1 (2024-05-30)
 
 - Defender: Fix proxy deployments when using `constructorArgs` option. ([#1029](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1029))
 

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1 (2024-05-29)
+
+- Defender: Fix proxy deployments when using `constructorArgs` option.
+
 ## 3.1.0 (2024-04-22)
 
 - Defender: Fix handling of license types for block explorer verification, support `licenseType` and `skipLicenseType` options. ([#1013](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1013))

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.1.1 (2024-05-31)
+## 3.1.1 (2024-06-03)
 
 - Defender: Fix proxy deployments when using `constructorArgs` option, support arbitrary constructor arguments. ([#1029](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1029))
 

--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 3.1.1 (2024-05-30)
+## 3.1.1 (2024-05-31)
 
-- Defender: Fix proxy deployments when using `constructorArgs` option. ([#1029](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1029))
+- Defender: Fix proxy deployments when using `constructorArgs` option, support arbitrary constructor arguments. ([#1029](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1029))
 
 ## 3.1.0 (2024-04-22)
 

--- a/packages/plugin-hardhat/contracts/Constructor.sol
+++ b/packages/plugin-hardhat/contracts/Constructor.sol
@@ -10,3 +10,12 @@ contract WithConstructor {
         value = args;
     }
 }
+
+contract WithConstructorArray {
+    uint256[] public x;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(uint256[] memory args) {
+        x = args;
+    }
+}

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/hardhat-upgrades",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/plugin-hardhat",
   "license": "MIT",

--- a/packages/plugin-hardhat/src/defender/deploy.ts
+++ b/packages/plugin-hardhat/src/defender/deploy.ts
@@ -67,7 +67,6 @@ export async function defenderDeploy(
   // The ones in the options are for implementation contracts only, while this function
   // can be used to deploy proxies as well.
   const contractInfo = await getContractInfo(hre, factory, { ...opts, constructorArgs: args });
-  const constructorBytecode = contractInfo.constructorBytecode;
   const network = await getNetwork(hre);
   debug(`Network ${network}`);
 
@@ -107,7 +106,7 @@ export async function defenderDeploy(
     network: network,
     artifactPayload: JSON.stringify(contractInfo.buildInfo),
     licenseType: licenseType,
-    constructorBytecode,
+    constructorBytecode: contractInfo.constructorBytecode,
     verifySourceCode: verifySourceCode,
     relayerId: opts.relayerId,
     salt: opts.salt,

--- a/packages/plugin-hardhat/src/defender/deploy.ts
+++ b/packages/plugin-hardhat/src/defender/deploy.ts
@@ -66,6 +66,7 @@ export async function defenderDeploy(
   // The ones in the options are for implementation contracts only, while this function
   // can be used to deploy proxies as well.
   const contractInfo = await getContractInfo(hre, factory, { ...opts, constructorArgs: args });
+  const constructorBytecode = factory.interface.encodeDeploy(args);
   const network = await getNetwork(hre);
   debug(`Network ${network}`);
 
@@ -105,7 +106,7 @@ export async function defenderDeploy(
     network: network,
     artifactPayload: JSON.stringify(contractInfo.buildInfo),
     licenseType: licenseType,
-    constructorInputs: args as any[],
+    constructorBytecode,
     verifySourceCode: verifySourceCode,
     relayerId: opts.relayerId,
     salt: opts.salt,

--- a/packages/plugin-hardhat/src/defender/deploy.ts
+++ b/packages/plugin-hardhat/src/defender/deploy.ts
@@ -65,8 +65,7 @@ export async function defenderDeploy(
   // Override constructor arguments in options with the ones passed as arguments to this function.
   // The ones in the options are for implementation contracts only, while this function
   // can be used to deploy proxies as well.
-  const overrideConstructorArgs = [...args] as (string | number | boolean)[];
-  const contractInfo = await getContractInfo(hre, factory, { ...opts, constructorArgs: overrideConstructorArgs });
+  const contractInfo = await getContractInfo(hre, factory, { ...opts, constructorArgs: args });
   const network = await getNetwork(hre);
   debug(`Network ${network}`);
 
@@ -106,7 +105,7 @@ export async function defenderDeploy(
     network: network,
     artifactPayload: JSON.stringify(contractInfo.buildInfo),
     licenseType: licenseType,
-    constructorInputs: overrideConstructorArgs,
+    constructorInputs: args as (string | number | boolean)[],
     verifySourceCode: verifySourceCode,
     relayerId: opts.relayerId,
     salt: opts.salt,

--- a/packages/plugin-hardhat/src/defender/deploy.ts
+++ b/packages/plugin-hardhat/src/defender/deploy.ts
@@ -62,8 +62,11 @@ export async function defenderDeploy(
 ): Promise<Required<Deployment & RemoteDeploymentId> & DeployTransaction> {
   const client = getDeployClient(hre);
 
-  const constructorArgs = [...args] as (string | number | boolean)[];
-  const contractInfo = await getContractInfo(hre, factory, { constructorArgs, ...opts });
+  // Override constructor arguments in options with the ones passed as arguments to this function.
+  // The ones in the options are for implementation contracts only, while this function
+  // can be used to deploy proxies as well.
+  const overrideConstructorArgs = [...args] as (string | number | boolean)[];
+  const contractInfo = await getContractInfo(hre, factory, { ...opts, constructorArgs: overrideConstructorArgs });
   const network = await getNetwork(hre);
   debug(`Network ${network}`);
 
@@ -103,7 +106,7 @@ export async function defenderDeploy(
     network: network,
     artifactPayload: JSON.stringify(contractInfo.buildInfo),
     licenseType: licenseType,
-    constructorInputs: constructorArgs,
+    constructorInputs: overrideConstructorArgs,
     verifySourceCode: verifySourceCode,
     relayerId: opts.relayerId,
     salt: opts.salt,

--- a/packages/plugin-hardhat/src/defender/deploy.ts
+++ b/packages/plugin-hardhat/src/defender/deploy.ts
@@ -105,7 +105,7 @@ export async function defenderDeploy(
     network: network,
     artifactPayload: JSON.stringify(contractInfo.buildInfo),
     licenseType: licenseType,
-    constructorInputs: args as (string | number | boolean)[],
+    constructorInputs: args as any[],
     verifySourceCode: verifySourceCode,
     relayerId: opts.relayerId,
     salt: opts.salt,

--- a/packages/plugin-hardhat/test/defender-deploy.js
+++ b/packages/plugin-hardhat/test/defender-deploy.js
@@ -505,6 +505,58 @@ test('calls defender deploy with ERC1967Proxy', async t => {
   });
 });
 
+test('calls defender deploy with ERC1967Proxy - ignores constructorArgs', async t => {
+  const { spy, deploy, fakeHre, fakeChainId } = t.context;
+
+  const contractPath = '@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol';
+  const contractName = 'ERC1967Proxy';
+  const factory = await getProxyFactory(hre);
+
+  const result = await deploy.defenderDeploy(fakeHre, factory, { constructorArgs: ['foo'] }, LOGIC_ADDRESS, DATA);
+  assertResult(t, result);
+
+  sinon.assert.calledWithExactly(spy, {
+    contractName: contractName,
+    contractPath: contractPath,
+    network: fakeChainId,
+    artifactPayload: JSON.stringify(artifactsBuildInfo),
+    licenseType: 'MIT',
+    constructorInputs: [LOGIC_ADDRESS, DATA],
+    verifySourceCode: true,
+    relayerId: undefined,
+    salt: undefined,
+    createFactoryAddress: undefined,
+    txOverrides: undefined,
+    libraries: undefined,
+  });
+});
+
+test('calls defender deploy with ERC1967Proxy - ignores empty constructorArgs', async t => {
+  const { spy, deploy, fakeHre, fakeChainId } = t.context;
+
+  const contractPath = '@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol';
+  const contractName = 'ERC1967Proxy';
+  const factory = await getProxyFactory(hre);
+
+  const result = await deploy.defenderDeploy(fakeHre, factory, { constructorArgs: [] }, LOGIC_ADDRESS, DATA);
+  assertResult(t, result);
+
+  sinon.assert.calledWithExactly(spy, {
+    contractName: contractName,
+    contractPath: contractPath,
+    network: fakeChainId,
+    artifactPayload: JSON.stringify(artifactsBuildInfo),
+    licenseType: 'MIT',
+    constructorInputs: [LOGIC_ADDRESS, DATA],
+    verifySourceCode: true,
+    relayerId: undefined,
+    salt: undefined,
+    createFactoryAddress: undefined,
+    txOverrides: undefined,
+    libraries: undefined,
+  });
+});
+
 test('calls defender deploy with BeaconProxy', async t => {
   const { spy, deploy, fakeHre, fakeChainId } = t.context;
 

--- a/packages/plugin-hardhat/test/defender-deploy.js
+++ b/packages/plugin-hardhat/test/defender-deploy.js
@@ -12,6 +12,8 @@ const {
 } = require('../dist/utils/factories');
 const artifactsBuildInfo = require('@openzeppelin/upgrades-core/artifacts/build-info-v5.json');
 
+const { AbiCoder } = require('ethers');
+
 const TX_HASH = '0x1';
 const DEPLOYMENT_ID = 'abc';
 const ADDRESS = '0x2';
@@ -100,7 +102,7 @@ test('calls defender deploy', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -128,7 +130,7 @@ test('calls defender deploy with relayerId', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: RELAYER_ID,
     salt: undefined,
@@ -156,7 +158,7 @@ test('calls defender deploy with salt', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: SALT,
@@ -184,7 +186,7 @@ test('calls defender deploy with createFactoryAddress', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -212,7 +214,7 @@ test('calls defender deploy with license', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: 'MIT',
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -242,7 +244,7 @@ test('calls defender deploy - licenseType', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: 'My License Type',
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -272,7 +274,7 @@ test('calls defender deploy - verifySourceCode false', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: false,
     relayerId: undefined,
     salt: undefined,
@@ -302,7 +304,7 @@ test('calls defender deploy - skipLicenseType', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -383,7 +385,7 @@ test('calls defender deploy - no contract license', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -411,7 +413,7 @@ test('calls defender deploy - unlicensed', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: 'None',
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -439,7 +441,35 @@ test('calls defender deploy with constructor args', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: 'MIT',
-    constructorInputs: [10],
+    constructorBytecode: AbiCoder.defaultAbiCoder().encode(['uint256'], [10]),
+    verifySourceCode: true,
+    relayerId: undefined,
+    salt: undefined,
+    createFactoryAddress: undefined,
+    txOverrides: undefined,
+    libraries: undefined,
+  });
+
+  assertResult(t, result);
+});
+
+test('calls defender deploy with constructor args with array', async t => {
+  const { spy, deploy, fakeHre, fakeChainId } = t.context;
+
+  const contractPath = 'contracts/Constructor.sol';
+  const contractName = 'WithConstructorArray';
+
+  const factory = await ethers.getContractFactory(contractName);
+  const result = await deploy.defenderDeploy(fakeHre, factory, {}, [1, 2, 3]);
+
+  const buildInfo = await hre.artifacts.getBuildInfo(`${contractPath}:${contractName}`);
+  sinon.assert.calledWithExactly(spy, {
+    contractName: contractName,
+    contractPath: contractPath,
+    network: fakeChainId,
+    artifactPayload: JSON.stringify(buildInfo),
+    licenseType: 'MIT',
+    constructorBytecode: AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1, 2, 3]]),
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -467,7 +497,7 @@ test('calls defender deploy with verify false', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: false,
     relayerId: undefined,
     salt: undefined,
@@ -495,7 +525,7 @@ test('calls defender deploy with ERC1967Proxy', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(artifactsBuildInfo),
     licenseType: 'MIT',
-    constructorInputs: [LOGIC_ADDRESS, DATA],
+    constructorBytecode: AbiCoder.defaultAbiCoder().encode(['address', 'bytes'], [LOGIC_ADDRESS, DATA]),
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -521,7 +551,7 @@ test('calls defender deploy with ERC1967Proxy - ignores constructorArgs', async 
     network: fakeChainId,
     artifactPayload: JSON.stringify(artifactsBuildInfo),
     licenseType: 'MIT',
-    constructorInputs: [LOGIC_ADDRESS, DATA],
+    constructorBytecode: AbiCoder.defaultAbiCoder().encode(['address', 'bytes'], [LOGIC_ADDRESS, DATA]),
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -547,7 +577,7 @@ test('calls defender deploy with ERC1967Proxy - ignores empty constructorArgs', 
     network: fakeChainId,
     artifactPayload: JSON.stringify(artifactsBuildInfo),
     licenseType: 'MIT',
-    constructorInputs: [LOGIC_ADDRESS, DATA],
+    constructorBytecode: AbiCoder.defaultAbiCoder().encode(['address', 'bytes'], [LOGIC_ADDRESS, DATA]),
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -573,7 +603,7 @@ test('calls defender deploy with BeaconProxy', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(artifactsBuildInfo),
     licenseType: 'MIT',
-    constructorInputs: [LOGIC_ADDRESS, DATA],
+    constructorBytecode: AbiCoder.defaultAbiCoder().encode(['address', 'bytes'], [LOGIC_ADDRESS, DATA]),
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -599,7 +629,10 @@ test('calls defender deploy with TransparentUpgradeableProxy', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(artifactsBuildInfo),
     licenseType: 'MIT',
-    constructorInputs: [LOGIC_ADDRESS, INITIAL_OWNER_ADDRESS, DATA],
+    constructorBytecode: AbiCoder.defaultAbiCoder().encode(
+      ['address', 'address', 'bytes'],
+      [LOGIC_ADDRESS, INITIAL_OWNER_ADDRESS, DATA],
+    ),
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -625,7 +658,7 @@ test('calls defender deploy with txOverrides.gasLimit', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -658,7 +691,7 @@ test('calls defender deploy with txOverrides.gasPrice', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -693,7 +726,7 @@ test('calls defender deploy with txOverrides.maxFeePerGas and txOverrides.maxPri
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -730,7 +763,7 @@ test('calls defender deploy with external library', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,
@@ -765,7 +798,7 @@ test('calls defender deploy with multiple external libraries', async t => {
     network: fakeChainId,
     artifactPayload: JSON.stringify(buildInfo),
     licenseType: undefined,
-    constructorInputs: [],
+    constructorBytecode: '0x',
     verifySourceCode: true,
     relayerId: undefined,
     salt: undefined,


### PR DESCRIPTION
Fixes #1026 

Defender deployments are run using the internal `defenderDeploy` function, which takes constructor arguments directly using the `...args` argument.  This function can deploy proxies or implementations.

However, users may provide `constructorArgs` to specify constructor args for the implementation contract.  These should not apply to the proxy deployment itself.

Therefore, the internal `defenderDeploy` function should use its `args` to override the ones in `opts.constructorArgs`, so that the correct arguments are used for each specific deployment.