### PR TITLE
Skip Slang parser for solc versions that it does not support

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix Hardhat compile error when using solc version `0.8.27`. ([#1075](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1075))
+
 ## 1.37.0 (2024-08-28)
 
 - **Breaking change**: CLI: Disallow self-references for storage layout validations. ([#1067](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1067))

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.37.1 (2024-09-09)
 
 - Fix Hardhat compile error when using solc version `0.8.27`. ([#1075](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1075))
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/upgrades-core",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/core",
   "license": "MIT",

--- a/packages/core/src/utils/make-namespaced.ts
+++ b/packages/core/src/utils/make-namespaced.ts
@@ -164,7 +164,7 @@ export function makeNamespacedInput(input: SolcInput, output: SolcOutput, solcVe
 }
 
 /**
- * If Slang is supported for the current platform and we have the compiler version available,
+ * If we have the compiler version available and Slang is supported for the current platform and compiler version,
  * use Slang to parse and remove all NatSpec comments that do not precede a struct definition and return the modified content.
  *
  * Otherwise, return the original content.
@@ -172,7 +172,7 @@ export function makeNamespacedInput(input: SolcInput, output: SolcOutput, solcVe
 function tryRemoveNonStructNatSpec(origContent: string, solcVersion: string | undefined): string {
   const natSpecRemovals: Modification[] = [];
 
-  if (solcVersion !== undefined && tryRequire('@nomicfoundation/slang')) {
+  if (solcVersion !== undefined && slangSupportsPlatformAndVersion(solcVersion)) {
     /* eslint-disable @typescript-eslint/no-var-requires */
     const { Language } = require('@nomicfoundation/slang/language');
     const { NonterminalKind, TerminalKind } = require('@nomicfoundation/slang/kinds');
@@ -215,6 +215,21 @@ function tryRequire(id: string) {
     // do nothing
   }
   return false;
+}
+
+/**
+ * Whether Slang is supported for the current platform and the given compiler version.
+ */
+function slangSupportsPlatformAndVersion(solcVersion: string): boolean {
+  if (tryRequire('@nomicfoundation/slang')) {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const { Language } = require('@nomicfoundation/slang/language');
+    /* eslint-enable @typescript-eslint/no-var-requires */
+
+    return Language.supportedVersions().includes(solcVersion);
+  } else {
+    return false;
+  }
 }
 
 interface Modification {

--- a/packages/core/src/utils/make-namespaced.ts
+++ b/packages/core/src/utils/make-namespaced.ts
@@ -172,7 +172,7 @@ export function makeNamespacedInput(input: SolcInput, output: SolcOutput, solcVe
 function tryRemoveNonStructNatSpec(origContent: string, solcVersion: string | undefined): string {
   const natSpecRemovals: Modification[] = [];
 
-  if (solcVersion !== undefined && slangSupportsPlatformAndVersion(solcVersion)) {
+  if (solcVersion !== undefined && tryRequire('@nomicfoundation/slang') && slangSupportsVersion(solcVersion)) {
     /* eslint-disable @typescript-eslint/no-var-requires */
     const { Language } = require('@nomicfoundation/slang/language');
     const { NonterminalKind, TerminalKind } = require('@nomicfoundation/slang/kinds');
@@ -217,19 +217,12 @@ function tryRequire(id: string) {
   return false;
 }
 
-/**
- * Whether Slang is supported for the current platform and the given compiler version.
- */
-function slangSupportsPlatformAndVersion(solcVersion: string): boolean {
-  if (tryRequire('@nomicfoundation/slang')) {
-    /* eslint-disable @typescript-eslint/no-var-requires */
-    const { Language } = require('@nomicfoundation/slang/language');
-    /* eslint-enable @typescript-eslint/no-var-requires */
+function slangSupportsVersion(solcVersion: string): boolean {
+  /* eslint-disable @typescript-eslint/no-var-requires */
+  const { Language } = require('@nomicfoundation/slang/language');
+  /* eslint-enable @typescript-eslint/no-var-requires */
 
-    return Language.supportedVersions().includes(solcVersion);
-  } else {
-    return false;
-  }
+  return Language.supportedVersions().includes(solcVersion);
 }
 
 interface Modification {


### PR DESCRIPTION
Fixes #1074 

Slang supports specific Solidity versions, currently up to `0.8.26`.  If the user's project is using `0.8.27`, this causes error `Unsupported language version '0.8.27'`

As a longer-term solution, we may want to try falling back to the most recent version supported by Slang for parsing, but we should evaluate the implications of that further.

For now, we just skip the Slang code path (i.e. we won't remove non-struct NatSpec) for solc versions not supported by Slang.