### PR TITLE
Remove version from Upgrades Plugins docs url

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: upgrades-plugins
 title: Upgrades Plugins
-version: 1.x
+version: ~
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
+++ b/docs/modules/ROOT/pages/api-hardhat-upgrades.adoc
@@ -257,7 +257,7 @@ Forces the import of an existing proxy, beacon, or implementation contract deplo
 
 CAUTION: When importing a proxy or beacon, the `deployedImpl` argument must be the contract factory of the *current* implementation contract version that is being used, not the version that you are planning to upgrade to.
 
-Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons and implementation contracts.
+Use this function to recreate a lost https://docs.openzeppelin.com/upgrades-plugins/network-files[network file] by importing previous deployments, or to register proxies or beacons for upgrading even if they were not originally deployed by this plugin. Supported for UUPS, Transparent, and Beacon proxies, as well as beacons and implementation contracts.
 
 *Parameters:*
 


### PR DESCRIPTION
Upgrades Plugins docs are for the latest versions of the plugins and includes information about previous versions where appropriate.

Its current link shows https://docs.openzeppelin.com/upgrades-plugins/1.x/ but the `1.x` is irrelevant.  This PR changes it to have no version according to https://docs.antora.org/antora/latest/component-with-no-version/

Afterwards, we can add a redirect in https://github.com/OpenZeppelin/docs.openzeppelin.com/pull/423 in case anyone is still using the old link.