### PR TITLE
Fix `ASTDereferencerError` when validating initializers

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.42.1 (2025-01-24)
+
+- Fix `ASTDereferencerError` when validating initializers.
+
 ## 1.42.0 (2025-01-23)
 
 - Update dependencies. ([#1096](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1096))

--- a/packages/core/contracts/test/ValidationsInitializer.sol
+++ b/packages/core/contracts/test/ValidationsInitializer.sol
@@ -263,6 +263,21 @@ contract InitializationOrder_UnsafeAllowDuplicate_But_WrongOrder is A, B, C, Par
   }
 }
 
+contract WithRequire_Ok is Parent__OnlyInitializingModifier {
+  uint y;
+  function initialize(bool foo) initializer public {
+    require(foo, "foo should be true");
+    __Parent_init();
+  }
+}
+
+contract WithRequire_Bad is Parent__OnlyInitializingModifier {
+  uint y;
+  function initialize(bool foo) initializer public {
+    require(foo, "foo should be true");
+  }
+}
+
 // ==== Initializer visibility ====
 
 abstract contract Parent_Private is Initializable {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/upgrades-core",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/core",
   "license": "MIT",

--- a/packages/core/src/validate-initializers.test.ts
+++ b/packages/core/src/validate-initializers.test.ts
@@ -124,6 +124,12 @@ testAccepts('InitializationOrder_Duplicate_UnsafeAllow_Call', 'transparent');
 testOverride('InitializationOrder_Duplicate_Bad', 'transparent', { unsafeAllow: ['duplicate-initializer-call'] });
 testAccepts('InitializationOrder_UnsafeAllowDuplicate_But_WrongOrder', 'transparent'); // warn 'Expected initializers to be called for parent contracts in the following order: A, B, C'
 
+testAccepts('WithRequire_Ok', 'transparent');
+testRejects('WithRequire_Bad', 'transparent', {
+  contains: ['Missing initializer calls for one or more parent contracts: `Parent__OnlyInitializingModifier`'],
+  count: 1,
+});
+
 testAccepts('Child_Of_Private_Ok', 'transparent');
 testAccepts('Child_Of_Public_Ok', 'transparent');
 testRejects('Child_Of_Public_MissingCall_Bad', 'transparent', {

--- a/packages/core/src/validate/run/initializer.ts
+++ b/packages/core/src/validate/run/initializer.ts
@@ -124,7 +124,7 @@ function getParentsNotInitializedByOtherParents(
           (fnCall.expression.nodeType === 'Identifier' || fnCall.expression.nodeType === 'MemberAccess')
         ) {
           const referencedFn = fnCall.expression.referencedDeclaration;
-          if (referencedFn) {
+          if (referencedFn && referencedFn > 0) {
             const earlierParents = remainingParents.slice(0, remainingParents.indexOf(parent));
             const callsEarlierParentInitializer = earlierParents.find(base =>
               parentNameToInitializersMap.get(base)!.some(init => init.id === referencedFn),
@@ -177,7 +177,7 @@ function* getInitializerCallExceptions(
     ) {
       let recursiveFunctionIds: number[] = [];
       const referencedFn = fnCall.expression.referencedDeclaration;
-      if (referencedFn) {
+      if (referencedFn && referencedFn > 0) {
         recursiveFunctionIds = getRecursiveFunctionIds(referencedFn, deref);
       }
 
@@ -284,7 +284,7 @@ function getRecursiveFunctionIds(referencedFn: number, deref: ASTDereferencer, v
       (fnCall.expression.nodeType === 'Identifier' || fnCall.expression.nodeType === 'MemberAccess')
     ) {
       const referencedId = fnCall.expression.referencedDeclaration;
-      if (referencedId) {
+      if (referencedId && referencedId > 0) {
         result.push(...getRecursiveFunctionIds(referencedId, deref, visited));
       }
     }


### PR DESCRIPTION
Referenced AST ids can be negative if they refer to nodes that are not in the solc output.  For example, `require` statements seem to have referenced AST ids of `-18`.

When validating initializers, we should ignore negative AST id references.

Fixes #1116 