### PR TITLE
Fix validateUpgradeSafety to handle undefined ast

### DIFF
--- a/packages/core/src/cli/validate/validate-upgrade-safety.test.ts
+++ b/packages/core/src/cli/validate/validate-upgrade-safety.test.ts
@@ -109,3 +109,17 @@ test('findSpecifiedContracts - requireReference option without contract', async 
     );
   }
 });
+
+test('validate upgrade safety with undefined ast', async t => {
+  const buildInfo = await artifacts.getBuildInfo(`contracts/test/cli/Validate.sol:Safe`);
+
+  // Modify buildInfo to have undefined ast
+  buildInfo.output.sources['contracts/test/cli/Validate.sol'].ast = undefined;
+
+  await fs.mkdir('validate-upgrade-safety-undefined-ast');
+  await fs.writeFile('validate-upgrade-safety-undefined-ast/1.json', JSON.stringify(buildInfo));
+
+  const report = await validateUpgradeSafety('validate-upgrade-safety-undefined-ast');
+  t.false(report.ok);
+  t.snapshot(report.explain());
+});

--- a/packages/core/src/validate/run.ts
+++ b/packages/core/src/validate/run.ts
@@ -302,6 +302,13 @@ function checkNamespaceSolidityVersion(source: string, solcVersion?: string, sol
 }
 
 function checkNamespacesOutsideContract(source: string, solcOutput: SolcOutput, decodeSrc: SrcDecoder) {
+  if (solcOutput.sources[source].ast === undefined) {
+    logWarning(`AST is undefined for source ${source}`, [
+      'Skipping namespace checks for this source.',
+    ]);
+    return;
+  }
+
   for (const node of solcOutput.sources[source].ast.nodes) {
     if (isNodeType('StructDefinition', node)) {
       // Namespace struct outside contract - error


### PR DESCRIPTION
Fixes #1126

Handle undefined `ast` in `validateUpgradeSafety`.

* Add a check in `checkNamespacesOutsideContract` to verify if `solcOutput.sources[source].ast` is undefined before accessing its `nodes` property.
* Log a warning and skip the check if `solcOutput.sources[source].ast` is undefined.
* Add a test case in `validate-upgrade-safety.test.ts` to verify the behavior when `solcOutput.sources[source].ast` is undefined.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OpenZeppelin/openzeppelin-upgrades/pull/1127?shareId=b0222ea9-0ae9-433f-ac12-f9c372123790).