### PR TITLE
Create action workflow to get latest docs changes from openzeppelin-foundry-upgrades

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,11 +100,18 @@ jobs:
         git push origin $BRANCH_NAME
 
     - name: Create a Pull Request for docs changes
+      id: create_pull_request
       if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh pr create --title "[CI] Update Foundry Upgrades plugin docs" \
-                   --body "[CI] This PR updates the docs for the Foundry Upgrades plugin" \
-                   --base main \
-                   --head $BRANCH_NAME
+                 --body "[CI] This PR updates the docs for the Foundry Upgrades plugin" \
+                 --base master \
+                 --head $BRANCH_NAME || echo "PR creation failed"
+
+    - name: Clean up branch if PR creation fails
+      if: steps.create_pull_request.outcome == 'failure'
+      run: |
+        git push origin --delete $BRANCH_NAME
+               

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
   pull_request: {}
   repository_dispatch:
-    types: [custom-event]
+    types: [update-foundry-submodule]
 
 concurrency:
   group: checks-${{ github.ref }}
@@ -62,9 +62,32 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true 
 
     - name: Set up environment
       uses: ./.github/actions/setup
 
-    - name: Run triggered job
-      run: echo "Running tests from ${{ github.event.client_payload }}"
+    - name: Update submodule
+      run: |
+        cd submodules/openzeppelin-foundry-upgrades
+        git pull origin main
+
+    - name: Regenerate docs
+      run: yarn docs
+
+    - name: Check for changes in docs/
+      id: check_changes
+      run: |
+        [ -n "$(git diff --name-only HEAD -- docs/)" ] && echo "SHOULD_COMMIT_DOC_UPDATE=true" >> $GITHUB_ENV
+
+    - name: Commit and push changes
+      if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
+      run: |
+        git add docs/
+        git commit -m "[CI] Update Foundry Upgrades plugin docs"
+
+    - name: Create a Pull Request for docs changes
+      if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
+      run: |
+        gh pr create --title "[CI] Update Foundry Upgrades plugin docs" --body "[CI] This PR updates the docs for the Foundry Upgrades plugin" --base main --head $GITHUB_REF

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master]
   pull_request: {}
+  repository_dispatch:
+    types: [custom-event]
 
 concurrency:
   group: checks-${{ github.ref }}
@@ -53,3 +55,16 @@ jobs:
       run: yarn coverage
 
     - uses: codecov/codecov-action@v5
+
+  update-foundry-submodule:
+    if: github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up environment
+      uses: ./.github/actions/setup
+
+    - name: Run triggered job
+      run: echo "Running tests from ${{ github.event.client_payload }}"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -82,6 +82,12 @@ jobs:
       run: |
         [ -n "$(git diff --name-only HEAD -- docs/modules/ROOT/pages/foundry/)" ] && echo "SHOULD_COMMIT_DOC_UPDATE=true" >> $GITHUB_ENV || true
 
+    - name: Set Git identity
+      if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
+      run: |
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "github-actions@github.com"
+      
     - name: Commit and push changes
       if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,8 +86,8 @@ jobs:
     - name: Set Git identity
       if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
       run: |
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "github-actions@github.com"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
     - name: Create new branch, commit and push changes
       if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,17 +75,17 @@ jobs:
         git reset --hard origin/main
 
     - name: Regenerate docs
-      run: yarn docs
+      run: yarn docs:foundry:ci
 
-    - name: Check for changes in docs/
+    - name: Check for changes in docs/modules/ROOT/pages/foundry/
       id: check_changes
       run: |
-        [ -n "$(git diff --name-only HEAD -- docs/)" ] && echo "SHOULD_COMMIT_DOC_UPDATE=true" >> $GITHUB_ENV || true
+        [ -n "$(git diff --name-only HEAD -- docs/modules/ROOT/pages/foundry/)" ] && echo "SHOULD_COMMIT_DOC_UPDATE=true" >> $GITHUB_ENV || true
 
     - name: Commit and push changes
       if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
       run: |
-        git add docs/
+        git add docs/modules/ROOT/pages/foundry/
         git commit -m "[CI] Update Foundry Upgrades plugin docs"
 
     - name: Create a Pull Request for docs changes

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
   pull_request: {}
   repository_dispatch:
-    types: [update-foundry-submodule]
+    types: [update-foundry-submodule-docs]
 
 concurrency:
   group: checks-${{ github.ref }}
@@ -56,7 +56,7 @@ jobs:
 
     - uses: codecov/codecov-action@v5
 
-  update-foundry-submodule:
+  update-foundry-submodule-docs:
     if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
 
@@ -71,7 +71,8 @@ jobs:
     - name: Update submodule
       run: |
         cd submodules/openzeppelin-foundry-upgrades
-        git pull origin main
+        git fetch origin main
+        git reset --hard origin/main
 
     - name: Regenerate docs
       run: yarn docs

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,6 +64,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true 
+        fetch-depth: 0
 
     - name: Set up environment
       uses: ./.github/actions/setup
@@ -87,14 +88,23 @@ jobs:
       run: |
         git config --global user.name "GitHub Actions"
         git config --global user.email "github-actions@github.com"
-      
-    - name: Commit and push changes
+
+    - name: Create new branch, commit and push changes
       if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
       run: |
+        BRANCH_NAME="ci/update-foundry-docs-$(date +'%Y-%m-%d-%H%M%S')-${{ github.run_id }}"
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+        git checkout -b $BRANCH_NAME
         git add docs/modules/ROOT/pages/foundry/
         git commit -m "[CI] Update Foundry Upgrades plugin docs"
+        git push origin $BRANCH_NAME
 
     - name: Create a Pull Request for docs changes
       if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh pr create --title "[CI] Update Foundry Upgrades plugin docs" --body "[CI] This PR updates the docs for the Foundry Upgrades plugin" --base main --head $GITHUB_REF
+        gh pr create --title "[CI] Update Foundry Upgrades plugin docs" \
+                   --body "[CI] This PR updates the docs for the Foundry Upgrades plugin" \
+                   --base main \
+                   --head $BRANCH_NAME

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Check for changes in docs/
       id: check_changes
       run: |
-        [ -n "$(git diff --name-only HEAD -- docs/)" ] && echo "SHOULD_COMMIT_DOC_UPDATE=true" >> $GITHUB_ENV
+        [ -n "$(git diff --name-only HEAD -- docs/)" ] && echo "SHOULD_COMMIT_DOC_UPDATE=true" >> $GITHUB_ENV || true
 
     - name: Commit and push changes
       if: env.SHOULD_COMMIT_DOC_UPDATE == 'true'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -106,11 +106,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh pr create --title "[CI] Update Foundry Upgrades plugin docs" \
-                 --body "[CI] This PR updates the docs for the Foundry Upgrades plugin" \
+                 --body "This Pull Request updates the docs for the Foundry Upgrades plugin" \
                  --base master \
-                 --head $BRANCH_NAME || echo "PR creation failed"
+                 --head $BRANCH_NAME || echo "Pull Request creation failed"
 
-    - name: Clean up branch if PR creation fails
+    - name: Clean up branch if Pull Request creation fails
       if: steps.create_pull_request.outcome == 'failure'
       run: |
         git push origin --delete $BRANCH_NAME

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/openzeppelin-foundry-upgrades"]
 	path = submodules/openzeppelin-foundry-upgrades
-	url = https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades
+	url = https://github.com/CoveMB/openzeppelin-foundry-upgrades

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/openzeppelin-foundry-upgrades"]
 	path = submodules/openzeppelin-foundry-upgrades
-	url = https://github.com/CoveMB/openzeppelin-foundry-upgrades
+	url = https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "docs": "bash scripts/prepare-foundry-docs.sh && oz-docs",
+    "docs": "bash scripts/prepare-foundry-docs.sh && bash scripts/check-diff-docs.sh && oz-docs",
+    "docs:foundry:ci": "bash scripts/prepare-foundry-docs.sh && oz-docs",
     "docs:watch": "oz-docs watch",
     "prepare": "wsrun -ms prepare && tsc -b",
     "lint": "yarn lint:path .",

--- a/scripts/check-diff-docs.sh
+++ b/scripts/check-diff-docs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Checks if Foundry docs are up to date. If this fails, commit the changes from the above commands.
+git diff --exit-code docs/modules/ROOT/pages/foundry

--- a/scripts/prepare-foundry-docs.sh
+++ b/scripts/prepare-foundry-docs.sh
@@ -2,5 +2,3 @@
 
 rm -rf docs/modules/ROOT/pages/foundry
 cp -r submodules/openzeppelin-foundry-upgrades/docs/modules docs/modules/ROOT/pages/foundry
-# Checks if Foundry docs are up to date. If this fails, commit the changes from the above commands.
-git diff --exit-code docs/modules/ROOT/pages/foundry


### PR DESCRIPTION
The workflow if trigger externally from `openzeppelin-foundry-upgrades` CI if changes were detected to the docs.
It updates the submodule, re-genrate the documentation, if changes are confirmed on the generated documentation creates a new branch, commit and push the changes then a pull request is open from this branch to the main branch (it creating the pull request fails the created branch is deleted).

Additionally the checking difference during preparing (copying) the docs from the submodule to the root got decoupled so that having differences does not fail the CI as the changes will be committed in the pull request.