### PR TITLE
Ignore function node IDs not found when validating parent initializer calls

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.42.2 (2025-03-19)
 
 - Fix `ASTDereferencerError` for additional scenario when validating initializers. ([#1137](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1137))
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Fix `ASTDereferencerError` for additional scenario when validating initializers. ([#1137](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1137))
+
 ## 1.42.1 (2025-01-24)
 
-- Fix `ASTDereferencerError` when validating initializers.
+- Fix `ASTDereferencerError` when validating initializers. ([#1118](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1118))
 
 ## 1.42.0 (2025-01-23)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/upgrades-core",
-  "version": "1.42.1",
+  "version": "1.42.2",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/core",
   "license": "MIT",

--- a/packages/core/src/validate/run.ts
+++ b/packages/core/src/validate/run.ts
@@ -512,7 +512,10 @@ function setCachedOpcodes(key: number, scope: string, cache: OpcodeCache, errors
   }
 }
 
-export function tryDerefFunction(deref: ASTDereferencer, referencedDeclaration: number): FunctionDefinition | undefined {
+export function tryDerefFunction(
+  deref: ASTDereferencer,
+  referencedDeclaration: number,
+): FunctionDefinition | undefined {
   try {
     return deref(['FunctionDefinition'], referencedDeclaration);
   } catch (e: any) {

--- a/packages/core/src/validate/run.ts
+++ b/packages/core/src/validate/run.ts
@@ -512,7 +512,7 @@ function setCachedOpcodes(key: number, scope: string, cache: OpcodeCache, errors
   }
 }
 
-function tryDerefFunction(deref: ASTDereferencer, referencedDeclaration: number): FunctionDefinition | undefined {
+export function tryDerefFunction(deref: ASTDereferencer, referencedDeclaration: number): FunctionDefinition | undefined {
   try {
     return deref(['FunctionDefinition'], referencedDeclaration);
   } catch (e: any) {

--- a/packages/core/src/validate/run/initializer.ts
+++ b/packages/core/src/validate/run/initializer.ts
@@ -266,7 +266,11 @@ function* getInitializerCallExceptions(
  * @param visited Set of function IDs that have already been visited
  * @returns The IDs of all functions that are recursively called by the given function, including the given function itself at the end of the list.
  */
-function getRecursiveFunctionIds(deref: ASTDereferencer, functionDef: FunctionDefinition, visited?: Set<number>): number[] {
+function getRecursiveFunctionIds(
+  deref: ASTDereferencer,
+  functionDef: FunctionDefinition,
+  visited?: Set<number>,
+): number[] {
   const result: number[] = [];
 
   if (visited === undefined) {
@@ -278,7 +282,8 @@ function getRecursiveFunctionIds(deref: ASTDereferencer, functionDef: FunctionDe
     visited.add(functionDef.id);
   }
 
-  const expressionStatements = functionDef.body?.statements?.filter(stmt => stmt.nodeType === 'ExpressionStatement') ?? [];
+  const expressionStatements =
+    functionDef.body?.statements?.filter(stmt => stmt.nodeType === 'ExpressionStatement') ?? [];
   for (const stmt of expressionStatements) {
     const fnCall = stmt.expression;
     if (

--- a/packages/core/src/validate/run/initializer.ts
+++ b/packages/core/src/validate/run/initializer.ts
@@ -180,7 +180,7 @@ function* getInitializerCallExceptions(
       if (referencedDeclaration && referencedDeclaration > 0) {
         const referencedNode = tryDerefFunction(deref, referencedDeclaration);
         if (referencedNode !== undefined) {
-          recursiveFunctionIds = getRecursiveFunctionIds(referencedNode, deref);
+          recursiveFunctionIds = getRecursiveFunctionIds(deref, referencedNode);
         }
       }
 
@@ -261,12 +261,12 @@ function* getInitializerCallExceptions(
 /**
  * Gets the IDs of all functions that are recursively called by the given function, including the given function itself at the end of the list.
  *
- * @param functionDef The node of the function definition to start from
  * @param deref AST dereferencer
+ * @param functionDef The node of the function definition to start from
  * @param visited Set of function IDs that have already been visited
  * @returns The IDs of all functions that are recursively called by the given function, including the given function itself at the end of the list.
  */
-function getRecursiveFunctionIds(functionDef: FunctionDefinition, deref: ASTDereferencer, visited?: Set<number>): number[] {
+function getRecursiveFunctionIds(deref: ASTDereferencer, functionDef: FunctionDefinition, visited?: Set<number>): number[] {
   const result: number[] = [];
 
   if (visited === undefined) {
@@ -289,7 +289,7 @@ function getRecursiveFunctionIds(functionDef: FunctionDefinition, deref: ASTDere
       if (referencedDeclaration && referencedDeclaration > 0) {
         const recursiveReferencedNode = tryDerefFunction(deref, referencedDeclaration);
         if (recursiveReferencedNode !== undefined) {
-          result.push(...getRecursiveFunctionIds(recursiveReferencedNode, deref, visited));
+          result.push(...getRecursiveFunctionIds(deref, recursiveReferencedNode, visited));
         }
       }
     }


### PR DESCRIPTION
Background:
When checking for issues in parent initializer calls according to https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1095, we recursively check initializer functions and the functions that they call.

When an function calls a built-in function, the referenced AST node ID of the built in function may be negative (which was fixed in https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1116), or it could be represented as a large positive number as reported in #1128.

We previously only ignored negative numbers, but since there is no way to conclusively identify that a large positive number is negative, we should also ignore when the referenced function node ID is not found.

---

Testing:
I tested that this works by temporarily removing the checks for negative node IDs and allowing the new error handling to ignore the error.  However, we should still keep the checks for negative node IDs for efficiency purposes (e.g. no need to dereference if we know that the id is negative and will not be found).

---

Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1128