### PR TITLE
Support annotation to validate arbitrary functions as initializers

### DIFF
--- a/docs/modules/ROOT/pages/writing-upgradeable.adoc
+++ b/docs/modules/ROOT/pages/writing-upgradeable.adoc
@@ -203,7 +203,7 @@ constructor() {
 
 The OpenZeppelin Upgrades plugins will automatically detect specific issues with initializers in implementation contracts. These include checking if your implementation contract is missing an initializer when there are parent initializers that need to be called, if a parent initializer is not called, or if a parent initializer is called more than once. The plugins will also warn if parent initializers are not called in linearized order.
 
-Note that reinitializers are not included in validations by default, because the Upgrades plugins cannot determine whether they are intended to be used for new deployments. If you want to validate a reinitializer function as an initializer that can be used for new deployments, annotate it with `@custom:oz-upgrades-validate-as-initializer`.
+Reinitializers are not included in validations by default, because the Upgrades plugins cannot determine whether they are intended to be used for new deployments. If you want to validate a reinitializer function as an initializer that can be used for new deployments, annotate it with `@custom:oz-upgrades-validate-as-initializer`. Note that functions which cannot possibly be initializers are always ignored, such as private functions that cannot be called externally or by child contracts.
 
 [[creating-new-instances-from-your-contract-code]]
 == Creating New Instances From Your Contract Code

--- a/docs/modules/ROOT/pages/writing-upgradeable.adoc
+++ b/docs/modules/ROOT/pages/writing-upgradeable.adoc
@@ -203,7 +203,7 @@ constructor() {
 
 The OpenZeppelin Upgrades plugins will automatically detect specific issues with initializers in implementation contracts. These include checking if your implementation contract is missing an initializer when there are parent initializers that need to be called, if a parent initializer is not called, or if a parent initializer is called more than once. The plugins will also warn if parent initializers are not called in linearized order.
 
-Note that reinitializers are not included in validations by default, because the Upgrades plugins cannot determine whether they are intended to be used for new deployments. If you want to validate a reinitializer function as an initializer that can be used for new deployments, annotate it with `@custom:oz-upgrades-assume-initializer`.
+Note that reinitializers are not included in validations by default, because the Upgrades plugins cannot determine whether they are intended to be used for new deployments. If you want to validate a reinitializer function as an initializer that can be used for new deployments, annotate it with `@custom:oz-upgrades-validate-as-initializer`.
 
 [[creating-new-instances-from-your-contract-code]]
 == Creating New Instances From Your Contract Code

--- a/docs/modules/ROOT/pages/writing-upgradeable.adoc
+++ b/docs/modules/ROOT/pages/writing-upgradeable.adoc
@@ -191,12 +191,19 @@ contract MyContract {
 
 Do not leave an implementation contract uninitialized. An uninitialized implementation contract can be taken over by an attacker, which may impact the proxy. To prevent the implementation contract from being used, you should invoke the `_disableInitializers` function in the constructor to automatically lock it when it is deployed:
 
-```
+[source,solidity]
+----
 /// @custom:oz-upgrades-unsafe-allow constructor
 constructor() {
     _disableInitializers();
 }
-```
+----
+
+=== Validating Initializers
+
+The OpenZeppelin Upgrades plugins will automatically detect issues in parent initializer calls. These include validating if your implementation contract is missing an initializer when there are parent initializers that need to be called, if a parent initializer is not called, or if a parent initializer is called more than once. The plugins will also warn if parent initializers are not called in linearized order.
+
+Note that reinitializers are not included in validations by default, because the Upgrades plugins cannot determine whether they are intended to be used for new deployments. If you want to validate a reinitializer function as an initializer that can be used for new deployments, annotate it with `@custom:oz-upgrades-assume-initializer`.
 
 [[creating-new-instances-from-your-contract-code]]
 == Creating New Instances From Your Contract Code

--- a/docs/modules/ROOT/pages/writing-upgradeable.adoc
+++ b/docs/modules/ROOT/pages/writing-upgradeable.adoc
@@ -201,7 +201,7 @@ constructor() {
 
 === Validating Initializers
 
-The OpenZeppelin Upgrades plugins will automatically detect issues in parent initializer calls. These include validating if your implementation contract is missing an initializer when there are parent initializers that need to be called, if a parent initializer is not called, or if a parent initializer is called more than once. The plugins will also warn if parent initializers are not called in linearized order.
+The OpenZeppelin Upgrades plugins will automatically detect specific issues with initializers in implementation contracts. These include checking if your implementation contract is missing an initializer when there are parent initializers that need to be called, if a parent initializer is not called, or if a parent initializer is called more than once. The plugins will also warn if parent initializers are not called in linearized order.
 
 Note that reinitializers are not included in validations by default, because the Upgrades plugins cannot determine whether they are intended to be used for new deployments. If you want to validate a reinitializer function as an initializer that can be used for new deployments, annotate it with `@custom:oz-upgrades-assume-initializer`.
 

--- a/docs/modules/ROOT/pages/writing-upgradeable.adoc
+++ b/docs/modules/ROOT/pages/writing-upgradeable.adoc
@@ -203,7 +203,7 @@ constructor() {
 
 The OpenZeppelin Upgrades plugins will automatically detect specific issues with initializers in implementation contracts. These include checking if your implementation contract is missing an initializer when there are parent initializers that need to be called, if a parent initializer is not called, or if a parent initializer is called more than once. The plugins will also warn if parent initializers are not called in linearized order.
 
-Reinitializers are not included in validations by default, because the Upgrades plugins cannot determine whether they are intended to be used for new deployments. If you want to validate a reinitializer function as an initializer that can be used for new deployments, annotate it with `@custom:oz-upgrades-validate-as-initializer`. Note that functions which cannot possibly be initializers are always ignored, such as private functions that cannot be called externally or by child contracts.
+Reinitializers are not included in validations by default, because the Upgrades plugins cannot determine whether they are intended to be used for new deployments. If you want to validate a reinitializer function as an initializer that can be used for new deployments, annotate it with `@custom:oz-upgrades-validate-as-initializer`. Note that functions which cannot possibly be initializers are always ignored, such as private functions which cannot be called externally or by child contracts.
 
 [[creating-new-instances-from-your-contract-code]]
 == Creating New Instances From Your Contract Code

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add Sonic network to manifest file names. ([#1146](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1146))
+- Support annotation to validate functions as initializers. ([#1148](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1148))
 
 ## 1.42.2 (2025-03-19)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.43.0 (2025-04-11)
 
 - Add Sonic network to manifest file names. ([#1146](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1146))
 - Support annotation to validate functions as initializers. ([#1148](https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1148))

--- a/packages/core/contracts/test/ValidationsInitializer.sol
+++ b/packages/core/contracts/test/ValidationsInitializer.sol
@@ -134,6 +134,27 @@ contract AssumeInitializer_Ok is Parent_InitializerModifier {
   }
 }
 
+contract Reinitializer_NotDetected is Parent_InitializerModifier {
+  uint y;
+  function initializeV2() public reinitializer(2) {
+    parentInit();
+    y = 2;
+  }
+}
+
+contract Reinitializer_AssumeInitializer_Ok is Parent_InitializerModifier {
+  uint y;
+  /**
+   * Text before
+   * @custom:oz-upgrades-assume-initializer
+   * Text after
+   */
+  function initializeV2() public reinitializer(2) {
+    parentInit();
+    y = 2;
+  }
+}
+
 contract A is Initializable {
   uint a;
   function __A_init() onlyInitializing internal {

--- a/packages/core/contracts/test/ValidationsInitializer.sol
+++ b/packages/core/contracts/test/ValidationsInitializer.sol
@@ -337,6 +337,22 @@ contract InitializationOrder_ValidateAsInitializer_DuplicateCall is A, B, C, Par
   }
 }
 
+contract Parent_ValidateAsInitializer_External_Ok {
+  uint8 x;
+  /// @custom:oz-upgrades-validate-as-initializer
+  function parentAssumeInit() external {
+    // this is a valid initializer, but it does not need to be called by the child (and it is not possible to do so), because it is external
+    x = 1;
+  }
+}
+
+contract Child_Of_ValidateAsInitializer_External_Ok is Parent_ValidateAsInitializer_External_Ok {
+  uint y;
+  function initialize() public {
+    y = 2;
+  }
+}
+
 contract WithRequire_Ok is Parent__OnlyInitializingModifier {
   uint y;
   function initialize(bool foo) initializer public {

--- a/packages/core/contracts/test/ValidationsInitializer.sol
+++ b/packages/core/contracts/test/ValidationsInitializer.sol
@@ -117,6 +117,15 @@ contract MissingInitializer_UnsafeAllow_Contract is Parent_InitializerModifier {
   }
 }
 
+contract AssumeInitializer_Ok is Parent_InitializerModifier {
+  uint y;
+  /// @custom:oz-upgrades-assume-initializer
+  function regularFn() public {
+    parentInit();
+    y = 2;
+  }
+}
+
 contract A is Initializable {
   uint a;
   function __A_init() onlyInitializing internal {

--- a/packages/core/contracts/test/ValidationsInitializer.sol
+++ b/packages/core/contracts/test/ValidationsInitializer.sol
@@ -24,9 +24,9 @@ contract Parent_NoInitializer {
   }
 }
 
-contract Parent_AssumeInitializer {
+contract Parent_ValidateAsInitializer {
   uint8 x;
-  /// @custom:oz-upgrades-assume-initializer
+  /// @custom:oz-upgrades-validate-as-initializer
   function parentAssumeInit() public {
     x = 1;
   }
@@ -125,9 +125,9 @@ contract MissingInitializer_UnsafeAllow_Contract is Parent_InitializerModifier {
   }
 }
 
-contract AssumeInitializer_Ok is Parent_InitializerModifier {
+contract ValidateAsInitializer_Ok is Parent_InitializerModifier {
   uint y;
-  /// @custom:oz-upgrades-assume-initializer
+  /// @custom:oz-upgrades-validate-as-initializer
   function regularFn() public {
     parentInit();
     y = 2;
@@ -142,11 +142,11 @@ contract Reinitializer_NotDetected is Parent_InitializerModifier {
   }
 }
 
-contract Reinitializer_AssumeInitializer_Ok is Parent_InitializerModifier {
+contract Reinitializer_ValidateAsInitializer_Ok is Parent_InitializerModifier {
   uint y;
   /**
    * Text before
-   * @custom:oz-upgrades-assume-initializer
+   * @custom:oz-upgrades-validate-as-initializer
    * Text after
    */
   function initializeV2() public reinitializer(2) {
@@ -301,7 +301,7 @@ contract InitializationOrder_UnsafeAllowDuplicate_But_WrongOrder is A, B, C, Par
   }
 }
 
-contract InitializationOrder_AssumeInitializer_Ok is A, B, C, Parent_AssumeInitializer {
+contract InitializationOrder_ValidateAsInitializer_Ok is A, B, C, Parent_ValidateAsInitializer {
   function initialize() public {
     __A_init();
     __B_init();
@@ -310,7 +310,7 @@ contract InitializationOrder_AssumeInitializer_Ok is A, B, C, Parent_AssumeIniti
   }
 }
 
-contract InitializationOrder_AssumeInitializer_WrongOrder is A, B, C, Parent_AssumeInitializer {
+contract InitializationOrder_ValidateAsInitializer_WrongOrder is A, B, C, Parent_ValidateAsInitializer {
   function initialize() public {
     __A_init();
     __B_init();
@@ -319,7 +319,7 @@ contract InitializationOrder_AssumeInitializer_WrongOrder is A, B, C, Parent_Ass
   }
 }
 
-contract InitializationOrder_AssumeInitializer_MissingCall is A, B, C, Parent_AssumeInitializer {
+contract InitializationOrder_ValidateAsInitializer_MissingCall is A, B, C, Parent_ValidateAsInitializer {
   function initialize() public {
     __A_init();
     __B_init();
@@ -327,7 +327,7 @@ contract InitializationOrder_AssumeInitializer_MissingCall is A, B, C, Parent_As
   }
 }
 
-contract InitializationOrder_AssumeInitializer_DuplicateCall is A, B, C, Parent_AssumeInitializer {
+contract InitializationOrder_ValidateAsInitializer_DuplicateCall is A, B, C, Parent_ValidateAsInitializer {
   function initialize() public {
     __A_init();
     __B_init();

--- a/packages/core/contracts/test/ValidationsInitializer.sol
+++ b/packages/core/contracts/test/ValidationsInitializer.sol
@@ -24,6 +24,14 @@ contract Parent_NoInitializer {
   }
 }
 
+contract Parent_AssumeInitializer {
+  uint8 x;
+  /// @custom:oz-upgrades-assume-initializer
+  function parentAssumeInit() public {
+    x = 1;
+  }
+}
+
 contract Parent_InitializerModifier is Initializable {
   uint8 x;
   function parentInit() initializer internal {
@@ -269,6 +277,42 @@ contract InitializationOrder_UnsafeAllowDuplicate_But_WrongOrder is A, B, C, Par
     __C_init();
     __B_init();
     __B_init();
+  }
+}
+
+contract InitializationOrder_AssumeInitializer_Ok is A, B, C, Parent_AssumeInitializer {
+  function initialize() public {
+    __A_init();
+    __B_init();
+    __C_init();
+    parentAssumeInit();
+  }
+}
+
+contract InitializationOrder_AssumeInitializer_WrongOrder is A, B, C, Parent_AssumeInitializer {
+  function initialize() public {
+    __A_init();
+    __B_init();
+    parentAssumeInit();
+    __C_init();
+  }
+}
+
+contract InitializationOrder_AssumeInitializer_MissingCall is A, B, C, Parent_AssumeInitializer {
+  function initialize() public {
+    __A_init();
+    __B_init();
+    __C_init();
+  }
+}
+
+contract InitializationOrder_AssumeInitializer_DuplicateCall is A, B, C, Parent_AssumeInitializer {
+  function initialize() public {
+    __A_init();
+    __B_init();
+    __C_init();
+    parentAssumeInit();
+    parentAssumeInit();
   }
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/upgrades-core",
-  "version": "1.42.2",
+  "version": "1.43.0",
   "description": "",
   "repository": "https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/core",
   "license": "MIT",

--- a/packages/core/src/validate-initializers.test.ts
+++ b/packages/core/src/validate-initializers.test.ts
@@ -42,7 +42,7 @@ interface ExpectedErrors {
   count: number;
 }
 
-function testRejects(name: string, kind: ValidationOptions['kind'], expectedErrors?: ExpectedErrors) {
+function testRejects(name: string, kind: ValidationOptions['kind'], expectedErrors: ExpectedErrors) {
   testOverride(name, kind, {}, expectedErrors);
 }
 
@@ -142,6 +142,9 @@ testRejects('InitializationOrder_ValidateAsInitializer_DuplicateCall', 'transpar
   contains: ['Duplicate calls found to initializer `parentAssumeInit` for contract `Parent_ValidateAsInitializer`'],
   count: 1,
 });
+
+testAccepts('Parent_ValidateAsInitializer_External_Ok', 'transparent');
+testAccepts('Child_Of_ValidateAsInitializer_External_Ok', 'transparent');
 
 testAccepts('WithRequire_Ok', 'transparent');
 testRejects('WithRequire_Bad', 'transparent', {

--- a/packages/core/src/validate-initializers.test.ts
+++ b/packages/core/src/validate-initializers.test.ts
@@ -98,13 +98,13 @@ testRejects('MissingInitializer_Bad', 'transparent', {
 testAccepts('MissingInitializer_UnsafeAllow_Contract', 'transparent');
 testOverride('MissingInitializer_Bad', 'transparent', { unsafeAllow: ['missing-initializer'] });
 
-testAccepts('AssumeInitializer_Ok', 'transparent');
+testAccepts('ValidateAsInitializer_Ok', 'transparent');
 
 testRejects('Reinitializer_NotDetected', 'transparent', {
   contains: ['Missing initializer'],
   count: 1,
 });
-testAccepts('Reinitializer_AssumeInitializer_Ok', 'transparent');
+testAccepts('Reinitializer_ValidateAsInitializer_Ok', 'transparent');
 
 testAccepts('InitializationOrder_Ok', 'transparent');
 testAccepts('InitializationOrder_Ok_2', 'transparent');
@@ -132,14 +132,14 @@ testAccepts('InitializationOrder_Duplicate_UnsafeAllow_Call', 'transparent');
 testOverride('InitializationOrder_Duplicate_Bad', 'transparent', { unsafeAllow: ['duplicate-initializer-call'] });
 testAccepts('InitializationOrder_UnsafeAllowDuplicate_But_WrongOrder', 'transparent'); // warn 'Expected: A, B, C'
 
-testAccepts('InitializationOrder_AssumeInitializer_Ok', 'transparent');
-testAccepts('InitializationOrder_AssumeInitializer_WrongOrder', 'transparent'); // warn 'Expected: A, B, C, Parent_AssumeInitializer'
-testRejects('InitializationOrder_AssumeInitializer_MissingCall', 'transparent', {
-  contains: ['Missing initializer calls for one or more parent contracts: `Parent_AssumeInitializer`'],
+testAccepts('InitializationOrder_ValidateAsInitializer_Ok', 'transparent');
+testAccepts('InitializationOrder_ValidateAsInitializer_WrongOrder', 'transparent'); // warn 'Expected: A, B, C, Parent_ValidateAsInitializer'
+testRejects('InitializationOrder_ValidateAsInitializer_MissingCall', 'transparent', {
+  contains: ['Missing initializer calls for one or more parent contracts: `Parent_ValidateAsInitializer`'],
   count: 1,
 });
-testRejects('InitializationOrder_AssumeInitializer_DuplicateCall', 'transparent', {
-  contains: ['Duplicate calls found to initializer `parentAssumeInit` for contract `Parent_AssumeInitializer`'],
+testRejects('InitializationOrder_ValidateAsInitializer_DuplicateCall', 'transparent', {
+  contains: ['Duplicate calls found to initializer `parentAssumeInit` for contract `Parent_ValidateAsInitializer`'],
   count: 1,
 });
 

--- a/packages/core/src/validate-initializers.test.ts
+++ b/packages/core/src/validate-initializers.test.ts
@@ -98,6 +98,8 @@ testRejects('MissingInitializer_Bad', 'transparent', {
 testAccepts('MissingInitializer_UnsafeAllow_Contract', 'transparent');
 testOverride('MissingInitializer_Bad', 'transparent', { unsafeAllow: ['missing-initializer'] });
 
+testAccepts('AssumeInitializer_Ok', 'transparent');
+
 testAccepts('InitializationOrder_Ok', 'transparent');
 testAccepts('InitializationOrder_Ok_2', 'transparent');
 

--- a/packages/core/src/validate-initializers.test.ts
+++ b/packages/core/src/validate-initializers.test.ts
@@ -103,7 +103,7 @@ testAccepts('AssumeInitializer_Ok', 'transparent');
 testAccepts('InitializationOrder_Ok', 'transparent');
 testAccepts('InitializationOrder_Ok_2', 'transparent');
 
-testAccepts('InitializationOrder_WrongOrder_Bad', 'transparent'); // warn 'Expected initializers to be called for parent contracts in the following order: A, B, C'
+testAccepts('InitializationOrder_WrongOrder_Bad', 'transparent'); // warn 'Expected: A, B, C'
 testAccepts('InitializationOrder_WrongOrder_UnsafeAllow_Contract', 'transparent');
 testAccepts('InitializationOrder_WrongOrder_UnsafeAllow_Function', 'transparent');
 testOverride('InitializationOrder_WrongOrder_Bad', 'transparent', { unsafeAllow: ['incorrect-initializer-order'] }); // skips the warning
@@ -124,7 +124,18 @@ testAccepts('InitializationOrder_Duplicate_UnsafeAllow_Contract', 'transparent')
 testAccepts('InitializationOrder_Duplicate_UnsafeAllow_Function', 'transparent');
 testAccepts('InitializationOrder_Duplicate_UnsafeAllow_Call', 'transparent');
 testOverride('InitializationOrder_Duplicate_Bad', 'transparent', { unsafeAllow: ['duplicate-initializer-call'] });
-testAccepts('InitializationOrder_UnsafeAllowDuplicate_But_WrongOrder', 'transparent'); // warn 'Expected initializers to be called for parent contracts in the following order: A, B, C'
+testAccepts('InitializationOrder_UnsafeAllowDuplicate_But_WrongOrder', 'transparent'); // warn 'Expected: A, B, C'
+
+testAccepts('InitializationOrder_AssumeInitializer_Ok', 'transparent');
+testAccepts('InitializationOrder_AssumeInitializer_WrongOrder', 'transparent'); // warn 'Expected: A, B, C, Parent_AssumeInitializer'
+testRejects('InitializationOrder_AssumeInitializer_MissingCall', 'transparent', {
+  contains: ['Missing initializer calls for one or more parent contracts: `Parent_AssumeInitializer`'],
+  count: 1,
+});
+testRejects('InitializationOrder_AssumeInitializer_DuplicateCall', 'transparent', {
+  contains: ['Duplicate calls found to initializer `parentAssumeInit` for contract `Parent_AssumeInitializer`'],
+  count: 1,
+});
 
 testAccepts('WithRequire_Ok', 'transparent');
 testRejects('WithRequire_Bad', 'transparent', {
@@ -180,11 +191,11 @@ testRejects('TransitiveChild_Bad_Parent', 'transparent', {
     'Missing initializer calls for one or more parent contracts: `TransitiveGrandparent2`', // occurs twice: missing initializer for child, missing initializer for parent
   ],
   count: 2,
-}); // warn 'Expected initializers to be called for parent contracts in the following order: TransitiveGrandparent2, TransitiveParent_Bad'
+}); // warn 'Expected: TransitiveGrandparent2, TransitiveParent_Bad'
 testRejects('TransitiveChild_Bad_Order', 'transparent', {
   contains: ['Missing initializer calls for one or more parent contracts: `TransitiveGrandparent2`'],
   count: 1,
-}); // warn 'Expected initializers to be called for parent contracts in the following order: TransitiveGrandparent2, TransitiveParent_Bad'
+}); // warn 'Expected: TransitiveGrandparent2, TransitiveParent_Bad'
 testRejects('TransitiveChild_Good_Order_Bad_Parent', 'transparent', {
   contains: ['Missing initializer calls for one or more parent contracts: `TransitiveGrandparent2`'],
   count: 1,

--- a/packages/core/src/validate-initializers.test.ts
+++ b/packages/core/src/validate-initializers.test.ts
@@ -100,6 +100,12 @@ testOverride('MissingInitializer_Bad', 'transparent', { unsafeAllow: ['missing-i
 
 testAccepts('AssumeInitializer_Ok', 'transparent');
 
+testRejects('Reinitializer_NotDetected', 'transparent', {
+  contains: ['Missing initializer'],
+  count: 1,
+});
+testAccepts('Reinitializer_AssumeInitializer_Ok', 'transparent');
+
 testAccepts('InitializationOrder_Ok', 'transparent');
 testAccepts('InitializationOrder_Ok_2', 'transparent');
 

--- a/packages/core/src/validate/run/initializer.ts
+++ b/packages/core/src/validate/run/initializer.ts
@@ -331,28 +331,28 @@ function getPossibleInitializers(
 ): FunctionDefinition[] {
   const fns = [...findAll('FunctionDefinition', contractDef)];
   return fns.filter((fnDef: FunctionDefinition) => {
-    const assumeInitializer = hasAssumeInitializerAnnotation(fnDef, decodeSrc);
-    if (!assumeInitializer && fnDef.modifiers.some(modifier => 'reinitializer' === modifier.modifierName.name)) {
+    const validateAsInitializer = hasValidateAsInitializerAnnotation(fnDef, decodeSrc);
+    if (!validateAsInitializer && fnDef.modifiers.some(modifier => 'reinitializer' === modifier.modifierName.name)) {
       logNote(`Reinitializers are not included in validations by default`, [
-        `${decodeSrc(fnDef)}: If you want to validate this function as an initializer, annotate it with '@custom:oz-upgrades-assume-initializer'`,
+        `${decodeSrc(fnDef)}: If you want to validate this function as an initializer, annotate it with '@custom:oz-upgrades-validate-as-initializer'`,
       ]);
     }
 
-    return assumeInitializer || inferPossibleInitializer(fnDef, isParentContract);
+    return validateAsInitializer || inferPossibleInitializer(fnDef, isParentContract);
   });
 }
 
-function hasAssumeInitializerAnnotation(node: Node, decodeSrc: SrcDecoder): boolean {
+function hasValidateAsInitializerAnnotation(node: Node, decodeSrc: SrcDecoder): boolean {
   const doc = getDocumentation(node);
-  const tag = 'oz-upgrades-assume-initializer';
-  const assumeInitializer = hasAnnotationTag(doc, tag);
-  if (assumeInitializer) {
+  const tag = 'oz-upgrades-validate-as-initializer';
+  const validateAsInitializer = hasAnnotationTag(doc, tag);
+  if (validateAsInitializer) {
     const annotationArgs = getAnnotationArgs(doc, tag);
     if (annotationArgs.length !== 0) {
       throw new Error(`${decodeSrc(node)}: @custom:${tag} annotation must not have any arguments`);
     }
   }
-  return assumeInitializer;
+  return validateAsInitializer;
 }
 
 /**

--- a/packages/core/src/validate/run/initializer.ts
+++ b/packages/core/src/validate/run/initializer.ts
@@ -334,7 +334,7 @@ function getPossibleInitializers(
     const assumeInitializer = hasAssumeInitializerAnnotation(fnDef, decodeSrc);
     if (!assumeInitializer && fnDef.modifiers.some(modifier => 'reinitializer' === modifier.modifierName.name)) {
       logNote(`Reinitializers are not included in validations by default`, [
-        `${decodeSrc(fnDef)}: If you want to validate this function as an initializer, add the NatSpec annotation \`@custom:oz-upgrades-assume-initializer\` above this function.`,
+        `${decodeSrc(fnDef)}: If you want to validate this function as an initializer, annotate it with '@custom:oz-upgrades-assume-initializer'`,
       ]);
     }
 

--- a/packages/core/src/validate/run/initializer.ts
+++ b/packages/core/src/validate/run/initializer.ts
@@ -321,8 +321,8 @@ function getRecursiveFunctionIds(
 }
 
 /**
- * Get all functions that could be initializers. Does not include private functions.
- * For parent contracts, only internal and public functions which contain statements are included.
+ * Get all functions that are annotated as initializers or are inferred to be initializers.
+ * Logs a note if any reinitializer is found.
  */
 function getPossibleInitializers(
   contractDef: ContractDefinition,
@@ -355,6 +355,10 @@ function hasAssumeInitializerAnnotation(node: Node, decodeSrc: SrcDecoder): bool
   return assumeInitializer;
 }
 
+/**
+ * Infers whether a function could be an initializer. Does not include private functions.
+ * For parent contracts, only internal and public functions which contain statements are included.
+ */
 function inferPossibleInitializer(fnDef: FunctionDefinition, isParentContract: boolean): boolean {
   return (
     (fnDef.modifiers.some(modifier => ['initializer', 'onlyInitializing'].includes(modifier.modifierName.name)) ||


### PR DESCRIPTION
- Adds a section in docs about the initializer validations that are performed by Upgrades Plugins.
- Logs a note when reinitializers are detected, to tell users that reinitializers are not included in validations by default.
- Support a custom NatSpec annotation `@custom:oz-upgrades-validate-as-initializer` to mark arbitrary functions to be treated as initializers for validations.
  - This can be used for any function that is not normally detected as an initializer (for example, custom initializer functions that do not use `onlyInitializing` or `initializer` modifiers), and can also be used on reinitializers to include them in validations.

Fixes https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1122
Related to https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1125