### PR TITLE
docs: clarify Defender Deploy Environment API keys

### DIFF
--- a/docs/modules/ROOT/pages/defender-deploy.adoc
+++ b/docs/modules/ROOT/pages/defender-deploy.adoc
@@ -17,7 +17,7 @@ module.exports = {
 }
 ----
 
-NOTE: The API key for the above must at least have the capability to Manage Deployments. You can configure your API keys at https://defender.openzeppelin.com/#/settings/api-keys.
+NOTE: The API key for the above must at least have the capability to Manage Deployments (optionally Manage Relayers is needed to create an approval process with a Relayer). You can configure your API keys at https://defender.openzeppelin.com/#/settings/api-keys.
 
 [[network-selection]]
 == Network Selection

--- a/docs/modules/ROOT/pages/defender-deploy.adoc
+++ b/docs/modules/ROOT/pages/defender-deploy.adoc
@@ -17,7 +17,7 @@ module.exports = {
 }
 ----
 
-NOTE: The API Key and Secret referenced above are specifically for the Production or Test Deploy Environment that you configured in Defender. You can obtain these from the Deploy module in Defender when setting up your environment. For more information, see https://docs.openzeppelin.com/defender/v2/tutorial/deploy#environment_setup.
+NOTE: The API key for the above must at least have the capability to Manage Deployments. You can configure your API keys at https://defender.openzeppelin.com/#/settings/api-keys.
 
 [[network-selection]]
 == Network Selection

--- a/docs/modules/ROOT/pages/defender-deploy.adoc
+++ b/docs/modules/ROOT/pages/defender-deploy.adoc
@@ -17,6 +17,8 @@ module.exports = {
 }
 ----
 
+NOTE: The API Key and Secret referenced above are specifically for the Production or Test Deploy Environment that you configured in Defender. You can obtain these from the Deploy module in Defender when setting up your environment. For more information, see https://docs.openzeppelin.com/defender/v2/tutorial/deploy#environment_setup.
+
 [[network-selection]]
 == Network Selection
 

--- a/docs/modules/ROOT/pages/foundry/pages/foundry-defender.adoc
+++ b/docs/modules/ROOT/pages/foundry/pages/foundry-defender.adoc
@@ -26,13 +26,15 @@ extra_output = ["storageLayout"]
 NOTE: Metadata must also be included in the compiler output, which it is by default.  
 
 [start=3]
-3. Set the following environment variables in your `.env` file at your project root, using your Team API key and secret from OpenZeppelin Defender:
+3. Set the following environment variables in your `.env` file at your project root, using your Team API key and secret from the OpenZeppelin Defender Deploy Environment (either Production or Test) that you configured:
 
 [source]
 ----
 DEFENDER_KEY=<Your API key>
 DEFENDER_SECRET=<Your API secret>
 ----
+
+NOTE: These API keys are specifically for the Deploy Environment (Production or Test) that you configured in Defender. You can obtain these keys from the Deploy module in Defender during the environment setup process. For more information, see https://docs.openzeppelin.com/defender/v2/tutorial/deploy#environment_setup.
 
 == Network Selection
 

--- a/docs/modules/ROOT/pages/foundry/pages/foundry-defender.adoc
+++ b/docs/modules/ROOT/pages/foundry/pages/foundry-defender.adoc
@@ -26,15 +26,13 @@ extra_output = ["storageLayout"]
 NOTE: Metadata must also be included in the compiler output, which it is by default.  
 
 [start=3]
-3. Set the following environment variables in your `.env` file at your project root, using your Team API key and secret from the OpenZeppelin Defender Deploy Environment (either Production or Test) that you configured:
+3. Set the following environment variables in your `.env` file at your project root, using your Team API key and secret from OpenZeppelin Defender:
 
 [source]
 ----
 DEFENDER_KEY=<Your API key>
 DEFENDER_SECRET=<Your API secret>
 ----
-
-NOTE: These API keys are specifically for the Deploy Environment (Production or Test) that you configured in Defender. You can obtain these keys from the Deploy module in Defender during the environment setup process. For more information, see https://docs.openzeppelin.com/defender/v2/tutorial/deploy#environment_setup.
 
 == Network Selection
 


### PR DESCRIPTION
## Description

This PR addresses the issue described in #996 by clarifying that the API keys referenced in the Defender integration documentation are specifically from the Production or Test Deploy Environment that was configured in Defender.

### Changes made:

- Updated `defender-deploy.adoc` to add a note explaining that the API keys are specifically from the Deploy Environment
- Updated `foundry-defender.adoc` to clarify that the API keys are from the Deploy Environment
- Added links to the Defender tutorial's environment setup documentation in both files

### Fixes

Closes #996 

### Checklist

- [x] Documentation update only
- [x] Links to relevant documentation added
- [x] Maintained consistent style with existing documentation