### PR TITLE
Updates to support contract verification via etherscan V2 API

### DIFF
--- a/.changeset/witty-zebras-fold.md
+++ b/.changeset/witty-zebras-fold.md
@@ -2,9 +2,8 @@
 '@openzeppelin/hardhat-upgrades': patch
 ---
 
-Support contract verification via etherscan V2 API. Update peer dependencies to include Pectra support.
+Support contract verification via etherscan V2 API.
 - **Potentially breaking changes**: Changes peer dependencies to the following:
-  - `"@nomicfoundation/hardhat-ethers": "^3.0.9"`
+  - `"@nomicfoundation/hardhat-ethers": "^3.0.6"`
   - `"@nomicfoundation/hardhat-verify": "^2.0.14"`
-  - `"ethers": "^6.14.0"`
   - `"hardhat": "^2.24.1"`

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-unicorn": "^51.0.0",
-    "ethers": "^6.14.0",
+    "ethers": "^6.8.1",
     "nyc": "^17.0.0",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0",

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -20,7 +20,7 @@
     "test:watch": "fgbg 'bash scripts/test.sh --watch' 'tsc -b --watch' --"
   },
   "devDependencies": {
-    "@nomicfoundation/hardhat-ethers": "^3.0.9",
+    "@nomicfoundation/hardhat-ethers": "^3.0.6",
     "@nomicfoundation/hardhat-verify": "^2.0.14",
     "@openzeppelin/contracts": "5.3.0",
     "@openzeppelin/contracts-upgradeable": "5.3.0",
@@ -45,9 +45,9 @@
     "undici": "^6.11.1"
   },
   "peerDependencies": {
-    "@nomicfoundation/hardhat-ethers": "^3.0.9",
+    "@nomicfoundation/hardhat-ethers": "^3.0.6",
     "@nomicfoundation/hardhat-verify": "^2.0.14",
-    "ethers": "^6.14.0",
+    "ethers": "^6.6.0",
     "hardhat": "^2.24.1"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,7 +1462,7 @@
     debug "^4.1.1"
     lodash.isequal "^4.5.0"
 
-"@nomicfoundation/hardhat-ethers@^3.0.9":
+"@nomicfoundation/hardhat-ethers@^3.0.6":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.9.tgz#a1fa5b123db39e4ee4ae86bee0e458e2b733ce02"
   integrity sha512-xBJdRUiCwKpr0OYrOzPwAyNGtsVzoBx32HFPJVv6S+sFA9TmBIBDaqNlFPmBH58ZjgNnGhEr/4oBZvGr4q4TjQ==
@@ -3940,7 +3940,7 @@ ethereumjs-util@^7.0.3, ethereumjs-util@^7.1.5:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@^6.14.0:
+ethers@^6.8.1:
   version "6.14.3"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.14.3.tgz#7c4443c165ee59b2964e691600fd4586004b2000"
   integrity sha512-qq7ft/oCJohoTcsNPFaXSQUm457MA5iWqkf1Mb11ujONdg7jBI6sAOrHaTi3j0CBqIGFSCeR/RMc+qwRRub7IA==


### PR DESCRIPTION
This PR adds support for contract verification via etherscan V2 API. 
- `hardhat-verify` dependency is updated to latest 
- `chainid` param is added in etherscan API call.

Fixes #1165 

