### PR TITLE
Contract Verification - Graceful failure on isBeacon check when using blockscout RPC.

### DIFF
--- a/packages/core/src/call-optional-signature.ts
+++ b/packages/core/src/call-optional-signature.ts
@@ -10,6 +10,7 @@ export async function callOptionalSignature(provider: EthereumProvider, address:
       e.message.includes('function selector was not recognized') ||
       e.message.includes('invalid opcode') ||
       e.message.includes('revert') ||
+      e.message.includes('Action not found') ||
       e.message.includes('execution error')
     ) {
       return undefined;


### PR DESCRIPTION
When verifying a non-beacon contract, the `verify` plugin will check if the `implementation()` call fails to determine if it's not a beacon. Unfortunately with a Blockscout eth-rpc the error message is different than the specified list, causing HH to assume there's something wrong with the RPC.

<img width="827" height="103" alt="rpc-error" src="https://github.com/user-attachments/assets/ab3f5be0-cc8d-455a-930a-e8ac0e90c43c" />

Adding this additional error message check supports the response coming back from `eth-rpc` found [here](https://github.com/blockscout/blockscout/blob/fab90607cb0c87c1695f0585640de82848b12196/apps/explorer/lib/explorer/eth_rpc.ex#L1304)