### PR TITLE
chore(license): update year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020-2025 Zeppelin Group Ltd
+Copyright (c) 2020-2026 Zeppelin Group Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
## Summary
Updated copyright year in LICENSE file(s).

**Before:** 2025
**After:** 2026

Routine maintenance to keep copyright notices up to date.