### PR TITLE
feat: Add validation for Foundry and Hardhat 3 build-info formats

### DIFF
--- a/packages/core/src/cli/validate/build-info-file.test.ts
+++ b/packages/core/src/cli/validate/build-info-file.test.ts
@@ -365,6 +365,41 @@ test.serial('invalid build info file', async t => {
   t.true(error?.message.includes('must contain Solidity compiler input, output, and solcVersion'));
 });
 
+test.serial('Foundry format (ethers-rs) with missing output suggests forge clean && forge build', async t => {
+  await fs.mkdir('foundry-format-missing', { recursive: true });
+
+  await fs.writeFile(
+    'foundry-format-missing/build.json',
+    JSON.stringify({
+      _format: 'ethers-rs-sol-build-info-1',
+      input: BUILD_INFO.input,
+      solcVersion: '0.8.31',
+      // output missing
+    }),
+  );
+  const error = await t.throwsAsync(getBuildInfoFiles('foundry-format-missing'));
+  t.true(error?.message.includes('must contain Solidity compiler input, output, and solcVersion'));
+  t.true(error?.message.includes('ethers-rs-sol-build-info'));
+  t.true(error?.message.includes('forge clean && forge build'));
+});
+
+test.serial('Hardhat 3 (HH3) format with missing .output.json suggests hardhat compile', async t => {
+  await fs.mkdir('hh3-format-missing-output', { recursive: true });
+
+  await fs.writeFile(
+    'hh3-format-missing-output/solc-0_8_0-abc123.json',
+    JSON.stringify({
+      _format: 'hh3-sol-build-info-1',
+      input: BUILD_INFO.input,
+      solcVersion: '0.8.9',
+      // output in separate .output.json which we do not create
+    }),
+  );
+  const error = await t.throwsAsync(getBuildInfoFiles('hh3-format-missing-output'));
+  t.true(error?.message.includes('could not be read') || error?.message.includes('missing Solidity compiler output'));
+  t.true(error?.message.includes('hardhat compile'));
+});
+
 test.serial('dir does not exist', async t => {
   const error = await t.throwsAsync(getBuildInfoFiles('invalid-dir'));
   t.true(error?.message.includes('does not exist'));

--- a/packages/core/src/cli/validate/build-info-file.ts
+++ b/packages/core/src/cli/validate/build-info-file.ts
@@ -151,6 +151,19 @@ async function readBuildInfo(buildInfoFilePaths: string[], dirShortName: string)
   return buildInfoFiles;
 }
 
+const FOUNDRY_BUILD_INFO_HELP = `\
+Foundry build-info files must contain Solidity compiler input, output, and solcVersion.
+Ensure foundry.toml has:
+  [profile.default]
+  build_info = true
+  extra_output = ["storageLayout"]
+Then run: ${FOUNDRY_COMPILE_COMMAND}`;
+
+const HH3_BUILD_INFO_HELP = `\
+Hardhat 3 (HH3) build-info uses a main .json file (input, solcVersion) and a separate .output.json (output).
+Ensure you have compiled with Hardhat 3 so that artifacts/build-info/ contains both the main files and the .output.json files.
+Then run: ${HARDHAT_COMPILE_COMMAND}`;
+
 async function loadBuildInfo(buildInfoFilePath: string): Promise<{
   input: SolcInput;
   output: SolcOutput;
@@ -172,75 +185,93 @@ async function loadBuildInfo(buildInfoFilePath: string): Promise<{
 
   const format = buildInfoJson._format as string | undefined;
 
+  // Foundry (ethers-rs-sol-build-info-1) normally has input, output, solcVersion at top level.
+  // If we reach here with Foundry format, a field is missing — suggest recompiling.
+  if (typeof format === 'string' && format.startsWith('ethers-rs-sol-build-info')) {
+    throw new ValidateCommandError(
+      `Build info file ${buildInfoFilePath} must contain Solidity compiler input, output, and solcVersion. Got format: ${format}.`,
+      () => FOUNDRY_BUILD_INFO_HELP,
+    );
+  }
+
   if (
     typeof format === 'string' &&
     (format.startsWith('hh3-sol-build-info') || format.startsWith('hh-sol-build-info'))
   ) {
-    if (buildInfoJson.input !== undefined && buildInfoJson.solcVersion !== undefined) {
-      let inputData: SolcInput = buildInfoJson.input;
-      let outputData: SolcOutput | undefined = buildInfoJson.output;
+    if (buildInfoJson.input === undefined || buildInfoJson.solcVersion === undefined) {
+      throw new ValidateCommandError(
+        `Build info file ${buildInfoFilePath} (Hardhat 3 format) must contain input and solcVersion. Got format: ${format}.`,
+        () => HH3_BUILD_INFO_HELP,
+      );
+    }
+    let inputData: SolcInput = buildInfoJson.input;
+    let outputData: SolcOutput | undefined = buildInfoJson.output;
+
+    if (outputData === undefined) {
+      const { dir, name } = path.parse(buildInfoFilePath);
+      const outputFilePath = path.join(dir, `${name}.output.json`);
+
+      try {
+        const outputJson = await readJSON(outputFilePath);
+        outputData = outputJson.output ?? outputJson;
+      } catch (error) {
+        throw new ValidateCommandError(
+          `Build info file ${buildInfoFilePath} does not contain output, and output file ${outputFilePath} could not be read.`,
+          () => HH3_BUILD_INFO_HELP,
+        );
+      }
 
       if (outputData === undefined) {
-        const { dir, name } = path.parse(buildInfoFilePath);
-        const outputFilePath = path.join(dir, `${name}.output.json`);
-
-        try {
-          const outputJson = await readJSON(outputFilePath);
-          outputData = outputJson.output ?? outputJson;
-        } catch (error) {
-          throw new ValidateCommandError(
-            `Build info file ${buildInfoFilePath} does not contain output, and output file ${outputFilePath} could not be read.`,
-          );
-        }
-
-        if (outputData === undefined) {
-          throw new ValidateCommandError(
-            `Build info file ${buildInfoFilePath} does not contain output, and output file ${outputFilePath} is missing Solidity compiler output.`,
-          );
-        }
+        throw new ValidateCommandError(
+          `Build info file ${buildInfoFilePath} does not contain output, and output file ${outputFilePath} is missing Solidity compiler output.`,
+          () => HH3_BUILD_INFO_HELP,
+        );
       }
-
-      const userSourceNameMap: Record<string, string> | undefined = buildInfoJson.userSourceNameMap;
-      if (userSourceNameMap !== undefined) {
-        const canonicalToUser: Record<string, string> = {};
-        for (const [userSource, canonicalSource] of Object.entries(userSourceNameMap)) {
-          canonicalToUser[canonicalSource] = userSource;
-        }
-
-        if (inputData.sources !== undefined) {
-          inputData = {
-            ...inputData,
-            sources: remapKeys(inputData.sources, canonicalToUser),
-          };
-        }
-
-        if (outputData.sources !== undefined) {
-          outputData = {
-            ...outputData,
-            sources: remapKeys(outputData.sources, canonicalToUser),
-            contracts:
-              outputData.contracts !== undefined
-                ? remapKeys(outputData.contracts, canonicalToUser)
-                : outputData.contracts,
-          };
-        } else if (outputData.contracts !== undefined) {
-          outputData = {
-            ...outputData,
-            contracts: remapKeys(outputData.contracts, canonicalToUser),
-          };
-        }
-      }
-
-      return {
-        input: inputData,
-        output: outputData,
-        solcVersion: buildInfoJson.solcVersion,
-      };
     }
+
+    const userSourceNameMap: Record<string, string> | undefined = buildInfoJson.userSourceNameMap;
+    if (userSourceNameMap !== undefined) {
+      const canonicalToUser: Record<string, string> = {};
+      for (const [userSource, canonicalSource] of Object.entries(userSourceNameMap)) {
+        canonicalToUser[canonicalSource] = userSource;
+      }
+
+      if (inputData.sources !== undefined) {
+        inputData = {
+          ...inputData,
+          sources: remapKeys(inputData.sources, canonicalToUser),
+        };
+      }
+
+      if (outputData.sources !== undefined) {
+        outputData = {
+          ...outputData,
+          sources: remapKeys(outputData.sources, canonicalToUser),
+          contracts:
+            outputData.contracts !== undefined
+              ? remapKeys(outputData.contracts, canonicalToUser)
+              : outputData.contracts,
+        };
+      } else if (outputData.contracts !== undefined) {
+        outputData = {
+          ...outputData,
+          contracts: remapKeys(outputData.contracts, canonicalToUser),
+        };
+      }
+    }
+
+    return {
+      input: inputData,
+      output: outputData,
+      solcVersion: buildInfoJson.solcVersion,
+    };
   }
 
+  const isHH3Dir = buildInfoFilePath.includes('artifacts' + path.sep + 'build-info');
+  const isFoundryDir = buildInfoFilePath.includes('out' + path.sep + 'build-info');
   throw new ValidateCommandError(
     `Build info file ${buildInfoFilePath} must contain Solidity compiler input, output, and solcVersion. Got format: ${format ?? 'unknown'}.`,
+    () => (isHH3Dir ? HH3_BUILD_INFO_HELP : isFoundryDir ? FOUNDRY_BUILD_INFO_HELP : ''),
   );
 }
 


### PR DESCRIPTION
We are having an issue with this PR https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1194 CI/CD that depends on a deployed core package; this could be the fix for it.

still investigating, not finished yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved build-info file validation with enhanced error messages for Foundry and Hardhat 3 formats.
  * Added format-specific guidance to direct users to appropriate remediation commands based on their build system.

* **Tests**
  * Added validation tests for missing build-info outputs across different build formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->