### PR TITLE
chore: Add Arbitrum Sepolia (chainId 421614) to the known network list

### DIFF
--- a/.changeset/rare-horses-type.md
+++ b/.changeset/rare-horses-type.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/upgrades-core': patch
+---
+
+Add Arbitrum Sepolia (chainId 421614) to the known network list

--- a/.changeset/rare-horses-type.md
+++ b/.changeset/rare-horses-type.md
@@ -2,4 +2,4 @@
 '@openzeppelin/upgrades-core': patch
 ---
 
-Add Arbitrum Sepolia (chainId 421614) to the known network list
+Add Arbitrum Sepolia network to manifest file names.

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -141,6 +141,7 @@ export const networkNames: { [chainId in number]?: string } = Object.freeze({
   42161: 'arbitrum-one',
   42170: 'arbitrum-nova',
   421613: 'arbitrum-goerli',
+  421614: 'arbitrum-sepolia',
   43113: 'avalanche-fuji',
   43114: 'avalanche',
   42220: 'celo',


### PR DESCRIPTION
Added support for Arbitrum Sepolia testnet in manifest file names.