### PR TITLE
fix(core): handle invalid bytecode in getUnlinkedBytecode for library-linked contracts

### DIFF
--- a/packages/core/src/validate/query.test.ts
+++ b/packages/core/src/validate/query.test.ts
@@ -46,3 +46,40 @@ test('getUnlinkedBytecode', t => {
 
   t.is(recovered, unlinkedBytecode);
 });
+
+test('getUnlinkedBytecode does not throw when build-info contains library-linked contracts', t => {
+  // Regression test for https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1227
+  // When a build-info file contains contracts with external library link references,
+  // getUnlinkedBytecode should not throw "Bytecode is not a valid hex string" for
+  // unrelated contracts that have no library dependencies.
+
+  // Target contract: simple bytecode with no library dependencies
+  const targetBytecode = '0x' + 'ab'.repeat(50); // 100 hex chars, valid hex
+
+  // A different contract has link references at offsets that fall within targetBytecode bounds
+  // Applying wrong link references corrupts the bytecode (produces non-hex strings)
+  const validation: Record<string, Partial<ContractValidation>> = {
+    LibraryLinkedContract: {
+      version: undefined, // different version, won't match
+      linkReferences: [
+        {
+          src: '',
+          name: '',
+          start: 1,  // within bounds of targetBytecode
+          length: 20,
+          placeholder: '__$5ae0c2211b657f8a7ca51e0b14f2a8333d$__',
+        },
+      ],
+    },
+    SimpleContract: {
+      version: getVersion(targetBytecode),
+      linkReferences: [], // no library dependencies
+    },
+  };
+
+  // Should not throw, should return targetBytecode unchanged since SimpleContract has no linkReferences
+  t.notThrows(() => {
+    const result = getUnlinkedBytecode(validation as ValidationRunData, targetBytecode);
+    t.is(result, targetBytecode);
+  });
+});

--- a/packages/core/src/validate/query.ts
+++ b/packages/core/src/validate/query.ts
@@ -130,10 +130,15 @@ export function getUnlinkedBytecode(data: ValidationData, bytecode: string): str
     for (const name of linkableContracts) {
       const { linkReferences } = validation[name];
       const unlinkedBytecode = unlinkBytecode(bytecode, linkReferences);
-      const version = getVersion(unlinkedBytecode);
+      try {
+        const version = getVersion(unlinkedBytecode);
 
-      if (validation[name].version?.withMetadata === version.withMetadata) {
-        return unlinkedBytecode;
+        if (validation[name].version?.withMetadata === version.withMetadata) {
+          return unlinkedBytecode;
+        }
+      } catch (e) {
+        // unlinkBytecode with wrong linkReferences can produce invalid bytecode — skip
+        continue;
       }
     }
   }

--- a/packages/core/src/validate/query.ts
+++ b/packages/core/src/validate/query.ts
@@ -129,8 +129,8 @@ export function getUnlinkedBytecode(data: ValidationData, bytecode: string): str
 
     for (const name of linkableContracts) {
       const { linkReferences } = validation[name];
-      const unlinkedBytecode = unlinkBytecode(bytecode, linkReferences);
       try {
+        const unlinkedBytecode = unlinkBytecode(bytecode, linkReferences);
         const version = getVersion(unlinkedBytecode);
 
         if (validation[name].version?.withMetadata === version.withMetadata) {


### PR DESCRIPTION
## Motivation
Fixes #1227

`getUnlinkedBytecode()` throws `"Bytecode is not a valid hex string"` when
a Hardhat build-info file contains contracts with external library link
references (e.g., `LockupLib`, `ERC3643BatchLib`), even when the contract
being deployed has no library dependencies.

## Root Cause
The function iterates over all contracts with `linkReferences` and applies
their link references to the target bytecode via `unlinkBytecode()`. When
wrong link references are applied, the resulting bytecode is corrupted.
`getVersion()` then throws on the invalid hex string before the version
check can determine it's not a match.

## Fix
Wrap the `getVersion()` call in a try/catch. When `unlinkBytecode()` with
wrong link references produces invalid bytecode, skip that candidate and
continue to the next one.

## Testing
Added regression test. All 588 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of bytecode validation to handle edge cases gracefully without interrupting the validation process.

* **Tests**
  * Added regression test to verify bytecode validation handles complex contract dependency scenarios correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-upgrades/pull/1246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->