### PR TITLE
Publish via npm OIDC trusted publishing, avoid submodule checkout in changeset workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,15 +1,25 @@
 name: Setup
 
+inputs:
+  node-version:
+    description: Node.js version to use
+    default: '22'
+  cache:
+    description: Whether to use dependency and compiler caches
+    default: 'true'
+
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: 22.x
-        cache: yarn
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache == 'true' && 'yarn' || '' }}
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Cache Hardhat solc compilers
-      uses: actions/cache@v4
+      if: ${{ inputs.cache == 'true' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/hardhat/compilers-v3

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0 # Include history so Changesets finds merge-base
-          submodules: recursive
+          # Submodules not needed: this job only checks for a changeset.
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Check changeset

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,9 +68,18 @@ jobs:
       - name: Configure npm auth
         run: |
           if [ "$HAS_NEW_PACKAGES" = "true" ]; then
+            # New packages aren't registered for OIDC trusted publishing yet, so
+            # authenticate with the npm token. setup-node's .npmrc reads it from
+            # NODE_AUTH_TOKEN.
             echo "NODE_AUTH_TOKEN=${NPM_TOKEN}" >> "$GITHUB_ENV"
           else
-            echo "NODE_AUTH_TOKEN=" >> "$GITHUB_ENV"
+            # Existing packages publish via OIDC trusted publishing. npm only
+            # falls through to OIDC when no _authToken is configured, so strip the
+            # line setup-node wrote to the npm userconfig. Removing it is enough:
+            # nothing downstream then reads NODE_AUTH_TOKEN.
+            if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+              sed -i '/_authToken=/d' "$NPM_CONFIG_USERCONFIG"
+            fi
           fi
         env:
           HAS_NEW_PACKAGES: ${{ steps.check-packages.outputs.has_new_packages }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           fetch-depth: 0 # To get all tags
           ref: ${{ github.ref }}
-          submodules: recursive
+          # Submodules are intentionally not checked out: publishing only builds
+          # the TypeScript packages, and commitMode: github-api rejects executable
+          # files anywhere in the working tree (e.g. forge-std scripts).
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Create Prepare Release PR or Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     runs-on: ubuntu-latest
     environment: publish
     steps:
@@ -23,6 +24,57 @@ jobs:
           # files anywhere in the working tree (e.g. forge-std scripts).
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          node-version: '24'
+          cache: 'false'
+      - name: Check for new packages
+        id: check-packages
+        run: |
+          : > "$RUNNER_TEMP/new_packages.txt"
+          while IFS=: read -r pkg dir; do
+            npm_stderr_file="$RUNNER_TEMP/npm-view-${pkg//[^a-zA-Z0-9]/_}.stderr"
+            if npm view "$pkg" version > /dev/null 2> "$npm_stderr_file"; then
+              echo "Existing package: $pkg"
+              rm -f "$npm_stderr_file"
+              continue
+            fi
+
+            npm_error="$(tr '\n' ' ' < "$npm_stderr_file")"
+            rm -f "$npm_stderr_file"
+
+            if [[ "$npm_error" == *"E404"* || "$npm_error" == *"404"* || "$npm_error" == *"Not Found"* ]]; then
+              echo "New package detected: $pkg ($dir)"
+              echo "$dir" >> "$RUNNER_TEMP/new_packages.txt"
+            else
+              echo "::error::npm view failed for $pkg: ${npm_error:-Unknown error}"
+              exit 1
+            fi
+          done < <(yarn workspaces --json info | node -e "
+            const info = JSON.parse(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).data);
+            for (const [name, meta] of Object.entries(info)) {
+              const pkgJson = require('./' + meta.location + '/package.json');
+              if (!pkgJson.private) console.log(name + ':' + meta.location);
+            }
+          ")
+
+          has_new_packages=false
+          if [ -s "$RUNNER_TEMP/new_packages.txt" ]; then
+            echo "::notice::New packages detected — will use NPM token for publish"
+            has_new_packages=true
+          else
+            echo "All packages exist on npm — using OIDC trusted publishing"
+          fi
+          echo "has_new_packages=$has_new_packages" >> "$GITHUB_OUTPUT"
+      - name: Configure npm auth
+        run: |
+          if [ "$HAS_NEW_PACKAGES" = "true" ]; then
+            echo "NODE_AUTH_TOKEN=${NPM_TOKEN}" >> "$GITHUB_ENV"
+          else
+            echo "NODE_AUTH_TOKEN=" >> "$GITHUB_ENV"
+          fi
+        env:
+          HAS_NEW_PACKAGES: ${{ steps.check-packages.outputs.has_new_packages }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Prepare Release PR or Publish
         id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
@@ -34,7 +86,7 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
       - name: Check changesets status
         if: steps.changesets.outputs.hasChangesets == 'true'
         run: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           fetch-depth: 0 # To get all tags
           ref: ${{ github.ref }}
-          submodules: recursive
+          # Submodules are intentionally not checked out: the Prepare Release PR
+          # job only runs `changeset version`, and commitMode: github-api rejects
+          # executable files anywhere in the working tree (e.g. forge-std scripts).
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Create Prepare Release PR


### PR DESCRIPTION
## Summary

Hardens the release workflows and switches publishing to npm OIDC trusted
publishing. Originally scoped to dropping the recursive submodule checkout;
now also covers the OIDC migration and workflow-hardening review feedback.

## Changes

### Don't checkout submodules in release workflows (`version.yml`, `publish.yml`, `changeset.yml`)
These jobs only run changeset version/publish/check and build the TypeScript
packages — they don't need submodules. The recursive checkout was a temporary
workaround for a `yarn install` crash back when `package.json` referenced
foundry-upgrades via the submodule; it now uses the published registry version.
It was also breaking releases: `commitMode: github-api` rejects executable files
anywhere in the working tree, and the nested forge-std submodule ships one
(`scripts/vm.py`). `checks.yml` keeps its submodule checkout (Solidity-test
integration + docs generation) and is untouched.

### OIDC trusted publishing (`publish.yml`)
Publishes authenticate via OIDC for existing packages, with an npm token used
only as a fallback for new packages; provenance enabled. The publish job runs
on Node 24 (required for OIDC / npm ≥ 11.5.1).

### Workflow hardening (review feedback)
- Disable dependency and compiler caching in the publish job.
- Pin `setup-node` and `cache` to commit SHAs instead of mutable `v4` tags.
