### PR TITLE
Fix publish: skip yarn engine check on the Node 24 job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,11 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     environment: publish
+    # The publish job runs on Node 24 (required for npm OIDC), but some dev-only
+    # test deps cap at Node 22. Publishing only builds and ships the packages and
+    # never runs those tools, so skip yarn's engine check for this job.
+    env:
+      YARN_IGNORE_ENGINES: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:


### PR DESCRIPTION
The publish job runs on Node 24 (required for npm OIDC), but a dev-only
test dep (`@ava/typescript@5`, in upgrades) caps at Node 22, so
`yarn install --frozen-lockfile` aborts the job on the engine mismatch.

Set `YARN_IGNORE_ENGINES: true` at the publish-job level so yarn skips
the engine check for both installs (setup action + publish.sh). Scoped to
the publish job only; test/version/changeset jobs (Node 22) are unaffected.

Safe because publishing only builds (tsc/hardhat) and ships the packages —
it never runs ava — and `--frozen-lockfile` means versions are unchanged.
Follow-up: bump `@ava/typescript` to ^6 (supports Node 24) and drop this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publish workflow configuration to improve release process reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-upgrades/pull/1251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->