### PR TITLE
Fix plugin publish: force tsc rebuild so core/dist is always built

### DIFF
--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "compile": "tsc -b && hardhat compile",
+    "compile": "tsc -b --force && hardhat compile",
     "prepare": "yarn compile",
     "test": "tsc -b && bash scripts/test.sh",
     "test:watch": "fgbg 'bash scripts/test.sh --watch' 'tsc -b --watch' --",


### PR DESCRIPTION
## Problem

`changeset publish` published `@openzeppelin/upgrades-core@1.45.0`, then failed
publishing `@openzeppelin/hardhat-upgrades@4.0.0` during the plugin's `prepare`:

  Cannot find package '.../node_modules/@openzeppelin/upgrades-core/dist/index.js'
  imported from '.../packages/plugin-hardhat/dist/utils/factory.js'

## Root cause

The plugin's `prepare` runs `tsc -b && hardhat compile`, and two things combine:

1. **The build now executes compiled output.** Under Hardhat 3 the plugin's
   `hardhat.config.ts` imports the built plugin (`./dist/index.js`), which imports
   `@openzeppelin/upgrades-core` → the yarn workspace symlink → local
   `packages/core/dist/index.js`. So `hardhat compile` requires `core/dist` to
   exist and be loadable. (Under HH2, `prepare` was just `tsc -b`, which only
   type-checks and never loads compiled code — which is why this never surfaced.)

2. **`tsc -b` is incremental and trusts `.tsbuildinfo` over the filesystem.** If
   `core/dist` is missing but `core/tsconfig.tsbuildinfo` still says core is
   up-to-date, `tsc -b` skips rebuilding core. The subsequent `hardhat compile`
   then can't load `core/dist/index.js`.

During the multi-package publish, `core/dist` was absent while its `.tsbuildinfo`
survived, so the plugin's `tsc -b` skipped rebuilding core and the load failed.

## Fix

Use `tsc -b --force` in the plugin's `compile`, so it ignores stale
`.tsbuildinfo` and rebuilds the whole project graph — including the referenced
`core` project — guaranteeing `core/dist` exists before `hardhat compile`.

## Why this is the right fix

- It matches the actual invariant: a build that *runs* compiled output must
  *produce* that output deterministically, not rely on incremental state.
- It's correct for the re-publish: `core@1.45.0` is already on npm, so the next
  run publishes only the plugin and core's own `prepare` won't run — `--force`
  makes the plugin's build rebuild `core/dist` itself rather than depending on it.
- Minimal and safe: `compile` only runs inside the monorepo (dev + `prepare`),
  never for consumers installing from npm; it changes no published bytes and adds
  a couple seconds to the build.
- Nothing else needs it: core's `prepare` already cleans first (no stale
  tsbuildinfo) and its config imports `src` not `dist`; other `tsc -b` sites
  aren't in the publish path.

Reproduced locally: deleting `core/dist` (keeping `.tsbuildinfo`) makes the
plugin's `tsc -b` skip core and fail; `tsc -b --force` rebuilds it and succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script configuration to optimize compilation performance in the Hardhat plugin.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-upgrades/pull/1252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->