### PR TITLE
Fix concurrent-publish race in package build scripts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "compile": "tsc -b && yarn compile:contracts",
     "compile:contracts": "hardhat compile",
     "copyfiles": "node scripts/copy-build-info-v5.js && bash scripts/copy-legacy-artifacts.sh",
-    "prepare": "yarn clean && yarn compile && yarn copyfiles",
+    "prepare": "yarn compile && yarn copyfiles",
     "pretest": "tsc -b && hardhat compile --force && yarn copyfiles",
     "test": "ava",
     "test:update-snapshots": "yarn test --update-snapshots",

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -23,8 +23,8 @@
   },
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "compile": "tsc -b --force && hardhat compile",
-    "prepare": "yarn compile",
+    "compile": "tsc -b && hardhat compile",
+    "prepare": "tsc -b",
     "test": "tsc -b && bash scripts/test.sh",
     "test:watch": "fgbg 'bash scripts/test.sh --watch' 'tsc -b --watch' --",
     "test:examples": "cd examples/BoxTransparent && npm install && npm test && cd ../BoxUUPS && npm install && npm test && cd ../BoxSolidityTests && npm install && npm test"


### PR DESCRIPTION
## Problem
`changeset publish` runs each package's `prepare` concurrently. **core**'s `prepare` deleted `core/dist` (via `yarn clean`) while **plugin-hardhat**'s `prepare` ran `hardhat compile`, which loads `core/dist` — so co-releases intermittently failed with `Cannot find package …/upgrades-core/dist/index.js`.

## Root cause
In **plugin-hardhat**, `prepare` delegated to `compile`, so the publishable build inherited a dev/test step — `hardhat compile`, which loads `core/dist`. Run concurrently by `changeset publish`, that load raced **core**'s `prepare`, which cleans `core/dist`.

## Fix — separate `prepare` (the publishable build) from `compile` (the dev/test build)
- **plugin-hardhat `prepare`** now does only the TypeScript build, so the publishable build no longer runs `hardhat compile` and never loads `core/dist`.
- **core `prepare`** no longer cleans, so it no longer deletes `core/dist` mid-publish.
- **plugin-hardhat `compile`** still runs `hardhat compile` to build the plugin's test contracts — that step is just no longer pulled into the publishable `prepare`.

With each entry point owning its purpose, the concurrent prepares no longer touch each other's output. `publish.sh` is unchanged, and published artifacts are identical (verified via `npm pack` file lists).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration in core package. The `prepare` script now compiles before copying build artifacts instead of just cleaning.
  * Updated build configuration in Hardhat plugin package. The `compile` script adjusted to use TypeScript build without force flag, and `prepare` script now runs TypeScript compilation directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->