### PR TITLE
Rename to hre.network.create() in markdown docs

### DIFF
--- a/packages/plugin-hardhat/CHANGELOG.md
+++ b/packages/plugin-hardhat/CHANGELOG.md
@@ -16,7 +16,7 @@
   - **API Changes**:
     - No automatic `hre.upgrades` — call the `upgrades(hre, connection)` factory explicitly.
     - Factory functions (`upgrades`, `defender`) are async and require a network connection.
-    - Network connection must be explicitly created: `const connection = await hre.network.connect()`. Share one connection across operations.
+    - Network connection must be explicitly created: `const connection = await hre.network.create()`. Share one connection across operations.
     - `ethers` now comes from the connection (`const { ethers } = connection`), not `hre.ethers`.
   - **Import Changes**: import factory functions instead of a side-effect import.
     - Before: `import '@openzeppelin/hardhat-upgrades'`

--- a/packages/plugin-hardhat/MIGRATION.md
+++ b/packages/plugin-hardhat/MIGRATION.md
@@ -81,7 +81,7 @@ await hre.upgrades.deployProxy(MyContract, []);
 
 **After:**
 ```typescript
-const connection = await hre.network.connect();
+const connection = await hre.network.create();
 const upgradesApi = await upgrades(hre, connection);
 await upgradesApi.deployProxy(MyContract, []);
 ```
@@ -100,7 +100,7 @@ import hre from 'hardhat';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
   
@@ -121,7 +121,7 @@ import { task } from 'hardhat/config';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
 task('deploy', async (args, hre) => {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
   const MyContract = await ethers.getContractFactory('MyContract');
@@ -156,7 +156,7 @@ describe('MyContract', () => {
   let ethers;
   
   before(async () => {
-    const connection = await hre.network.connect();
+    const connection = await hre.network.create();
     ({ ethers } = connection);
     upgradesApi = await upgrades(hre, connection);
   });
@@ -173,7 +173,7 @@ describe('MyContract', () => {
 import hre from 'hardhat';
 import { upgrades, defender } from '@openzeppelin/hardhat-upgrades';
 
-const connection = await hre.network.connect();
+const connection = await hre.network.create();
 const { ethers } = connection;
 const upgradesApi = await upgrades(hre, connection);
 const defenderApi = await defender(hre, connection);
@@ -208,7 +208,7 @@ Note that you do not need to include constructor arguments when verifying if you
 - Add `hardhatUpgrades` to `plugins` in `hardhat.config.ts`
 - If using `verify`, add `hardhatVerify` to `plugins`, install `@nomicfoundation/hardhat-verify`, and configure Hardhat's `verify.etherscan.apiKey` setting
 - Replace `import '@openzeppelin/hardhat-upgrades'` → `import { upgrades, defender } from '@openzeppelin/hardhat-upgrades'` in scripts/tests
-- Add `const connection = await hre.network.connect();` (share connection across operations, don't create new ones)
+- Add `const connection = await hre.network.create();` (share connection across operations, don't create new ones)
 - Replace `hre.ethers` → `ethers` from connection (`const { ethers } = connection`)
 - Replace `hre.upgrades.method()` → call methods from `const upgradesApi = await upgrades(hre, connection)`
 - Replace `hre.defender.method()` → call methods from `const defenderApi = await defender(hre, connection)`

--- a/packages/plugin-hardhat/README.md
+++ b/packages/plugin-hardhat/README.md
@@ -43,7 +43,7 @@ import { upgrades } from "@openzeppelin/hardhat-upgrades";
 
 async function main() {
   // Create connection once and reuse for all operations
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
   
@@ -70,7 +70,7 @@ import hre from "hardhat";
 import { upgrades } from "@openzeppelin/hardhat-upgrades";
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
   
@@ -96,7 +96,7 @@ import hre from "hardhat";
 import { upgrades } from "@openzeppelin/hardhat-upgrades";
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
   
@@ -122,7 +122,7 @@ import hre from "hardhat";
 import { upgrades } from "@openzeppelin/hardhat-upgrades";
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
   
@@ -154,7 +154,7 @@ describe("Box", function() {
   let ethers;
 
   before(async () => {
-    const connection = await hre.network.connect();
+    const connection = await hre.network.create();
     ({ ethers } = connection);
     upgradesApi = await upgrades(hre, connection);
   });
@@ -184,7 +184,7 @@ describe("Box", function() {
   let ethers;
 
   before(async () => {
-    const connection = await hre.network.connect();
+    const connection = await hre.network.create();
     ({ ethers } = connection);
     upgradesApi = await upgrades(hre, connection);
   });


### PR DESCRIPTION
Use hre.network.create() instead of the deprecated hre.network.connect() in the README, MIGRATION guide, and changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hardhat 3 migration documentation (CHANGELOG, MIGRATION guide, and README) with corrected network connection setup examples throughout. All code samples across scripts, tasks, tests, and proxy deployment scenarios now demonstrate the accurate API method for properly creating and managing shared network connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->