### PR TITLE
Re-export hardhat-ethers from hardhat-upgrades

### DIFF
--- a/.changeset/reexport-hardhat-ethers-types.md
+++ b/.changeset/reexport-hardhat-ethers-types.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/hardhat-upgrades': patch
+---
+
+Re-export `@nomicfoundation/hardhat-ethers` types so that TypeScript recognizes `connection.ethers` when only this plugin is registered.

--- a/packages/plugin-hardhat/MIGRATION.md
+++ b/packages/plugin-hardhat/MIGRATION.md
@@ -17,7 +17,7 @@ If upgrading from a previous version, ensure these packages are in your `devDepe
 npm install --save-dev hardhat @nomicfoundation/hardhat-ethers
 ```
 
-> **Using viem?** You can install both `@nomicfoundation/hardhat-ethers` and `@nomicfoundation/hardhat-viem`. The upgrades plugin uses ethers internally; your own scripts and tests can still use viem.
+> **Using viem?** You can install both `@nomicfoundation/hardhat-ethers` and `@nomicfoundation/hardhat-viem`. The upgrades plugin uses ethers internally; your own scripts and tests can still use viem. Note that the plugin's functions take ethers contract factories and return ethers contracts, so use `connection.ethers` when calling them.
 
 ## Migration
 

--- a/packages/plugin-hardhat/README.md
+++ b/packages/plugin-hardhat/README.md
@@ -14,7 +14,7 @@ npm install --save-dev @openzeppelin/hardhat-upgrades
 npm install --save-dev @nomicfoundation/hardhat-ethers ethers # peer dependencies
 ```
 
-> **Note:** Hardhat 3 supports both ethers and viem. This plugin uses `@nomicfoundation/hardhat-ethers` internally and loads it automatically. If your project uses viem, install `@nomicfoundation/hardhat-viem` and add it to your config alongside this plugin.
+> **Note:** Hardhat 3 supports both ethers and viem. This plugin uses `@nomicfoundation/hardhat-ethers` internally and loads it automatically. If your project uses viem, install `@nomicfoundation/hardhat-viem` and add it to your config alongside this plugin: your own scripts and tests can use viem, while the plugin's functions take ethers contract factories from `connection.ethers` and return ethers contracts.
 
 Register the `@openzeppelin/hardhat-upgrades` plugin in your [`hardhat.config.ts`](https://hardhat.org/config/):
 

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -25,9 +25,10 @@
     "clean": "rimraf dist *.tsbuildinfo",
     "compile": "tsc -b && hardhat compile",
     "prepare": "tsc -b",
-    "test": "tsc -b && bash scripts/test.sh",
+    "test": "tsc -b && tsc --noEmit -p test/types && bash scripts/test.sh",
     "test:watch": "fgbg 'bash scripts/test.sh --watch' 'tsc -b --watch' --",
-    "test:examples": "cd examples/BoxTransparent && npm install && npm test && cd ../BoxUUPS && npm install && npm test && cd ../BoxSolidityTests && npm install && npm test"
+    "test:examples": "cd examples/BoxTransparent && npm install && npm test && cd ../BoxUUPS && npm install && npm test && cd ../BoxSolidityTests && npm install && npm test",
+    "test:types": "tsc -b && tsc --noEmit -p test/types"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^4.0.0",

--- a/packages/plugin-hardhat/src/type-extensions.ts
+++ b/packages/plugin-hardhat/src/type-extensions.ts
@@ -3,6 +3,11 @@ import 'hardhat/types/hre';
 import type { HardhatUpgrades, DefenderHardhatUpgrades } from './types.js';
 import type { ContractFactory } from 'ethers';
 
+// Re-export the types of @nomicfoundation/hardhat-ethers, which this plugin loads as a
+// plugin dependency at runtime, so that `connection.ethers` is recognized by TypeScript
+// without requiring users to register the hardhat-ethers plugin themselves.
+export type * from '@nomicfoundation/hardhat-ethers';
+
 export type ContractTypeOfFactory<F extends ContractFactory> = ReturnType<F['attach']> & ReturnType<F['deploy']>;
 
 export interface HardhatDefenderConfig {

--- a/packages/plugin-hardhat/test/types/connection-ethers.ts
+++ b/packages/plugin-hardhat/test/types/connection-ethers.ts
@@ -1,0 +1,20 @@
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
+
+/**
+ * Regression test for the re-export of @nomicfoundation/hardhat-ethers types from this plugin.
+ *
+ * This file is type-checked (not executed) against the built `dist` types via the tsconfig in
+ * this directory, in isolation from the rest of the repo. It asserts that importing only
+ * `@openzeppelin/hardhat-upgrades` is enough for TypeScript to recognize `connection.ethers`,
+ * matching the runtime behavior where the plugin loads hardhat-ethers as a plugin dependency.
+ */
+export async function typeCheck(): Promise<void> {
+  const connection = await hre.network.create();
+  const { ethers } = connection;
+  const upgradesApi = await upgrades(hre, connection);
+
+  const factory = await ethers.getContractFactory('MyContract');
+  const proxy = await upgradesApi.deployProxy(factory, [42]);
+  await proxy.getAddress();
+}

--- a/packages/plugin-hardhat/test/types/tsconfig.json
+++ b/packages/plugin-hardhat/test/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["./*.ts"]
+}


### PR DESCRIPTION
The plugin loads `@nomicfoundation/hardhat-ethers` at runtime as a plugin dependency, but its published types do not reference it, so TypeScript does not recognize `connection.ethers` unless the project registers hardhat-ethers itself or casts the connection. This re-exports the hardhat-ethers types from the plugin (same pattern as `@nomicfoundation/hardhat-ignition-ethers`), making `plugins: [hardhatUpgrades]` sufficient for both runtime and types.

Also:
- Adds a type test that compiles a consumer-style fixture against the built `dist` in an isolated program, wired into `npm test`. Runtime tests pass with or without the re-export, so this is the only automated check that can catch a regression here.
- Adds one clarifying sentence to the viem callouts in README/MIGRATION (matches OpenZeppelin/docs#180).

A follow-up after release will remove the `as any` workarounds from the example projects and bump their lockfiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TypeScript types for ethers are now re-exported, enabling seamless type recognition when using the plugin without separately registering the hardhat-ethers plugin.

* **Documentation**
  * Updated migration guide with expanded viem setup instructions and clarification on plugin dependencies for Hardhat 3.
  * Clarified README guidance on installing and configuring hardhat-ethers and hardhat-viem together.

* **Tests**
  * Added type-checking test to verify TypeScript compatibility with ethers integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->