### PR TITLE
Update examples to hardhat-upgrades 4.0.2 and remove connection casts

### DIFF
--- a/packages/plugin-hardhat/examples/BoxSolidityTests/package-lock.json
+++ b/packages/plugin-hardhat/examples/BoxSolidityTests/package-lock.json
@@ -12,7 +12,7 @@
         "@openzeppelin/contracts": "^5.6.1",
         "@openzeppelin/contracts-upgradeable": "^5.6.1",
         "@openzeppelin/foundry-upgrades": "^0.4.1",
-        "@openzeppelin/hardhat-upgrades": "^4.0.0",
+        "@openzeppelin/hardhat-upgrades": "^4.0.2",
         "forge-std": "github:foundry-rs/forge-std#semver:^1.9.5",
         "hardhat": "^3.6.0",
         "tsx": "^4.7.0",
@@ -1239,10 +1239,11 @@
       }
     },
     "node_modules/@openzeppelin/hardhat-upgrades": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-4.0.1.tgz",
-      "integrity": "sha512-1rr6B5IHDr7GH4Dcq0IW2Tv2rb41gH5VhraUgMuFbwyaMji0dUDfjK2SVCWct6MQ+k70l0rdb8Xm9HXzh957eA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-4.0.2.tgz",
+      "integrity": "sha512-KF9y2Wv+4G3doi6HTw2EFZydP8GR7vfmQpoDpChXZ3kEcSaSO5LoU7OB+d6owqSDh5s4ik2tzEOHDqwWfdw6Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@openzeppelin/defender-sdk-base-client": "^2.1.0",
         "@openzeppelin/defender-sdk-deploy-client": "^2.1.0",

--- a/packages/plugin-hardhat/examples/BoxSolidityTests/package.json
+++ b/packages/plugin-hardhat/examples/BoxSolidityTests/package.json
@@ -11,7 +11,7 @@
     "@openzeppelin/contracts": "^5.6.1",
     "@openzeppelin/contracts-upgradeable": "^5.6.1",
     "@openzeppelin/foundry-upgrades": "^0.4.1",
-    "@openzeppelin/hardhat-upgrades": "^4.0.0",
+    "@openzeppelin/hardhat-upgrades": "^4.0.2",
     "forge-std": "github:foundry-rs/forge-std#semver:^1.9.5",
     "hardhat": "^3.6.0",
     "tsx": "^4.7.0",

--- a/packages/plugin-hardhat/examples/BoxTransparent/package-lock.json
+++ b/packages/plugin-hardhat/examples/BoxTransparent/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-ethers": "^4.0.2",
         "@openzeppelin/contracts-upgradeable": "^5.6.1",
-        "@openzeppelin/hardhat-upgrades": "^4.0.0",
+        "@openzeppelin/hardhat-upgrades": "^4.0.2",
         "ava": "^6.0.0",
         "ethers": "^6.8.1",
         "hardhat": "^3.6.0",
@@ -1298,10 +1298,11 @@
       }
     },
     "node_modules/@openzeppelin/hardhat-upgrades": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-4.0.1.tgz",
-      "integrity": "sha512-1rr6B5IHDr7GH4Dcq0IW2Tv2rb41gH5VhraUgMuFbwyaMji0dUDfjK2SVCWct6MQ+k70l0rdb8Xm9HXzh957eA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-4.0.2.tgz",
+      "integrity": "sha512-KF9y2Wv+4G3doi6HTw2EFZydP8GR7vfmQpoDpChXZ3kEcSaSO5LoU7OB+d6owqSDh5s4ik2tzEOHDqwWfdw6Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@openzeppelin/defender-sdk-base-client": "^2.1.0",
         "@openzeppelin/defender-sdk-deploy-client": "^2.1.0",

--- a/packages/plugin-hardhat/examples/BoxTransparent/package.json
+++ b/packages/plugin-hardhat/examples/BoxTransparent/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^4.0.2",
     "@openzeppelin/contracts-upgradeable": "^5.6.1",
-    "@openzeppelin/hardhat-upgrades": "^4.0.0",
+    "@openzeppelin/hardhat-upgrades": "^4.0.2",
     "ava": "^6.0.0",
     "ethers": "^6.8.1",
     "hardhat": "^3.6.0",

--- a/packages/plugin-hardhat/examples/BoxTransparent/test/upgrade.test.ts
+++ b/packages/plugin-hardhat/examples/BoxTransparent/test/upgrade.test.ts
@@ -3,7 +3,7 @@ import hre from 'hardhat';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
 const connection = await hre.network.create();
-const { ethers } = connection as any;
+const { ethers } = connection;
 const upgradesApi = await upgrades(hre, connection);
 
 test.after.always(() => connection.close());

--- a/packages/plugin-hardhat/examples/BoxUUPS/package-lock.json
+++ b/packages/plugin-hardhat/examples/BoxUUPS/package-lock.json
@@ -11,7 +11,7 @@
         "@nomicfoundation/hardhat-ethers": "^4.0.2",
         "@openzeppelin/contracts": "^5.6.1",
         "@openzeppelin/contracts-upgradeable": "^5.6.1",
-        "@openzeppelin/hardhat-upgrades": "^4.0.0",
+        "@openzeppelin/hardhat-upgrades": "^4.0.2",
         "ava": "^6.0.0",
         "ethers": "^6.8.1",
         "hardhat": "^3.6.0",
@@ -1298,10 +1298,11 @@
       }
     },
     "node_modules/@openzeppelin/hardhat-upgrades": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-4.0.1.tgz",
-      "integrity": "sha512-1rr6B5IHDr7GH4Dcq0IW2Tv2rb41gH5VhraUgMuFbwyaMji0dUDfjK2SVCWct6MQ+k70l0rdb8Xm9HXzh957eA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-4.0.2.tgz",
+      "integrity": "sha512-KF9y2Wv+4G3doi6HTw2EFZydP8GR7vfmQpoDpChXZ3kEcSaSO5LoU7OB+d6owqSDh5s4ik2tzEOHDqwWfdw6Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@openzeppelin/defender-sdk-base-client": "^2.1.0",
         "@openzeppelin/defender-sdk-deploy-client": "^2.1.0",

--- a/packages/plugin-hardhat/examples/BoxUUPS/package.json
+++ b/packages/plugin-hardhat/examples/BoxUUPS/package.json
@@ -12,7 +12,7 @@
     "@nomicfoundation/hardhat-ethers": "^4.0.2",
     "@openzeppelin/contracts": "^5.6.1",
     "@openzeppelin/contracts-upgradeable": "^5.6.1",
-    "@openzeppelin/hardhat-upgrades": "^4.0.0",
+    "@openzeppelin/hardhat-upgrades": "^4.0.2",
     "ava": "^6.0.0",
     "ethers": "^6.8.1",
     "hardhat": "^3.6.0",

--- a/packages/plugin-hardhat/examples/BoxUUPS/test/upgrade.test.ts
+++ b/packages/plugin-hardhat/examples/BoxUUPS/test/upgrade.test.ts
@@ -3,7 +3,7 @@ import hre from 'hardhat';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
 const connection = await hre.network.create();
-const { ethers } = connection as any;
+const { ethers } = connection;
 const upgradesApi = await upgrades(hre, connection);
 
 test.after.always(() => connection.close());


### PR DESCRIPTION
`@openzeppelin/hardhat-upgrades` 4.0.2 re-exports the hardhat-ethers types (#1275), so the examples no longer need `as any` on the network connection. Bumps the examples to `^4.0.2`, updates their lockfiles, and removes the casts. Verified against the published package: `npm test` passes in all three examples and `tsc --noEmit` is clean in BoxUUPS and BoxTransparent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the `@openzeppelin/hardhat-upgrades` development dependency to version 4.0.2 in example projects.

* **Refactor**
  * Enhanced type safety in upgrade test examples through improved connection variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->