### PR TITLE
core, plugin-hardhat: replace ethereumjs-util with ethereum-cryptography

### DIFF
--- a/.changeset/drop-ethereumjs-util.md
+++ b/.changeset/drop-ethereumjs-util.md
@@ -1,0 +1,6 @@
+---
+"@openzeppelin/upgrades-core": patch
+"@openzeppelin/hardhat-upgrades": patch
+---
+
+Replace the deprecated `ethereumjs-util` dependency with `ethereum-cryptography`, removing the transitive `secp256k1` and `elliptic` packages.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "compare-versions": "^6.0.0",
     "bignumber.js": "^9.1.2",
     "debug": "^4.1.1",
-    "ethereumjs-util": "^7.0.3",
+    "ethereum-cryptography": "^2.2.1",
     "minimist": "^1.2.7",
     "proper-lockfile": "^4.1.1",
     "solidity-ast": "^0.4.60",

--- a/packages/core/src/call-optional-signature.ts
+++ b/packages/core/src/call-optional-signature.ts
@@ -1,4 +1,4 @@
-import { keccak256 } from 'ethereumjs-util';
+import { keccak256 } from './utils/keccak256';
 import { call, EthereumProvider } from './provider';
 
 export async function callOptionalSignature(provider: EthereumProvider, address: string, signature: string) {

--- a/packages/core/src/eip-1967.ts
+++ b/packages/core/src/eip-1967.ts
@@ -1,4 +1,4 @@
-import { keccak256 } from 'ethereumjs-util';
+import { keccak256 } from './utils/keccak256';
 import { UpgradesError } from './error';
 import { EthereumProvider, getStorageAt } from './provider';
 import { parseAddress } from './utils/address';

--- a/packages/core/src/utils/address.ts
+++ b/packages/core/src/utils/address.ts
@@ -1,4 +1,26 @@
-import { toChecksumAddress } from 'ethereumjs-util';
+import { keccak256 } from './keccak256';
+
+/**
+ * Converts an address to its EIP-55 checksummed representation.
+ *
+ * Replaces `toChecksumAddress` previously imported from `ethereumjs-util`. Unlike that
+ * implementation, this intentionally omits input hex-string validation and the optional
+ * EIP-1191 chain id: the only caller (`parseAddress` below) always passes a well-formed
+ * `0x`-prefixed 20-byte address and never needs chain-specific checksums. Output matches
+ * the standard EIP-55 algorithm byte-for-byte.
+ *
+ * @param address A hex address string (with or without the `0x` prefix).
+ * @returns The EIP-55 checksummed address.
+ */
+function toChecksumAddress(address: string): string {
+  const lowerCase = address.toLowerCase().replace(/^0x/, '');
+  const hash = keccak256(Buffer.from(lowerCase, 'utf8')).toString('hex');
+  let checksummed = '0x';
+  for (let i = 0; i < lowerCase.length; i++) {
+    checksummed += parseInt(hash[i], 16) >= 8 ? lowerCase[i].toUpperCase() : lowerCase[i];
+  }
+  return checksummed;
+}
 
 /**
  * Parses an address from a hex string which may come from storage or a returned address via eth_call.

--- a/packages/core/src/utils/erc7201.ts
+++ b/packages/core/src/utils/erc7201.ts
@@ -1,5 +1,4 @@
-import { keccak256 } from 'ethereumjs-util';
-
+import { keccak256 } from './keccak256';
 import { toBytes32Hex } from './integer-literals';
 
 export const ERC7201_FORMULA_PREFIX = 'erc7201:';

--- a/packages/core/src/utils/keccak256.ts
+++ b/packages/core/src/utils/keccak256.ts
@@ -1,0 +1,12 @@
+import { keccak256 as nobleKeccak256 } from 'ethereum-cryptography/keccak';
+
+/**
+ * Computes the keccak256 hash of the input and returns it as a Node.js Buffer.
+ *
+ * Drop-in replacement for the `keccak256` previously imported from `ethereumjs-util`,
+ * preserving the Buffer return type (and therefore the `.toString('hex', start, end)`
+ * semantics) that callers rely on.
+ */
+export function keccak256(data: Uint8Array): Buffer {
+  return Buffer.from(nobleKeccak256(data));
+}

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,4 +1,4 @@
-import { keccak256 } from 'ethereumjs-util';
+import { keccak256 } from './utils/keccak256';
 import cbor from 'cbor';
 
 export interface Version {

--- a/packages/plugin-hardhat/package.json
+++ b/packages/plugin-hardhat/package.json
@@ -65,7 +65,7 @@
     "@openzeppelin/upgrades-core": "^1.45.0",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",
-    "ethereumjs-util": "^7.1.5",
+    "ethereum-cryptography": "^2.2.1",
     "proper-lockfile": "^4.1.1",
     "undici": "^8.3.0"
   }

--- a/packages/plugin-hardhat/src/verify-proxy.ts
+++ b/packages/plugin-hardhat/src/verify-proxy.ts
@@ -21,7 +21,7 @@ import UpgradeableBeacon from '@openzeppelin/upgrades-core/artifacts/@openzeppel
 import TransparentUpgradeableProxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts-v5/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json';
 import ProxyAdmin from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts-v5/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json';
 
-import { keccak256 } from 'ethereumjs-util';
+import { keccak256 } from 'ethereum-cryptography/keccak';
 
 import debug from './utils/debug.js';
 import {
@@ -470,7 +470,7 @@ async function getEventResponse(
     fromBlock: '0',
     toBlock: 'latest',
     address,
-    topic0: '0x' + keccak256(Buffer.from(topic)).toString('hex'),
+    topic0: '0x' + Buffer.from(keccak256(Buffer.from(topic))).toString('hex'),
   };
 
   const responseBody = await callEtherscanApi(etherscan, params);


### PR DESCRIPTION
Removes the deprecated `ethereumjs-util` dependency, which transitively pulls in `secp256k1` and the legacy `elliptic` package. It was used only for `keccak256` and `toChecksumAddress`; both are reimplemented on top of `ethereum-cryptography` (already noble-based, no native bindings, no elliptic), via a small Buffer-returning keccak256 helper and an inline EIP-55 checksum. No behavioral change: keccak and checksum outputs are byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced a deprecated hashing/address utility with a maintained alternative, reducing bundled crypto dependencies.
  * Kept address checksumming, storage slot calculations, bytecode hashing, and proxy verification behavior consistent while updating the underlying implementation.
* **Chores**
  * Published patch updates for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->