### PR TITLE
Keep baseSlot when unfolding storage layouts

### DIFF
--- a/.changeset/keep-baseslot-on-unfold.md
+++ b/.changeset/keep-baseslot-on-unfold.md
@@ -1,0 +1,5 @@
+---
+"@openzeppelin/upgrades-core": patch
+---
+
+Keep `baseSlot` when unfolding a storage layout so a changed custom layout is still rejected.

--- a/packages/core/src/storage-custom-layout.test.ts
+++ b/packages/core/src/storage-custom-layout.test.ts
@@ -8,6 +8,9 @@ import { getStorageUpgradeErrors } from './storage';
 import { StorageLayout } from './storage/layout';
 import { extractStorageLayout } from './storage/extract';
 import { stabilizeStorageLayout } from './utils/stabilize-layout';
+import { getStorageLayout } from './validate/query';
+import { ContractValidation } from './validate/run';
+import { Version } from './version';
 
 interface Context {
   extractStorageLayout: (contract: string) => ReturnType<typeof extractStorageLayout>;
@@ -355,4 +358,87 @@ test('Gap - changed root - fallback - unsafeSkipStorageCheck', t => {
   const v2 = t.context.extractStorageLayoutFallback('Gap_Changed_Root_Ok');
   const comparison = getStorageUpgradeErrors(v1, v2, { unsafeSkipStorageCheck: true });
   t.deepEqual(comparison, []);
+});
+
+const unfoldVersion: Version = {
+  withMetadata: 'wm',
+  withoutMetadata: 'wo',
+  linkedWithoutMetadata: 'lw',
+};
+
+const unfoldTypes = { t_uint256: { label: 'uint256', numberOfBytes: '32' } };
+const unfoldStorage = [{ label: 'alpha', type: 't_uint256', contract: 'T', src: 'S.sol:4' }];
+
+function validationEntry(layout: StorageLayout, inherit: string[] = []): ContractValidation {
+  return {
+    version: unfoldVersion,
+    src: 'S.sol:1',
+    inherit,
+    libraries: [],
+    methods: [],
+    linkReferences: [],
+    errors: [],
+    solcVersion: '0.8.29',
+    layout,
+  };
+}
+
+function unfoldLayout(layout: StorageLayout, inherit: string[] = [], parents: Record<string, StorageLayout> = {}) {
+  const run: Record<string, ContractValidation> = {
+    'S.sol:T': validationEntry(layout, inherit),
+  };
+  for (const name of inherit) {
+    run[name] = {
+      src: `${name}:1`,
+      inherit: [],
+      libraries: [],
+      methods: [],
+      linkReferences: [],
+      errors: [],
+      solcVersion: '0.8.29',
+      layout: parents[name],
+    };
+  }
+  return getStorageLayout({ version: '3.4', log: [run] }, unfoldVersion);
+}
+
+test('getStorageLayout preserves baseSlot for a flat layout', t => {
+  const layout: StorageLayout = {
+    solcVersion: '0.8.29',
+    baseSlot: '0x1',
+    storage: unfoldStorage,
+    types: unfoldTypes,
+    flat: true,
+  };
+  t.is(unfoldLayout(layout).baseSlot, '0x1');
+});
+
+test('getStorageLayout preserves baseSlot when unfolding inherited layouts', t => {
+  const layout: StorageLayout = {
+    solcVersion: '0.8.29',
+    baseSlot: '0x1',
+    storage: unfoldStorage,
+    types: unfoldTypes,
+  };
+  const parent: StorageLayout = {
+    solcVersion: '0.8.29',
+    storage: [{ label: 'beta', type: 't_uint256', contract: 'B', src: 'B.sol:4' }],
+    types: unfoldTypes,
+  };
+  t.is(unfoldLayout(layout, ['B.sol:B'], { 'B.sol:B': parent }).baseSlot, '0x1');
+});
+
+test('getStorageLayout round-trip still detects a changed base slot', t => {
+  const layoutAt = (baseSlot: string): StorageLayout => ({
+    solcVersion: '0.8.29',
+    baseSlot,
+    storage: unfoldStorage,
+    types: unfoldTypes,
+    flat: true,
+  });
+  const before = unfoldLayout(layoutAt('0x' + '00'.repeat(32)));
+  const after = unfoldLayout(layoutAt('0x' + '00'.repeat(31) + '01'));
+  t.throws(() => getStorageUpgradeErrors(before, after), {
+    message: /Base slot for custom storage layout changed/,
+  });
 });

--- a/packages/core/src/validate/query.ts
+++ b/packages/core/src/validate/query.ts
@@ -94,10 +94,17 @@ export function unfoldStorageLayout(runData: ValidationRunData, fullContractName
       storage: c.layout.storage,
       types: c.layout.types,
       namespaces: c.layout.namespaces,
+      baseSlot: c.layout.baseSlot,
     };
   } else {
     // Namespaces are pre-flattened
-    const layout: StorageLayout = { solcVersion, storage: [], types: {}, namespaces: c.layout.namespaces };
+    const layout: StorageLayout = {
+      solcVersion,
+      storage: [],
+      types: {},
+      namespaces: c.layout.namespaces,
+      baseSlot: c.layout.baseSlot,
+    };
     for (const name of [fullContractName].concat(c.inherit)) {
       layout.storage.unshift(...runData[name].layout.storage);
       Object.assign(layout.types, runData[name].layout.types);


### PR DESCRIPTION
`unfoldStorageLayout` rebuilt the layout without `baseSlot`. `getStorageLayout` and the deprecated `UpgradeableContract` API both go through that, so `validateBaseSlotUnchanged` compared `undefined` to `undefined` and a changed `layout at` slot passed on the AST-only path.

Hardhat/CLI flows already have compiler layouts, so they were not affected.

Credit to @nahimterrazas for the report and the repro.

Fixes #1296
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved storage layout base slots when unfolding and querying layouts.
  * Improved handling of flat and inherited storage layouts.
  * Continued detecting incompatible base slot changes during upgrade validation.

* **Tests**
  * Added regression coverage for base slot preservation and upgrade validation.

* **Chores**
  * Scheduled a patch release for the storage layout improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
