### PR TITLE
fix: await previous deployment confirmation before merge

### DIFF
--- a/.changeset/await-merge-deployment.md
+++ b/.changeset/await-merge-deployment.md
@@ -1,0 +1,5 @@
+---
+"@openzeppelin/upgrades-core": patch
+---
+
+Await confirmation of a previous deployment before merging a new one

--- a/packages/core/src/deployment.test.ts
+++ b/packages/core/src/deployment.test.ts
@@ -92,6 +92,15 @@ test('fails deployment fast if tx reverts', async t => {
   await t.throwsAsync(waitAndValidateDeployment(provider, deployment));
 });
 
+test('merge waits for previous deployment and fails if it reverted', async t => {
+  const provider = stubProvider();
+  const first = await resumeOrDeploy(provider, undefined, provider.deploy);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  provider.failTx(first.txHash!);
+  await t.throwsAsync(resumeOrDeploy(provider, first, provider.deploy, 'implementation', undefined, undefined, true));
+  t.is(provider.deployCount, 1);
+});
+
 test('waits for a deployment to return contract code', async t => {
   const timeout = Symbol('timeout');
   const provider = stubProvider();

--- a/packages/core/src/deployment.ts
+++ b/packages/core/src/deployment.ts
@@ -144,7 +144,7 @@ async function validateStoredDeployment<T extends Deployment & RemoteDeploymentI
       debug('resuming previous deployment', foundDeployment);
       if (merge) {
         // If merging, wait for the existing deployment to be mined
-        waitAndValidateDeployment(provider, deployment, type, opts, getRemoteDeployment);
+        await waitAndValidateDeployment(provider, deployment, type, opts, getRemoteDeployment);
       }
     } else {
       // If the transaction is not found we throw an error, except if we're in


### PR DESCRIPTION
## Summary

`resumeOrDeploy(..., merge=true)` comments that a previous cached deployment must be confirmed before a new one is created and merged. The call to `waitAndValidateDeployment` was missing `await`.

When the previous implementation transaction had reverted, that error was dropped as an unhandled rejection. `resumeOrDeploy` still deployed a new contract, so a later address merge could record the dead implementation.

## Test plan

- [x] `packages/core`: `npx ava src/deployment.test.ts` (20/20)
- [x] Revert-test: without `await`, `merge waits for previous deployment and fails if it reverted` resolves a new deployment and leaves an unhandled `InvalidDeployment`

I used an AI coding assistant to draft the test and this description. I reviewed the missing `await` against the existing comment and the revert-test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge deployments now wait for previous deployments to be confirmed before continuing.
  * Reverted deployment transactions are reported correctly, preventing subsequent deployments from starting prematurely.

* **Tests**
  * Added regression coverage for deployment ordering and transaction failure handling.

* **Chores**
  * Prepared a patch release for the deployment behavior fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->