### PR TITLE
fix: preserve storage layout base slots

### DIFF
--- a/packages/core/src/validate/query.test.ts
+++ b/packages/core/src/validate/query.test.ts
@@ -1,8 +1,33 @@
 import test from 'ava';
 
 import { ContractValidation, ValidationRunData } from './run';
-import { getUnlinkedBytecode } from './query';
+import { getUnlinkedBytecode, unfoldStorageLayout } from './query';
 import { getVersion } from '../version';
+
+test('unfoldStorageLayout preserves baseSlot for inherited layouts', t => {
+  const runData = {
+    'contracts/Base.sol:Base': {
+      layout: {
+        storage: [],
+        types: {},
+        flat: false,
+        namespaces: {},
+      },
+    },
+    'contracts/Child.sol:Child': {
+      layout: {
+        storage: [],
+        types: {},
+        flat: false,
+        namespaces: {},
+        baseSlot: '0x1',
+      },
+      inherit: ['contracts/Base.sol:Base'],
+    },
+  } as unknown as ValidationRunData;
+
+  t.is(unfoldStorageLayout(runData, 'contracts/Child.sol:Child').baseSlot, '0x1');
+});
 
 test('getUnlinkedBytecode', t => {
   const unlinkedBytecode = '0x12__$5ae0c2211b657f8a7ca51e0b14f2a8333d$__78';

--- a/packages/core/src/validate/query.test.ts
+++ b/packages/core/src/validate/query.test.ts
@@ -29,6 +29,22 @@ test('unfoldStorageLayout preserves baseSlot for inherited layouts', t => {
   t.is(unfoldStorageLayout(runData, 'contracts/Child.sol:Child').baseSlot, '0x1');
 });
 
+test('unfoldStorageLayout preserves baseSlot for flat layouts', t => {
+  const runData = {
+    'contracts/Flat.sol:Flat': {
+      layout: {
+        storage: [],
+        types: {},
+        flat: true,
+        namespaces: {},
+        baseSlot: '0x2',
+      },
+    },
+  } as unknown as ValidationRunData;
+
+  t.is(unfoldStorageLayout(runData, 'contracts/Flat.sol:Flat').baseSlot, '0x2');
+});
+
 test('getUnlinkedBytecode', t => {
   const unlinkedBytecode = '0x12__$5ae0c2211b657f8a7ca51e0b14f2a8333d$__78';
   const linkedBytecode = '0x12456456456456456456456456456456456456456478';

--- a/packages/core/src/validate/query.ts
+++ b/packages/core/src/validate/query.ts
@@ -94,10 +94,17 @@ export function unfoldStorageLayout(runData: ValidationRunData, fullContractName
       storage: c.layout.storage,
       types: c.layout.types,
       namespaces: c.layout.namespaces,
+      baseSlot: c.layout.baseSlot,
     };
   } else {
     // Namespaces are pre-flattened
-    const layout: StorageLayout = { solcVersion, storage: [], types: {}, namespaces: c.layout.namespaces };
+    const layout: StorageLayout = {
+      solcVersion,
+      storage: [],
+      types: {},
+      namespaces: c.layout.namespaces,
+      baseSlot: c.layout.baseSlot,
+    };
     for (const name of [fullContractName].concat(c.inherit)) {
       layout.storage.unshift(...runData[name].layout.storage);
       Object.assign(layout.types, runData[name].layout.types);


### PR DESCRIPTION
## Summary

Fix storage layout reconstruction for custom storage base slots.

`unfoldStorageLayout` now preserves `baseSlot` for both flat layouts and layouts assembled from inherited contracts. This allows `validateBaseSlotUnchanged` to compare the actual custom base slot instead of treating missing values as zero.

## Tests

Added a regression test for inherited layouts with a custom `baseSlot`.

`git diff --check` passes.

The local AVA and TypeScript binaries were unavailable after dependency installation was blocked by filesystem inode exhaustion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed storage layout processing to preserve inherited layouts’ base slot values.
  - Ensured base slot information remains available in both flattened and namespace-preflattened layouts.
  - Added regression coverage to prevent this issue from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->