### PR TITLE
fix: skip invalid bytecode link candidates

### DIFF
--- a/packages/core/src/validate/query.test.ts
+++ b/packages/core/src/validate/query.test.ts
@@ -4,6 +4,25 @@ import { ContractValidation, ValidationRunData } from './run';
 import { getUnlinkedBytecode } from './query';
 import { getVersion } from '../version';
 
+test('getUnlinkedBytecode skips invalid unrelated link references', t => {
+  const bytecode = '0x6000';
+  const validation: Record<string, Partial<ContractValidation>> = {
+    Unrelated: {
+      version: getVersion(bytecode),
+      linkReferences: [
+        {
+          src: '',
+          name: 'Library',
+          start: 0,
+          length: 1,
+          placeholder: '__$not-a-valid-placeholder$__',
+        },
+      ],
+    },
+  };
+
+  t.is(getUnlinkedBytecode(validation as ValidationRunData, bytecode), bytecode);
+});
 test('getUnlinkedBytecode', t => {
   const unlinkedBytecode = '0x12__$5ae0c2211b657f8a7ca51e0b14f2a8333d$__78';
   const linkedBytecode = '0x12456456456456456456456456456456456456456478';

--- a/packages/core/src/validate/query.ts
+++ b/packages/core/src/validate/query.ts
@@ -130,10 +130,14 @@ export function getUnlinkedBytecode(data: ValidationData, bytecode: string): str
     for (const name of linkableContracts) {
       const { linkReferences } = validation[name];
       const unlinkedBytecode = unlinkBytecode(bytecode, linkReferences);
-      const version = getVersion(unlinkedBytecode);
+      try {
+        const version = getVersion(unlinkedBytecode);
 
-      if (validation[name].version?.withMetadata === version.withMetadata) {
-        return unlinkedBytecode;
+        if (validation[name].version?.withMetadata === version.withMetadata) {
+          return unlinkedBytecode;
+        }
+      } catch {
+        // Unrelated link references can produce invalid bytecode. Try the next candidate.
       }
     }
   }


### PR DESCRIPTION
## Summary

Fix `getUnlinkedBytecode()` when validation data contains unrelated library-linked contracts.

The function now skips candidates whose link references produce invalid bytecode, then continues checking other candidates or returns the original bytecode. This prevents unrelated library references from breaking deployments of contracts without libraries.

## Tests

Added a regression test for invalid unrelated link references.

`git diff --check` passes.

The local AVA and TypeScript binaries were unavailable after dependency installation was blocked by filesystem inode exhaustion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bytecode validation when unrelated contract references contain malformed link placeholders.
  * Validation now continues checking other candidate contracts instead of failing prematurely.
  * Bytecode is preserved unchanged when no valid matching link reference is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->