### PR TITLE
fix: simplify storage error type labels

### DIFF
--- a/packages/core/src/storage/report.ts
+++ b/packages/core/src/storage/report.ts
@@ -11,6 +11,7 @@ import {
   LayoutChange,
   storageFieldEnd,
   storageFieldBegin,
+  stripContractSubstrings,
 } from './compare';
 import { itemize, itemizeWith } from '../utils/itemize';
 import { indent } from '../utils/indent';
@@ -118,7 +119,7 @@ function explainStorageOperation(op: StorageOperation<StorageField>, ctx: Storag
     case 'layoutchange': {
       const title =
         `Layout ${op.change.uncertain ? 'could have changed' : 'changed'} for ${label(op.updated)} ` +
-        `(${op.original.type.item.label} -> ${op.updated.type.item.label})\n` +
+        `(${typeLabel(op.original.type)} -> ${typeLabel(op.updated.type)})\n` +
         describeLayoutTransition(op.change);
       const hints = [];
 
@@ -184,11 +185,11 @@ function explainTypeChange(ch: TypeChange, original: StorageField, updated: Stor
       return `Bad upgrade ${describeTransition(ch.original, ch.updated)}\nDifferent representation sizes`;
 
     case 'mapping key':
-      return `In key of ${ch.updated.item.label}\n` + itemize(explainTypeChange(ch.inner, original, updated));
+      return `In key of ${typeLabel(ch.updated)}\n` + itemize(explainTypeChange(ch.inner, original, updated));
 
     case 'mapping value':
     case 'array value':
-      return `In ${ch.updated.item.label}\n` + itemize(explainTypeChange(ch.inner, original, updated));
+      return `In ${typeLabel(ch.updated)}\n` + itemize(explainTypeChange(ch.inner, original, updated));
 
     case 'array shrink':
     case 'array grow': {
@@ -220,7 +221,7 @@ function explainTypeChange(ch: TypeChange, original: StorageField, updated: Stor
     }
 
     case 'unknown':
-      return `Unknown type ${ch.updated.item.label}`;
+      return `Unknown type ${typeLabel(ch.updated)}`;
   }
 }
 
@@ -265,7 +266,7 @@ function explainTypeChangeDetails(ch: TypeChange): string | undefined {
     case 'struct members': {
       const { allowAppend } = ch;
       return (
-        `In ${ch.updated.item.label}\n` +
+        `In ${typeLabel(ch.updated)}\n` +
         itemize(
           ...ch.ops.flatMap((op, i) => {
             if (op.kind === 'layoutchange' && i !== 0) {
@@ -280,7 +281,7 @@ function explainTypeChangeDetails(ch: TypeChange): string | undefined {
     }
 
     case 'enum members':
-      return `In ${ch.updated.item.label}\n` + itemize(...ch.ops.map(explainEnumOperation));
+      return `In ${typeLabel(ch.updated)}\n` + itemize(...ch.ops.map(explainEnumOperation));
   }
 }
 
@@ -311,8 +312,8 @@ function explainBasicOperation<T>(op: BasicOperation<T>, getName: (t: T) => stri
 }
 
 function describeTransition(original: ParsedTypeDetailed, updated: ParsedTypeDetailed): string {
-  const originalLabel = original.item.label;
-  const updatedLabel = updated.item.label;
+  const originalLabel = typeLabel(original);
+  const updatedLabel = typeLabel(updated);
 
   if (originalLabel === updatedLabel) {
     return `to ${updatedLabel}`;
@@ -331,6 +332,10 @@ function describeLayoutTransition(change: LayoutChange): string {
     }
   }
   return itemize(...res);
+}
+
+function typeLabel(type: ParsedTypeDetailed): string {
+  return stripContractSubstrings(type.item.label) ?? type.item.label;
 }
 
 function label(variable: { label: string }): string {


### PR DESCRIPTION
Closes #728

Storage compatibility errors now remove leading Solidity type keywords such as `struct`, `enum`, and `contract` from displayed type labels. This keeps retype annotations copy-pastable while preserving the underlying storage comparison behavior.

Validation: `git diff --check` passed. Full TypeScript and AVA validation was unavailable because dependencies are not installed in the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-change and layout reports by presenting cleaner, more readable type labels.
  * Removed contract-specific text from type descriptions across nested mappings, arrays, structs, enums, unknown types, and transition details.
  * Preserved the original label when a cleaner description is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->